### PR TITLE
feat(caddy): serve imagineering.cc landing page

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -15,5 +15,15 @@ dav.imagineering.cc {
 }
 
 matrix.imagineering.cc {
-    reverse_proxy localhost:8008
+    handle /mautrix-discord/* {
+        reverse_proxy localhost:29334
+    }
+    handle {
+        reverse_proxy localhost:8008
+    }
+}
+
+imagineering.cc {
+    root * /srv/site
+    file_server
 }

--- a/caddy/docker-compose.yml
+++ b/caddy/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
+      - /home/nick/apps/site:/srv/site:ro
 
 volumes:
   caddy_data:


### PR DESCRIPTION
## Summary
- Add `imagineering.cc` block to Caddyfile serving static site from `/srv/site` volume mount
- Sync `matrix.imagineering.cc` config with live (adds mautrix-discord avatar proxy route)
- Add bind mount for site directory in docker-compose.yml

Already deployed and live at https://imagineering.cc — this PR syncs the infra repo with what's running.

## Test plan
- [x] https://imagineering.cc serves the landing page
- [x] Caddy auto-provisioned TLS cert via Let's Encrypt

Generated with [Claude Code](https://claude.com/claude-code)