### PR TITLE
refactor(dreamfinder): update deploy for shared MCP server submodule

### DIFF
--- a/dreamfinder/docker-compose.yml
+++ b/dreamfinder/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - SIGNAL_PHONE_NUMBER=${SIGNAL_PHONE_NUMBER}
       - KAN_BASE_URL=${KAN_BASE_URL:-https://kan.imagineering.cc/api/v1}
       - KAN_API_KEY=${KAN_API_KEY}
-      - KAN_MCP_PATH=mcp-servers/packages/kan/index.js
       - OUTLINE_BASE_URL=${OUTLINE_BASE_URL:-https://outline.imagineering.cc/api}
       - OUTLINE_API_KEY=${OUTLINE_API_KEY:-}
       - RADICALE_BASE_URL=${RADICALE_BASE_URL:-https://dav.imagineering.cc}

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -323,8 +323,11 @@ LOG_LEVEL=\(.log_level)"' > "$REPO_ROOT/dreamfinder/.env"
     # Copy docker compose and .env
     rsync -avz --exclude 'secrets.yaml' "$REPO_ROOT/dreamfinder/" "$REMOTE":~/apps/dreamfinder/
 
+    # Ensure MCP server submodule is initialized
+    (cd "$PM_BOT_SRC" && git submodule update --init)
+
     # Copy source code (Dart project)
-    rsync -avz --delete --exclude '.dart_tool' --exclude '.packages' --exclude 'data' --exclude '.env' "$PM_BOT_SRC/" "$REMOTE":~/apps/dreamfinder/src/
+    rsync -avz --delete --exclude '.dart_tool' --exclude '.packages' --exclude 'data' --exclude '.env' --exclude '.git' "$PM_BOT_SRC/" "$REMOTE":~/apps/dreamfinder/src/
 
     # Clean up local .env
     rm -f "$REPO_ROOT/dreamfinder/.env"
@@ -371,7 +374,7 @@ deploy_matrix() {
     echo "Deploying Matrix (Continuwuity + bridges + relay bot)..."
 
     local MATRIX_SECRETS="$REPO_ROOT/matrix/secrets.yaml"
-    local MATRIX_SRC="$HOME/git/orgs/imagineering/matrix"
+    local MATRIX_SRC="$HOME/git/orgs/imagineering/matrix-chat-superbridge"
 
     # Check for secrets file
     if [ ! -f "$MATRIX_SECRETS" ]; then


### PR DESCRIPTION
## Summary

- Remove `KAN_MCP_PATH` env var from docker-compose (bug it worked around fixed in imagineering-cc/dreamfinder#50)
- Add `git submodule update --init` before rsync in deploy script (MCP servers now come via submodule)
- Exclude `.git` from rsync to avoid copying submodule metadata to server
- Fix matrix source path (`matrix` → `matrix-chat-superbridge`)

Companion to imagineering-cc/dreamfinder#50.

## Test plan

- [ ] `./scripts/deploy-to.sh <ip> dreamfinder` succeeds (submodule initialized, source rsync'd without .git)

🤖 Generated with [Claude Code](https://claude.com/claude-code)