### PR TITLE
feat(dreamfinder): migrate from Signal to Matrix

### DIFF
--- a/dreamfinder/docker-compose.yml
+++ b/dreamfinder/docker-compose.yml
@@ -1,24 +1,13 @@
 services:
-  signal-api:
-    image: bbernhard/signal-cli-rest-api:0.97
-    container_name: imagineering-signal-api
-    restart: unless-stopped
-    environment:
-      - MODE=normal
-    volumes:
-      - signal_data:/home/.local/share/signal-cli
-
   bot:
     build:
       context: ./src
     container_name: dreamfinder
     restart: unless-stopped
-    depends_on:
-      - signal-api
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - SIGNAL_API_URL=http://signal-api:8080
-      - SIGNAL_PHONE_NUMBER=${SIGNAL_PHONE_NUMBER}
+      - MATRIX_HOMESERVER=${MATRIX_HOMESERVER:-https://matrix.imagineering.cc}
+      - MATRIX_ACCESS_TOKEN=${MATRIX_ACCESS_TOKEN}
       - KAN_BASE_URL=${KAN_BASE_URL:-https://kan.imagineering.cc/api/v1}
       - KAN_API_KEY=${KAN_API_KEY}
       - OUTLINE_BASE_URL=${OUTLINE_BASE_URL:-https://outline.imagineering.cc/api}
@@ -34,5 +23,4 @@ services:
       - bot_data:/app/data
 
 volumes:
-  signal_data:
   bot_data:

--- a/dreamfinder/secrets.yaml
+++ b/dreamfinder/secrets.yaml
@@ -1,27 +1,28 @@
-anthropic_api_key: ENC[AES256_GCM,data:BJV0MmVDwF54EDsqzI5c/CLZoSf1Ge544WQ7XNdzMEc5gVWvH1g5j3S6KBjEqRwLljZ6rQLzM7jxcVrpxwqnY7XvQlkkkdQDk6Fwe9h6f/e9hti6Rp5dr2ZTI/W1cCY8HwQDJv0u2Is9pkYJ,iv:Deo8nnIf58dGpxWF0FDZfAwW850CLkDyeljZExtCARc=,tag:gSgtyZPEDK4jN3GF4ShkeQ==,type:str]
-signal_phone_number: ENC[AES256_GCM,data:ekcEmxABiQ3lFgID,iv:EhsJG59MmC+NAFZ2gbI6Kk67PA+CIjokG+CU+hfhh8c=,tag:98hKJf1e9JTit9AxbMS8/w==,type:str]
-kan_base_url: ENC[AES256_GCM,data:SN97jkMb6H0qIkNWB7iy25OHYuOdEr9u4OwJRhp8h3PeGw==,iv:SlvhA4n7jBONqokI4mKzKSRB0ZKNXOdnn/u5m55TVG4=,tag:GZXbYoFfYp3yWynuI+urZQ==,type:str]
-kan_api_key: ENC[AES256_GCM,data:wWQx+aBO2wmpLVaiMsXIfuCb0c3byPvmIjWwwLEYNkQM1vlbjTScURYItjv9KemzVm1fG5wmbtCp0UcfkIWX0k0MIXU=,iv:yMuByZXPRDLE+/fwRolEyXJUTxS0RuYNFkVtI9BmlHk=,tag:ZQ7tBp0mqcF5eT6vlLnBIQ==,type:str]
-outline_base_url: ENC[AES256_GCM,data:2R+4u17W3Da+f2nIu4hHBT2jBCSs+WBHYyiQAF6HR2dyMaU=,iv:JEoSjA3Gzy1dd8YJIp6ZlDoes6HgcYVQ/MK0RZZj3uA=,tag:V2JUhs9HwuuxB3UR2i1c1Q==,type:str]
-outline_api_key: ENC[AES256_GCM,data:Q9AptPkC2rYrHSqSrMl/sOEKNSBeYettmYMatg7nqKcgY03pQBiQrMcHuB/X,iv:kZjmgOv1Jk8596OgXJUCz9vNf3JdFrHzMaw5JHm1erY=,tag:RF8r56+bckG2TOJVDwRXlg==,type:str]
-radicale_base_url: ENC[AES256_GCM,data:3u9GMnVAltTvPU157zBs13NYM/3RJJ8dIfkR,iv:wY6c2ZfQQ7+pSEy8AR9WYlHO/Sdiklv4nyce94zVfyM=,tag:AAmajzNx9R/JCgDZ1WMFmw==,type:str]
-radicale_username: ENC[AES256_GCM,data:thbOEv0Csa8=,iv:9Z92orjHeY5pMhBHE/TVyprAopYSC9ouan/YvJWQh/8=,tag:erkb1Ol/rJQOx5/MpzjZRg==,type:str]
-radicale_password: ENC[AES256_GCM,data:mKofAKorote2S4Sk/KqjJwIuwgbEqJof,iv:Wi5R8cD+Mgv+JMKqu5oTXjIXG22+IafPA/ag2aniPAU=,tag:iLihqJVr6SkaJvm94EU+7w==,type:str]
-playwright_enabled: ENC[AES256_GCM,data:4xj+3G8=,iv:srRJnmKjDYzC8KDkEhae4orxlIeuo0IHBmWN2Kar0xk=,tag:4npz/uzZeXy0UXjUrUNVSg==,type:str]
-bot_name: ENC[AES256_GCM,data:JVBEzTUb52ar7NQ=,iv:EdLhGECtMi27xpMLOF23CsX8+/Ex7TdSCg4PKsWMujY=,tag:N08ZIAwrKbh8wX2eklWDjw==,type:str]
-log_level: ENC[AES256_GCM,data:PjUkAg==,iv:+r261MojGEXSCty3QSh8hVJUbdhFMMm4nKfNNylaFOQ=,tag:djDYW6B3Hqn+AO0vairzAw==,type:str]
+anthropic_api_key: ENC[AES256_GCM,data:Goch0mDnY1t33SsuxavEDEEjAX5bG3vSdZnCn9zGbHfNVdeIsobyWZExaXvNJoLtTrtP3PuDwCWW9xsQkXRTMWqnXCTeGkLcElFyzsMRLwtXA3ultiGUZZMMAFXFEBmKOs6zuVaWQ6ClVoOL,iv:5hA4Da9a8jtKAJ/7jBI8HJlWxfOoYuZE+Fgm7DR8C5E=,tag:ICIkAK4YuqnC2ILm2NmD3g==,type:str]
+matrix_homeserver: ENC[AES256_GCM,data:jkp3XQfTLbaOkgxZMAZi24IhO/DC26mGNmbmeRtv,iv:/o8t7iPGKToMX0lzcsguz6tfSHJO8Appyy23YGJ9YCA=,tag:tDiVNBwGsUUKI9vWjyPgXA==,type:str]
+matrix_access_token: ENC[AES256_GCM,data:JVCC5VIXYL1uCYlGPldW55AbN0cGBFNT3wJOXYkPU/g=,iv:KctQFu5WoYQIjiIGDl+nEPUXPBnwOoZ2VcTKUGVofsE=,tag:lrF5atw9nWK2Bo7roXf4bA==,type:str]
+kan_base_url: ENC[AES256_GCM,data:Gq1pD7lSUdNLfsX3SRYsyOc46JsU10SclybSKB8XzLBkhg==,iv:AJEOB3gWrxwiJoqDkR1sI8dCNA3nFx0uH3DCXBfer24=,tag:0R8je4vl1hD/v8ZmfDsAWA==,type:str]
+kan_api_key: ENC[AES256_GCM,data:wAf3fWAGJgmhXwkB3HRoQ6TnPUZs0fn781yTV7aniju9wx+a7QHRRh4vJ/HJ6vjGLsi6yvdp/fItFo+TnEJjBm4iX0A=,iv:DJ1gtQBwIAIqhe0xEE8raiqF4+LvV3iZaPEeOHTCtVw=,tag:vGGbjTwoDAitCYA54r/bOg==,type:str]
+outline_base_url: ENC[AES256_GCM,data:tCTBKyzUmMBGS7AgpuPwlv61B9iNw0jPdt8WclHuF2xgfqE=,iv:WRJgHAdmfeq+UrIVybsJuh2Zw6cEBoQSLc9aW3KeQ1Y=,tag:wJ6KC6NjYOHngWy0iUg71g==,type:str]
+outline_api_key: ENC[AES256_GCM,data:7GazIo+Jb5fjIGt/eVsXMKElZ4KMIlo1iNLNY74v5BbmRlQOJAnwhZyPe8cu,iv:+3R9OeygKyXoHRmUDtFKSGPp/ak5uG0N5l03dwySVYA=,tag:UENFHvabHcjb4xAnEqhG/A==,type:str]
+radicale_base_url: ENC[AES256_GCM,data:oSXHJNInVnwrc2OJwc8SJtPTqYw7MISmA88F,iv:WZQLYYhieJLXI3WEY45TUw93B+zMKLRUYYsNTcr1MnM=,tag:u4xEPFytyJ0eLT4yPVXe3Q==,type:str]
+radicale_username: ENC[AES256_GCM,data:X5vKrE+hagM=,iv:ZZ2nZa4IcmGyQ1+TIHVE1lQP+im4lQ3j3CL7+pfaN94=,tag:mlD1m6/yPoMbti0QMG3Iwg==,type:str]
+radicale_password: ENC[AES256_GCM,data:5MDFBvMeJa0BD8CXKofSAZBCVF4X83Yt,iv:elfgGZ09J+t+V45bsKEs/rATEX6bdvZvOJjvTkyW42A=,tag:JK2KLUYoEkCH2dBQies44w==,type:str]
+playwright_enabled: ENC[AES256_GCM,data:IT60G8o=,iv:tl9Ww+mjrNbojG6aIXjUUJyr2d66NO3LADTAQmdlUIw=,tag:oUEw2t3NnW9vYw/EaXrwrQ==,type:str]
+bot_name: ENC[AES256_GCM,data:XKq1MbNodqWpQVI=,iv:JFDN0BYjvq+jwQefdbKLUMIZ+q0DUGEn49qsn+khQmQ=,tag:WTa+98fcydD2JP7W5GsnjA==,type:str]
+log_level: ENC[AES256_GCM,data:TW8cig==,iv:CC26n/UVip+0urgCj7Xsm4jzc85ioIR5u5tN4k7fprs=,tag:IsgY87S40rW00PJMI3QHCA==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJVGFpaWlOdEo4b2pFU01n
-            TG9jY1pNNDJGUHM1SWVrZ1N2ZFFHSlVKbWowCm0yTVkxcUdWdkNtanhFUXR0QUlP
-            dmk1Wml2eFk5M3F2Z2hTZ1QyM01kelkKLS0tIDRzbWRPQ0k3amllbzhDSEI4bGhB
-            ZUVtcytyMnk2U3VjbmYyWUNXbm91a28KE2rwrIc6pSkmb2ZKj8agI9RYpHuJ5PcY
-            qpNxz+pKVxbTyunpwAq07+OI/voYaIlI35xeBcDJuCZBfyFWHoMvkw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaVWVlV1hieTFmZFpEYzZj
+            d2Frd25WQjcwYkl3RzA0NVY5ZDFjZ2tHM2pZCnlvS3NFRTFtR2xESTN4aDlSeUI5
+            Qm1ka3JxSGg1ckRxUzlEWmJPYm54QVUKLS0tIGU4eEdMVXp4RHg1VUo0T1czVytW
+            YmdadjRFSzBVL2dLbURtN2VyRmtOQUEK4HMasFj3FUCsEtgPFHrOXn3N0YTEmVuh
+            5Y9O1uD3IHWIilErlUJIfb2Bj9+1/TLgTH1EID1k4yorcJrHIhOVSw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-06T09:15:41Z"
-    mac: ENC[AES256_GCM,data:mpEjg9pZNcHVA+MxcNTmiOjpFZPQSmWxBJMf3SxfQcDFk2gxwEgeMmTlx06JkL+Nvetuh93YqTXfYTTPA73V133CYf5v7ZhnR2MMphqpImGaD5i9zF5KC/913JPjBAl1RdyzIv6lb7Q9IZ+EZ5Q2bjxtrdxMzFf+zb7a7AzHRUI=,iv:pfSyHwg2hnuYjNH+i2UdWkcDhkfcBha1r9Af4wdU+Mk=,tag:iLC/H4qTS4NmuI/PmBVVaw==,type:str]
+    lastmodified: "2026-03-22T21:47:10Z"
+    mac: ENC[AES256_GCM,data:OOO4OsESY0c8Pnvhezb3fvm8vREIWSY06JTpE3Jhw9NwE1W0wBG8lvGWtHyE2JaVU7sUwVzV1Un07dutxiNodAS0ziKOaPCUzeAXyQsgutyo9USoMj51hJRWblwyFa1U/cTZjofnFBHe+r7jfUoC+Z2ywwZL2jHhT5PRqAoDvBc=,iv:5wbpNij7j2vvEnhRTnGNNc1byRdWlL+GFijsOvYb+nw=,tag:1fofe2sDe0MrGV+3mk9n+g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -305,7 +305,8 @@ deploy_pm_bot() {
     echo "Generating .env from encrypted secrets..."
     sops -d "$PM_BOT_SECRETS" | yq -r '"# Dreamfinder Configuration (auto-generated from secrets.yaml)
 ANTHROPIC_API_KEY=\(.anthropic_api_key)
-SIGNAL_PHONE_NUMBER=\(.signal_phone_number)
+MATRIX_HOMESERVER=\(.matrix_homeserver)
+MATRIX_ACCESS_TOKEN=\(.matrix_access_token)
 KAN_BASE_URL=\(.kan_base_url)
 KAN_API_KEY=\(.kan_api_key)
 OUTLINE_BASE_URL=\(.outline_base_url)


### PR DESCRIPTION
## Summary

- Drop `signal-api` sidecar and `signal_data` volume — Dreamfinder no longer uses Signal
- Add `MATRIX_HOMESERVER` and `MATRIX_ACCESS_TOKEN` env vars to docker-compose
- Update deploy script `.env` template to generate Matrix credentials from secrets
- Bot account `@dreamfinder-bot:imagineering.cc` registered on Continuwuity

The Dreamfinder source was already refactored to Matrix in imagineering-cc/dreamfinder#48. This updates the infra config to match, unblocking deployment.

## Test plan

- [ ] `./scripts/deploy-to.sh 149.118.69.221 dreamfinder` deploys successfully
- [ ] `docker logs dreamfinder` shows Matrix sync loop running
- [ ] Send a message to @dreamfinder-bot in a Matrix room and get a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)