### PR TITLE
feat(ops): backup downstream-server SQLite + alert on request-count drops

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Unified backup script for all services
 # Dumps databases/data, pushes to GitHub (imagineering-cc/imagineering-backups)
-# Usage: ./backup.sh [all|kanbn|outline|radicale|pm-bot|claudius]
+# Usage: ./backup.sh [all|kanbn|outline|radicale|pm-bot|claudius|downstream-server]
 
 SERVICE=${1:-all}
 BACKUP_DIR="/tmp/backups"
@@ -127,6 +127,32 @@ backup_claudius() {
   log "Claudius backup complete: claudius-$DATE.tar.gz"
 }
 
+backup_downstream_server() {
+  log "Backing up downstream-server..."
+
+  local db_path="$HOME/apps/downstream-server/data/downstream.db"
+  local backup_file="$BACKUP_DIR/downstream-server-$DATE.db"
+
+  if [ ! -f "$db_path" ]; then
+    error "downstream-server DB not found at $db_path"
+    return 1
+  fi
+
+  if ! command -v sqlite3 &> /dev/null; then
+    error "sqlite3 not installed, cannot back up downstream-server"
+    return 1
+  fi
+
+  # Use the SQLite .backup command for a consistent online snapshot
+  # (safe to run while the server is writing to the DB).
+  if ! sqlite3 "$db_path" ".backup '$backup_file'"; then
+    error "sqlite3 .backup failed for downstream-server"
+    return 1
+  fi
+
+  log "downstream-server backup complete: downstream-server-$DATE.db"
+}
+
 backup_to_github() {
   local services=("$@")
 
@@ -212,7 +238,7 @@ cleanup_old_backups() {
 case $SERVICE in
   all)
     SUCCEEDED=()
-    for svc in kanbn outline radicale pm-bot claudius; do
+    for svc in kanbn outline radicale pm-bot claudius downstream-server; do
       if "backup_${svc//-/_}"; then
         SUCCEEDED+=("$svc")
       else
@@ -240,11 +266,14 @@ case $SERVICE in
   claudius)
     backup_claudius && backup_to_github claudius || FAILED_SERVICES+=(claudius)
     ;;
+  downstream-server)
+    backup_downstream_server && backup_to_github downstream-server || FAILED_SERVICES+=(downstream-server)
+    ;;
   cleanup)
     cleanup_old_backups
     ;;
   *)
-    echo "Usage: $0 [all|kanbn|outline|radicale|pm-bot|claudius|cleanup]"
+    echo "Usage: $0 [all|kanbn|outline|radicale|pm-bot|claudius|downstream-server|cleanup]"
     exit 1
     ;;
 esac

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -6,6 +6,14 @@ DISK_THRESHOLD=80
 MEMORY_THRESHOLD=90
 SWAP_THRESHOLD=50
 
+# downstream-server health: alert if total request rows fall below the previous
+# observed total (suggests data loss like the 2026-04-29 incident) or below an
+# absolute floor. The "previous total" is persisted between runs.
+DOWNSTREAM_HEALTH_URL="https://api.downstream-storage.cc/api/health"
+DOWNSTREAM_STATE_DIR="$HOME/.health-state"
+DOWNSTREAM_PREV_FILE="$DOWNSTREAM_STATE_DIR/downstream-prev-total"
+DOWNSTREAM_MIN_TOTAL=10
+
 issues=()
 
 # Check disk usage (all mounted filesystems, excluding tmpfs/devtmpfs)
@@ -40,6 +48,33 @@ fi
 while read -r name status; do
     issues+=("Container *${name}*: ${status}")
 done < <(docker ps -a --filter "status=exited" --filter "status=restarting" --format "{{.Names}} {{.Status}}" 2>/dev/null)
+
+# Check downstream-server request count (data-loss canary)
+mkdir -p "$DOWNSTREAM_STATE_DIR"
+ds_response=$(curl -sS --max-time 10 "$DOWNSTREAM_HEALTH_URL" 2>/dev/null)
+ds_curl_rc=$?
+if [ "$ds_curl_rc" -ne 0 ] || [ -z "$ds_response" ]; then
+    issues+=("downstream-server: /api/health unreachable \\(curl rc=${ds_curl_rc}\\)")
+elif ! ds_total=$(echo "$ds_response" | jq -e '.requests.total' 2>/dev/null); then
+    issues+=("downstream-server: /api/health returned unexpected JSON")
+else
+    # Absolute floor
+    if [ "$ds_total" -lt "$DOWNSTREAM_MIN_TOTAL" ]; then
+        issues+=("downstream-server: requests.total=${ds_total} below floor ${DOWNSTREAM_MIN_TOTAL}")
+    fi
+    # Drop vs previous snapshot
+    if [ -f "$DOWNSTREAM_PREV_FILE" ]; then
+        ds_prev=$(cat "$DOWNSTREAM_PREV_FILE" 2>/dev/null)
+        if [ -n "$ds_prev" ] && [ "$ds_total" -lt "$ds_prev" ]; then
+            issues+=("downstream-server: requests.total dropped ${ds_prev} → ${ds_total}")
+        fi
+    fi
+    # Persist the new high-water mark (only ratchet up, so a transient drop
+    # still alerts on the next run rather than silently re-baselining low).
+    if [ ! -f "$DOWNSTREAM_PREV_FILE" ] || [ "$ds_total" -gt "$(cat "$DOWNSTREAM_PREV_FILE" 2>/dev/null || echo 0)" ]; then
+        echo "$ds_total" > "$DOWNSTREAM_PREV_FILE"
+    fi
+fi
 
 # Send alert if any issues found
 if [ ${#issues[@]} -gt 0 ]; then


### PR DESCRIPTION
## Summary

Two ops gaps in one PR — both surfaced by the 2026-04-29 downstream DB-loss investigation:

- **backup.sh**: adds `backup_downstream_server` using `sqlite3 .backup` for a consistent online snapshot of `~/apps/downstream-server/data/downstream.db`. Hooked into the daily `all` rotation and shipped to the GitHub-mirror repo via the existing flow (decompressed as `downstream-server.db` so git deltas work).
- **health-check.sh**: polls `https://api.downstream-storage.cc/api/health` hourly and alerts via the existing Telegram setup if `requests.total` either:
  - falls below the previous high-water mark (persisted at `~/.health-state/downstream-prev-total`), or
  - drops below an absolute floor of 10.

The high-water file only ratchets up — so a transient drop still alerts on the next run rather than silently re-baselining low.

Closes the cron-half of downstream Task #9 and extends backup coverage per Task #13.

## Test plan

- [x] `bash -n` clean on both scripts
- [x] `shellcheck` clean on both scripts (CI severity: warning)
- [ ] Deploy to OCI host (`./scripts/deploy-to.sh 149.118.69.221 scripts`) — left for Nick
- [ ] Run `backup.sh downstream-server` once on the host and verify `downstream-server.db` lands in the `imagineering-backups` repo
- [ ] Run `health-check.sh` once and verify it creates `~/.health-state/downstream-prev-total`; force a drop (edit the file to a high value) and confirm a Telegram alert fires