### PR TITLE
feat(downstream): nightly reconcile_b2 cron on OCI

### DIFF
--- a/downstream-server/README.md
+++ b/downstream-server/README.md
@@ -1,0 +1,98 @@
+# downstream-server ops bits
+
+This directory holds the host-side ops wiring for the `downstream-server`
+guest service. The service itself (Dart + Drift on SQLite) lives in the
+[downstream monorepo](https://github.com/nickmeinhold/downstream); this
+directory only owns things that run on the OCI box *around* the container.
+
+## Nightly reconciler cron
+
+`bin/reconcile_b2.dart` (in the downstream-server source) probes every DB
+row marked `available` against B2/CDN reality:
+
+1. DB row says `status=available`.
+2. The CDN object responds 200 with non-zero content-length.
+3. The MP4 has a `moov` atom near the start of the file (faststart).
+
+It mutates nothing. The point is to catch drift between the DB and B2 (Fight
+Club / Housemaid manifest-ghost incidents, `movie_9323` with no moov atom)
+proactively rather than at playback time. See the script's header comment
+for full semantics and exit codes.
+
+### What runs when
+
+A cron file at `cron/reconcile-downstream` schedules a nightly run at
+**04:15 server time** — staggered 15 minutes after the 04:00 backup cron
+(`scripts/deploy-to.sh::deploy_backups`) so they don't collide on the
+SQLite snapshot path or load the box simultaneously.
+
+The cron invokes `/opt/scripts/reconcile-downstream.sh`, which:
+
+1. Snapshots the live DB via `sqlite3 .backup` (WAL-aware; the live DB is
+   held open by the running container, so a plain copy isn't safe).
+2. Runs the Dart script inside a one-shot `dart:stable` container with the
+   rsynced server source tree mounted, the snapshot mounted read-only, and
+   a persistent named volume (`downstream-reconcile-pub-cache`) so we don't
+   re-fetch 65 packages every night.
+3. Cleans up the snapshot.
+
+Output is appended to `/home/nick/logs/reconcile-downstream.log` and rotated
+weekly (8 weeks retained, gzipped) by `/etc/logrotate.d/reconcile-downstream`.
+
+### Why a one-shot dart container instead of `docker exec`
+
+The production runtime image (`debian:bookworm-slim` with the AOT-compiled
+`server` binary) doesn't ship a Dart runtime — `docker exec
+img-downstream-server dart …` fails with `dart: not found`. The options
+were:
+
+- **Bake reconcile into the prod image** (add a second `dart compile exe`
+  in the Dockerfile). Cleanest at runtime, but requires an image rebuild
+  for every change to the script, and a deferred PR in another repo touched
+  the file. Skipped for scope.
+- **Install Dart on the host.** Adds a host-level dependency and another
+  thing to upgrade.
+- **One-shot dart:stable container, source mounted.** Chosen. Slightly
+  slower first run; with the persistent pub-cache volume, subsequent runs
+  reuse the resolved deps. No host-level state.
+
+### Manual ad-hoc run
+
+```bash
+# default: full reconcile against all `available` rows
+ssh imagineering /opt/scripts/reconcile-downstream.sh
+
+# pass extra args to the Dart script
+ssh imagineering "RECONCILE_ARGS='--limit 20 --verbose' /opt/scripts/reconcile-downstream.sh"
+
+# strict mode (transient probe failures become exit 1)
+ssh imagineering "RECONCILE_ARGS='--strict' /opt/scripts/reconcile-downstream.sh"
+```
+
+### Checking the latest results
+
+```bash
+# tail the log
+ssh imagineering tail -50 /home/nick/logs/reconcile-downstream.log
+
+# just the most recent run's summary
+ssh imagineering "awk '/^=== reconcile-downstream/{block=\"\"} {block=block ORS \$0} END{print block}' /home/nick/logs/reconcile-downstream.log"
+
+# count data issues found in the last 7 days (after rotation)
+ssh imagineering "zgrep -c 'Data issues:' /home/nick/logs/reconcile-downstream.log* 2>/dev/null"
+```
+
+### Deploy
+
+```bash
+# Deploys the cron-invoked script (in /opt/scripts/) and any other
+# imagineering-infra scripts.
+./scripts/deploy-to.sh 149.118.69.221 scripts
+
+# Deploys only the cron + logrotate files (idempotent, no scripts touched).
+./scripts/deploy-to.sh 149.118.69.221 downstream-reconciler
+```
+
+The first command is the one that needs to run after edits to
+`scripts/reconcile-downstream.sh`. The second is a fast path when only the
+cron schedule or logrotate policy changes.

--- a/downstream-server/cron/reconcile-downstream
+++ b/downstream-server/cron/reconcile-downstream
@@ -1,0 +1,14 @@
+# Nightly reconciler for downstream-server.
+# Installed at /etc/cron.d/reconcile-downstream by deploy_downstream_reconciler.
+#
+# Runs at 04:15 daily — staggered 15 minutes after the 04:00 backup cron
+# (see deploy_backups in scripts/deploy-to.sh) so the two don't fight over
+# the SQLite snapshot path or load the box at the same moment.
+#
+# Output is appended to /home/nick/logs/reconcile-downstream.log and
+# rotated weekly by /etc/logrotate.d/reconcile-downstream.
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+15 4 * * * nick /opt/scripts/reconcile-downstream.sh >> /home/nick/logs/reconcile-downstream.log 2>&1

--- a/downstream-server/logrotate/reconcile-downstream
+++ b/downstream-server/logrotate/reconcile-downstream
@@ -1,0 +1,9 @@
+/home/nick/logs/reconcile-downstream.log {
+    weekly
+    rotate 8
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 nick nick
+}

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -47,6 +47,33 @@ deploy_scripts() {
     echo "Scripts deployed to /opt/scripts/"
 }
 
+deploy_downstream_reconciler() {
+    # Install the nightly reconcile_b2 cron + logrotate config on the host.
+    # Reads no secrets — the cron script reaches into the rsynced server
+    # source tree and runs the Dart script in a one-shot dart:stable
+    # container. `deploy_scripts` is responsible for placing the cron's
+    # invoking script in /opt/scripts/; this function only owns the cron +
+    # logrotate wiring.
+    echo "Setting up downstream reconcile_b2 nightly cron..."
+
+    local CRON_SRC="$REPO_ROOT/downstream-server/cron/reconcile-downstream"
+    local LOGROTATE_SRC="$REPO_ROOT/downstream-server/logrotate/reconcile-downstream"
+
+    if [ ! -f "$CRON_SRC" ] || [ ! -f "$LOGROTATE_SRC" ]; then
+        echo "ERROR: reconcile cron/logrotate sources missing in $REPO_ROOT/downstream-server/"
+        return 1
+    fi
+
+    ssh "$REMOTE" "mkdir -p ~/logs"
+    scp "$CRON_SRC" "$REMOTE":/tmp/reconcile-downstream.cron
+    scp "$LOGROTATE_SRC" "$REMOTE":/tmp/reconcile-downstream.logrotate
+    ssh "$REMOTE" "sudo install -m 0644 -o root -g root /tmp/reconcile-downstream.cron /etc/cron.d/reconcile-downstream && \
+        sudo install -m 0644 -o root -g root /tmp/reconcile-downstream.logrotate /etc/logrotate.d/reconcile-downstream && \
+        rm -f /tmp/reconcile-downstream.cron /tmp/reconcile-downstream.logrotate"
+
+    echo "Reconcile cron installed (daily 04:15, logs at /home/nick/logs/reconcile-downstream.log)"
+}
+
 deploy_site() {
     local SITE_SRC="$HOME/git/orgs/imagineering/website"
 
@@ -911,6 +938,9 @@ case $SERVICE in
         ;;
     notify)
         deploy_notify
+        ;;
+    downstream-reconciler|reconciler)
+        deploy_downstream_reconciler
         ;;
     *)
         echo "Unknown service: $SERVICE"

--- a/scripts/reconcile-downstream.sh
+++ b/scripts/reconcile-downstream.sh
@@ -22,8 +22,30 @@
 #   /opt/scripts/reconcile-downstream.sh
 # Tail the latest run:
 #   tail -f /home/nick/logs/reconcile-downstream.log
+#
+# RECONCILE_ARGS is forwarded into a `bash -c` and word-split by the inner
+# shell. Flags + integers + URLs without spaces are fine (the current usage).
+# Args containing spaces are not supported — pass them through a wrapper if
+# you ever need that.
 
+# `set -e` is deliberately omitted so the snapshot retry loop and the final
+# `docker run` can return non-zero without aborting the script before we
+# capture the exit code into `$status` for the caller.
 set -uo pipefail
+
+# Singleton guard: prevent two cron-triggered runs from overlapping (e.g.
+# if a long reconcile against a slow CDN bleeds past 24h). The second run
+# exits silently with status 0 — overlap is not an error condition, just
+# a no-op.
+LOCKFILE="/var/lock/reconcile-downstream.lock"
+exec 9>"$LOCKFILE" 2>/dev/null || {
+  echo "ERROR: cannot open lockfile $LOCKFILE" >&2
+  exit 12
+}
+if ! flock -n 9; then
+  echo "$(date -Iseconds): another reconcile run is in progress, skipping"
+  exit 0
+fi
 
 DB_LIVE="/home/nick/apps/downstream-server/data/downstream.db"
 DB_SNAPSHOT="/tmp/downstream-reconcile-$$.db"

--- a/scripts/reconcile-downstream.sh
+++ b/scripts/reconcile-downstream.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Nightly reconciler for downstream-server.
+#
+# Probes every `available` row in the live SQLite DB against B2/CDN reality
+# (DB → CDN 200 → moov-atom presence) and writes a structured report to a
+# log file. Report-only — never mutates DB or B2.
+#
+# Runs the Dart script `bin/reconcile_b2.dart` from the rsynced server source
+# tree under a one-shot `dart:stable` container with a persistent pub-cache
+# volume so subsequent runs are fast. The DB is snapshotted via
+# `sqlite3 .backup` first because the live DB is held open in WAL mode by
+# the running container — opening it directly fails with "database is locked".
+#
+# Exit codes (mirrors bin/reconcile_b2.dart):
+#   0  no issues found (or only transient probe failures and not --strict)
+#   1  data-integrity issues found
+#   2  invalid arguments
+#   3  transient probe failures with --strict set
+#   other  setup/snapshot failure (logged)
+#
+# Manual run for ad-hoc verification:
+#   /opt/scripts/reconcile-downstream.sh
+# Tail the latest run:
+#   tail -f /home/nick/logs/reconcile-downstream.log
+
+set -uo pipefail
+
+DB_LIVE="/home/nick/apps/downstream-server/data/downstream.db"
+DB_SNAPSHOT="/tmp/downstream-reconcile-$$.db"
+SOURCE_DIR="/home/nick/apps/downstream-server/source"
+PUB_CACHE_VOLUME="downstream-reconcile-pub-cache"
+DART_IMAGE="dart:stable"
+
+# Forwarded to the Dart script. Override at the cron call-site or env.
+RECONCILE_ARGS="${RECONCILE_ARGS:-}"
+
+cleanup() {
+  rm -f "$DB_SNAPSHOT"
+}
+trap cleanup EXIT
+
+echo "=== reconcile-downstream $(date -Iseconds) ==="
+
+if [ ! -f "$DB_LIVE" ]; then
+  echo "ERROR: live DB not found at $DB_LIVE" >&2
+  exit 10
+fi
+
+# Snapshot the live DB. `sqlite3 .backup` is safe against a writer holding
+# the DB open (WAL-aware); a plain cp is not. The container can hold a brief
+# write lock during a transaction, so we retry a few times with a busy
+# timeout before giving up.
+snapshot_ok=0
+for attempt in 1 2 3 4 5; do
+  if sqlite3 -cmd ".timeout 5000" "$DB_LIVE" ".backup $DB_SNAPSHOT" 2>/tmp/recon-snap-err.$$; then
+    snapshot_ok=1
+    break
+  fi
+  echo "snapshot attempt $attempt failed: $(cat /tmp/recon-snap-err.$$)" >&2
+  rm -f "$DB_SNAPSHOT"
+  sleep 3
+done
+rm -f /tmp/recon-snap-err.$$
+if [ "$snapshot_ok" -ne 1 ]; then
+  echo "ERROR: sqlite3 .backup failed after 5 attempts" >&2
+  exit 11
+fi
+
+# Run reconcile in a one-shot dart container.
+#   - source mounted read-write at /src so `dart pub get` can write the
+#     synthetic workspace pubspec and .dart_tool/. The image is ephemeral.
+#   - snapshot mounted read-only at the path the script expects by default.
+#   - pub cache persisted across runs in a named volume so we don't re-fetch
+#     65 packages every night.
+#   - libsqlite3-dev installed at runtime (Drift's FFI loader needs the
+#     unversioned `libsqlite3.so` symlink, same constraint as the prod image).
+docker run --rm \
+  -v "$SOURCE_DIR":/src \
+  -v "$DB_SNAPSHOT":/data/downstream.db:ro \
+  -v "$PUB_CACHE_VOLUME":/root/.pub-cache \
+  -w /src \
+  "$DART_IMAGE" \
+  bash -c '
+    set -e
+    apt-get update -qq && apt-get install -y -qq libsqlite3-dev > /dev/null
+    # Generate the minimal workspace pubspec the Dockerfile uses so
+    # `dart pub get` resolves only the server + shared package, not the
+    # full monorepo workspace.
+    cat > pubspec.yaml <<EOF
+name: downstream_workspace
+publish_to: none
+environment:
+  sdk: ^3.5.0
+workspace:
+  - downstream-server
+  - packages/downstream_shared
+EOF
+    cd downstream-server
+    dart pub get
+    exec dart run bin/reconcile_b2.dart '"$RECONCILE_ARGS"'
+  '
+status=$?
+
+echo "=== reconcile-downstream done (exit=$status) ==="
+exit $status


### PR DESCRIPTION
## Summary

- Adds a nightly cron at 04:15 (server time) that runs the existing report-only `downstream-server/bin/reconcile_b2.dart` against the live DB and logs structured output to `/home/nick/logs/reconcile-downstream.log` (weekly logrotate, 8 weeks retained).
- New `scripts/reconcile-downstream.sh` wrapper: snapshots the live SQLite DB via `sqlite3 .backup` (WAL-aware, with retries against transient lock contention), then runs the Dart script in a one-shot `dart:stable` container with a persistent named volume for `~/.pub-cache`.
- New `deploy-to.sh` target: `./scripts/deploy-to.sh <ip> downstream-reconciler` installs cron + logrotate idempotently. Sources live in `downstream-server/cron/` and `downstream-server/logrotate/`.

## Why this architecture

The prod runtime image (`debian:bookworm-slim` + AOT-compiled `server` binary) doesn't ship a Dart runtime, so `docker exec img-downstream-server dart …` isn't viable. Three options weighed in `downstream-server/README.md`; one-shot dart container with mounted source + pub-cache volume picked because it requires no host-level Dart install and no rebuild of the prod image.

Schedule is staggered 15 min after the 04:00 `deploy_backups` cron so they don't collide on `/tmp` or load the box together.

## Deploy verified

```
$ ssh imagineering ls -la /etc/cron.d/reconcile-downstream /etc/logrotate.d/reconcile-downstream /opt/scripts/reconcile-downstream.sh
-rw-r--r-- 1 root root  656 ... /etc/cron.d/reconcile-downstream
-rw-r--r-- 1 root root  155 ... /etc/logrotate.d/reconcile-downstream
-rwxr-xr-x 1 nick nick 3189 ... /opt/scripts/reconcile-downstream.sh

$ ssh imagineering "RECONCILE_ARGS='--limit 5 --verbose' /opt/scripts/reconcile-downstream.sh"
=== reconcile-downstream 2026-04-30T09:09:27+00:00 ===
Reconciling 5 available row(s) against https://cdn.downstream-storage.cc/file/downstream-media
OK   movie_27205
OK   movie_51876
... (10 rows total — fan-out children expanded)
=== Summary ===
  OK: 10  Data issues: 0  Transient probes: 0
=== reconcile-downstream done (exit=0) ===
```

Manual run hit a transient `database is locked` on first attempt (live container in mid-transaction) — fixed in the snapshot loop with `-cmd ".timeout 5000"` + 5x retry / 3s backoff.

## Test plan

- [x] Cron file installed at `/etc/cron.d/reconcile-downstream` with correct permissions
- [x] Logrotate config installed at `/etc/logrotate.d/reconcile-downstream`
- [x] Wrapper script at `/opt/scripts/reconcile-downstream.sh` is executable
- [x] Manual run (`/opt/scripts/reconcile-downstream.sh`) succeeds end-to-end against live DB
- [x] Snapshot retry loop survives a transient `database is locked` from the live container
- [x] Log file `/home/nick/logs/reconcile-downstream.log` exists and is appended to
- [ ] First scheduled cron fire (04:15 tomorrow server time) — observe via `tail /home/nick/logs/reconcile-downstream.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)