### PR TITLE
fix(invite): correct deploy paths to match Caddy container mounts

### DIFF
--- a/caddy/docker-compose.yml
+++ b/caddy/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - caddy_data:/data
       - caddy_config:/config
       - /home/nick/apps/site:/srv/site:ro
+      - /home/nick/apps/invite:/srv/invite:ro
       - /srv/tech-world:/srv/tech-world:ro
 
 volumes:

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -127,6 +127,12 @@ deploy_invite() {
     # Static QR-code slide / shareable join URL served at invite.imagineering.cc.
     # Source lives in this repo (unlike deploy_site which pulls from a separate
     # website/ repo), so we rsync straight from $REPO_ROOT/invite.
+    #
+    # Destination is ~/apps/invite (NOT /srv/invite) — the Caddy container
+    # bind-mounts /home/nick/apps/invite -> /srv/invite:ro at the path the
+    # Caddyfile references. See caddy/docker-compose.yml. Same convention as
+    # the existing /home/nick/apps/site mount. (deploy_site itself currently
+    # writes to /srv/site, which is a pre-existing bug — tracked separately.)
     local INVITE_SRC="$REPO_ROOT/invite"
 
     if [ ! -d "$INVITE_SRC" ]; then
@@ -135,9 +141,9 @@ deploy_invite() {
     fi
 
     echo "Deploying invite.imagineering.cc..."
-    ssh "$REMOTE" "mkdir -p /srv/invite"
-    rsync -avz --delete "$INVITE_SRC/" "$REMOTE":/srv/invite/
-    echo "Invite deployed to /srv/invite"
+    ssh "$REMOTE" "mkdir -p ~/apps/invite"
+    rsync -avz --delete "$INVITE_SRC/" "$REMOTE":apps/invite/
+    echo "Invite deployed to ~/apps/invite (mounted into Caddy as /srv/invite)"
 }
 
 deploy_contact() {


### PR DESCRIPTION
## Summary

PR #41 shipped `invite.imagineering.cc` but the deploy was broken in two ways that only surfaced at deploy time. Server-side state was already fixed manually to get the meetup URL live; this PR aligns the repo with reality so future deploys don't regress.

**The two bugs:**

1. **`deploy_invite()` rsync'd to wrong path.** It wrote to host `/srv/invite/`, but Caddy runs in a container — `root * /srv/invite` resolves *inside* the container's filesystem, not on the host. `network_mode: host` is networking-only; the FS boundary still applies. Fix: rsync to `~/apps/invite/` (the path that the compose file bind-mounts in), matching the existing `/home/nick/apps/site` convention.
2. **`caddy/docker-compose.yml` was missing the invite mount entirely.** Even after Caddy picked up the new site block, every request 404'd because `/srv/invite` didn't exist in the container's filesystem. Fix: add `/home/nick/apps/invite:/srv/invite:ro`.

## Why this slipped past PR #41 review

Both issues are invisible from a code review of PR #41 — they only manifest when you compare what the deploy script does against what the running container actually mounts. Worth keeping in mind for future Caddy-fronted services.

## Verified live

`https://invite.imagineering.cc` → HTTP/2 200, valid Let's Encrypt cert, page renders, QR scans to `imagineering.cc`. (Server state corrected manually during PR #41 deploy; this PR persists those fixes in the repo.)

## Related

Discovered during this work: `deploy_site` has the same `/srv/<name>` vs `~/apps/<name>` mismatch — it writes to `/srv/site` which the container doesn't read. Tracked as a separate task (Task #1) to fix carefully without disrupting a working production website.

## Test plan

- [ ] CI green (ShellCheck, yamllint)
- [ ] After merge, run `./scripts/deploy-to.sh 149.118.69.221 invite` — should be a no-op rsync (files already in place from manual deploy)
- [ ] After merge, optionally re-run `./scripts/deploy-to.sh 149.118.69.221 caddy` — compose mount should reconcile cleanly (we already added it manually)
- [ ] `curl -sI https://invite.imagineering.cc` continues to return 200