### PR TITLE
fix(site): redirect deploy_site to the path Caddy actually reads

### DIFF
--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -110,6 +110,15 @@ deploy_downstream_reconciler() {
 }
 
 deploy_site() {
+    # imagineering.cc landing page. Source: separate website/ repo.
+    #
+    # Destination is ~/apps/site (NOT /srv/site) — the Caddy container
+    # bind-mounts /home/nick/apps/site -> /srv/site:ro at the path the
+    # Caddyfile references. See caddy/docker-compose.yml. Same convention as
+    # the invite mount. Previously this rsynced to host /srv/site, which is
+    # not visible inside the Caddy container's filesystem — the script was
+    # writing to dead state for some time, and live deploys must have been
+    # happening out of band (manual rsync to ~/apps/site).
     local SITE_SRC="$HOME/git/orgs/imagineering/website"
 
     if [ ! -d "$SITE_SRC" ]; then
@@ -118,9 +127,9 @@ deploy_site() {
     fi
 
     echo "Deploying imagineering.cc landing page..."
-    ssh "$REMOTE" "mkdir -p /srv/site"
-    rsync -avz --delete --exclude '.git' --exclude '.github' --exclude 'README.md' "$SITE_SRC/" "$REMOTE":/srv/site/
-    echo "Site deployed to /srv/site"
+    ssh "$REMOTE" "mkdir -p ~/apps/site"
+    rsync -avz --delete --exclude '.git' --exclude '.github' --exclude 'README.md' "$SITE_SRC/" "$REMOTE":apps/site/
+    echo "Site deployed to ~/apps/site (mounted into Caddy as /srv/site)"
 }
 
 deploy_invite() {


### PR DESCRIPTION
## Summary

`deploy_site` rsyncs the website to host `/srv/site/`, but the Caddy container only ever reads from `/home/nick/apps/site/` (per the volume mount in `caddy/docker-compose.yml`). The script has been effectively dead code — live deploys of `imagineering.cc` must have been happening out of band (manual rsync directly to `~/apps/site/`), explaining the timestamp + content divergence I observed between the two directories on the server (`/srv/site/` is older and missing `README.md`; `/home/nick/apps/site/` is newer and has it).

**Fix**: change the rsync target to `~/apps/site/`, matching the convention `deploy_invite` now uses (PR #42).

## Why this is safe

- `rsync --delete --exclude README.md` does **not** delete files from the destination that match the exclude pattern (rsync's default behavior unless `--delete-excluded` is set). The existing `README.md` in `~/apps/site/` is preserved.
- The `--exclude .git --exclude .github` flags continue to keep version-control plumbing out of the served directory.
- `/srv/site/` is left in place — it's harmless dead state and removing it is a separate cleanup decision (someone might script against it; verifying that is beyond this PR's scope).

## Verification plan

- [ ] CI green (ShellCheck, yamllint)
- [ ] After merge, run `./scripts/deploy-to.sh 149.118.69.221 site`
- [ ] `curl -sI https://imagineering.cc` returns 200, content matches the website repo's `index.html`
- [ ] `ls -la /home/nick/apps/site/README.md` still exists (sanity check on the rsync exclude behavior)

## Context

Discovered during the `invite.imagineering.cc` work (PRs #41/#42). Tracked as Task #1.