### PR TITLE
fix(site): exclude all dotfiles from rsync to production

### DIFF
--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -128,7 +128,10 @@ deploy_site() {
 
     echo "Deploying imagineering.cc landing page..."
     ssh "$REMOTE" "mkdir -p ~/apps/site"
-    rsync -avz --delete --exclude '.git' --exclude '.github' --exclude 'README.md' "$SITE_SRC/" "$REMOTE":apps/site/
+    # --exclude '.*' skips ALL dotfile entries (.git, .github, .claude,
+    # .playwright-mcp, etc.). Replaces the previous narrow excludes which
+    # missed Claude/Playwright artefacts. README.md stays excluded explicitly.
+    rsync -avz --delete --exclude '.*' --exclude 'README.md' "$SITE_SRC/" "$REMOTE":apps/site/
     echo "Site deployed to ~/apps/site (mounted into Caddy as /srv/site)"
 }
 


### PR DESCRIPTION
## Summary

PR #43 redirected `deploy_site` to write where Caddy actually reads. Running the new path against the live website (dry-run) revealed a second issue: the existing narrow excludes (`.git`, `.github`, `README.md`) miss `.claude/` and `.playwright-mcp/` artefacts that accumulate in the website source dir. With the path fix in place, those would now ship to production on every deploy.

**Fix**: switch to `--exclude '.*'` to skip all dotfile entries — covers `.git`, `.github`, `.claude`, `.playwright-mcp`, and any future Claude/MCP/editor junk. Keeps the explicit `README.md` exclude.

## Why this is safe for a static landing page

A landing page has no legitimate dotfiles to ship. Caddy's automatic ACME challenges go through its own internal storage, not `/srv/site/.well-known/`. There is no `.htaccess`, no `.env`, no dotfile that should be served from this directory.

## Verified

`rsync --dry-run` with the new filter narrows the transfer from 11 files (incl. `.claude/`, `.playwright-mcp/`) to 5 (`index.html`, `assets/`, `favicon.png`, hero PNG). Exactly what should be on the live site.

## Context

Same chain: `invite.imagineering.cc` work → Task #1 → PR #43 (path fix) → this PR (filter fix). After merge, planning to run `./scripts/deploy-to.sh 149.118.69.221 site` to verify end-to-end and confirm `imagineering.cc` continues to serve correctly.