### PR TITLE
feat(watchers): Melbourne→Sydney peer instance watcher

### DIFF
--- a/scripts/watchers/oci-instance-watch-melbourne.sh
+++ b/scripts/watchers/oci-instance-watch-melbourne.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# OCI instance-RUNNING watcher — Melbourne→Sydney peer.
+#
+# Counterpart to oci-instance-watch.sh (which runs on Sydney and watches
+# Melbourne). Sydney watches Melbourne via its NICK_MEL profile; this
+# script watches Sydney via its SYDNEY profile. Each box catches the
+# other's silent death — neither tries to monitor itself (chicken-and-
+# egg: a watcher on the box it's watching can't notice the box dying).
+#
+# Sydney's tenancy is owned by gaylejewson@gmail.com (CreatedOn
+# 2026-03-18). API access is via a Melbourne-generated key registered
+# against Nick's user in that tenancy on 2026-05-03.
+#
+# Phase A: Sydney's tenancy has fewer RUNNING instances than expected
+#          (1) → 🚨 (names the affected profile + delta).
+# Phase B: count back to expected → ✅, self-disable.
+#
+# Cron: 17 */2 * * * /home/ubuntu/oci-instance-watch.sh  # oci-instance-watch
+# (Every 2 hours, off the hour. Offset 4 min from Sydney's :13 to spread
+#  load and avoid simultaneous fires.)
+
+set -euo pipefail
+
+# shellcheck disable=SC2034
+WATCHER_NAME="oci-instance-watch"
+# shellcheck disable=SC2034
+CRON_TAG="oci-instance-watch"
+
+__lib="$(dirname "$0")/lib/watcher-base.sh"
+[[ -r "$__lib" ]] || __lib="$HOME/lib/watcher-base.sh"
+# shellcheck disable=SC1090
+source "$__lib"
+unset __lib
+
+export PATH="$HOME/bin:$PATH"   # oci CLI lives in ~/bin
+export SUPPRESS_LABEL_WARNING=True
+
+# Per-tenancy: PROFILE|TENANCY_OCID|EXPECTED_RUNNING_COUNT
+TENANCIES=(
+    "SYDNEY|ocid1.tenancy.oc1..aaaaaaaaruqlptcngoh3dwzx3nu6ahahh3dbl5hy64o4rojhfmkmbgn3yfaa|1"
+)
+
+# Echoes "<profile>:<actual>:<expected>" per tenancy.
+# actual is "?" on query failure; the caller treats "?" as "don't know,
+# don't fire" so a transient API blip doesn't trigger Phase A.
+check_all_tenancies() {
+    local entry profile tenancy expected result actual
+    for entry in "${TENANCIES[@]}"; do
+        IFS='|' read -r profile tenancy expected <<< "$entry"
+        result=$(oci compute instance list \
+                --compartment-id "$tenancy" \
+                --profile "$profile" \
+                --lifecycle-state RUNNING 2>&1 | grep -v Warning) || { echo "$profile:?:$expected"; continue; }
+        actual=$(echo "$result" | jq -r '.data | length // 0' 2>/dev/null) || actual="?"
+        echo "$profile:$actual:$expected"
+    done
+}
+
+phase_a_check() {
+    local lines below
+    lines=$(check_all_tenancies)
+    log "phase_a: $(tr '\n' ' ' <<< "$lines")"
+    below=$(awk -F: '$2 ~ /^[0-9]+$/ && $2 < $3 { print }' <<< "$lines")
+    if [[ -n "$below" ]]; then
+        local pretty
+        pretty=$(awk -F: '{ printf "  %s: running=%s expected=%s\n", $1, $2, $3 }' <<< "$below")
+        tg "$(printf '🚨 <b>OCI instance(s) not RUNNING</b> (Melbourne→Sydney peer)\n\n<pre>%s</pre>\nMeans Oracle reclaimed the instance, it crashed, or it was terminated. Check OCI console + try a manual start.' "$pretty")"
+        return 0
+    fi
+    return 1
+}
+
+phase_b_check() {
+    local lines stillBelow
+    lines=$(check_all_tenancies)
+    log "phase_b: $(tr '\n' ' ' <<< "$lines")"
+    stillBelow=$(awk -F: '$2 ~ /^[0-9]+$/ && $2 < $3 { print }' <<< "$lines")
+    if [[ -z "$stillBelow" ]]; then
+        tg '✅ <b>OCI instance(s) RUNNING again</b> (Melbourne→Sydney peer) — recovery complete.'
+        return 0
+    fi
+    return 1
+}
+
+run_watcher

--- a/scripts/watchers/oci-instance-watch.sh
+++ b/scripts/watchers/oci-instance-watch.sh
@@ -22,10 +22,10 @@
 # people's instances.
 #
 # This watcher cannot watch Sydney itself (it runs ON Sydney — chicken
-# and egg). Sydney's OCI tenancy is undocumented and isn't represented
-# in /home/ubuntu/.oci/config. Future work: set up a peer watcher on
-# Melbourne (nick-mel) that monitors Sydney from outside. Tracked as a
-# follow-up task.
+# and egg). Sydney is watched from outside by oci-instance-watch-
+# melbourne.sh, which runs on nick-mel via a SYDNEY profile keyed
+# against Nick's user in Sydney's tenancy (gaylejewson@gmail.com,
+# created 2026-03-18). Set up 2026-05-03.
 #
 # Cron: 13 */2 * * * /home/ubuntu/oci-instance-watch.sh  # oci-instance-watch
 # (Every 2 hours, off the hour. Instance state changes infrequently;


### PR DESCRIPTION
## Summary
- Adds `oci-instance-watch-melbourne.sh` — runs on nick-mel via `SYDNEY` OCI profile, watches Sydney's tenancy from outside.
- Closes the mutual peer-monitoring loop: Sydney already watches Melbourne (NICK_MEL profile); now each box catches the other's silent death.
- Refreshes Sydney's `oci-instance-watch.sh` header to point at the new sibling instead of citing the gap as "future work."

## How peer monitoring works
| Direction | Runs on | Cron | Profile | Tenancy watched |
|---|---|---|---|---|
| Sydney → Melbourne | 149.118.69.221 | `13 */2 * * *` | NICK_MEL | nick-mel @ ap-melbourne-1 |
| Melbourne → Sydney | 130.162.192.233 | `17 */2 * * *` | SYDNEY | imagineering-syd @ ap-sydney-1 |

Both share `scripts/watchers/lib/watcher-base.sh` (state machine + `tg()` notify). Cron offsets (`:13` vs `:17`) spread load.

## Bootstrap (already done on nick-mel)
- OCI CLI installed at `/home/ubuntu/bin/oci`
- New API keypair generated locally; private key stays on Melbourne (`~/.oci/sydney_api_key.pem`)
- Public key registered against Nick's user in Sydney's tenancy via OCI console
- `~/.oci/config` written with `SYDNEY` profile (fingerprint `2f:ee:3d:a9:2f:b1:a7:dd:15:23:4e:b8:bf:9c:41:c8`)
- Notify creds copied from Sydney via ssh→ssh pipe (no terminal echo)
- Smoke-tested via `DRY_RUN=1` — `phase_a: SYDNEY:1:1` (clean, expected)
- Cron entry installed

## Test plan
- [x] `DRY_RUN=1 ~/oci-instance-watch.sh` on nick-mel logs `phase_a: SYDNEY:1:1` and does not fire
- [x] Live `oci compute instance list --profile SYDNEY` from nick-mel returns `imagineering-syd: RUNNING`
- [ ] First scheduled fire (next `:17`) lands without alert (Sydney up)
- [ ] (Eventual) Phase A→B exercise when Sydney is restarted for whatever reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)