### PR TITLE
feat(watchers): diagnostic enrichment lib + 3 watcher updates

### DIFF
--- a/scripts/watchers/cert-expiry-watch.sh
+++ b/scripts/watchers/cert-expiry-watch.sh
@@ -31,6 +31,12 @@ __lib="$(dirname "$0")/lib/watcher-base.sh"
 source "$__lib"
 unset __lib
 
+__diag="$(dirname "$0")/lib/diagnose.sh"
+[[ -r "$__diag" ]] || __diag="$HOME/lib/diagnose.sh"
+# shellcheck disable=SC1090
+source "$__diag"
+unset __diag
+
 WARN_DAYS=14
 SAFE_DAYS=30
 
@@ -83,9 +89,14 @@ phase_a_check() {
     warning=$(awk -F: -v t="$WARN_DAYS" '$2 < t { print }' <<< "$lines")
     log "phase_a: probed=$probed_count under_${WARN_DAYS}d=$(nlines "$warning")"
     if [[ -n "$warning" ]]; then
-        local pretty
+        local pretty acme
         pretty=$(awk -F: '{ printf "  %s: %sd\n", $1, $2 }' <<< "$warning")
-        tg "$(printf '🚨 <b>Caddy cert(s) near expiry</b> (auto-renew may have stalled)\n\n<pre>%s</pre>\n\nCheck <code>docker logs caddy 2&gt;&amp;1 | tail -100</code> on Sydney for renewal errors.' "$pretty")"
+        # ACME reachability diagnostic: distinguishes "Caddy can't talk
+        # to Let's Encrypt" (network/firewall) from "Caddy reaches LE
+        # but renewal still fails" (account/cert-config issue). One curl,
+        # ~5s budget, included inline.
+        acme=$(html_escape "$(acme_probe)")
+        tg "$(printf '🚨 <b>Caddy cert(s) near expiry</b> (auto-renew may have stalled)\n\n<pre>%s</pre>\nACME endpoint reachability: <code>%s</code>\n\nCheck <code>docker logs caddy 2&gt;&amp;1 | tail -100</code> on Sydney for renewal errors.' "$pretty" "$acme")"
         return 0
     fi
     return 1

--- a/scripts/watchers/disk-usage-watch.sh
+++ b/scripts/watchers/disk-usage-watch.sh
@@ -22,10 +22,26 @@ __lib="$(dirname "$0")/lib/watcher-base.sh"
 source "$__lib"
 unset __lib
 
+__diag="$(dirname "$0")/lib/diagnose.sh"
+[[ -r "$__diag" ]] || __diag="$HOME/lib/diagnose.sh"
+# shellcheck disable=SC1090
+source "$__diag"
+unset __diag
+
 # Watcher-specific helpers
 root_usage_pct() { df / | awk 'NR==2 { gsub("%",""); print $5 }'; }
 top_dirs() {
     du -sh /var/log/* /home/* /tmp/* /var/lib/* /opt/* 2>/dev/null | sort -rh | head -5
+}
+# Top single files anywhere ubuntu can read — adds a "what one file is
+# eating the disk" view that top_dirs (sums) can hide. Largest offenders
+# are typically log files, journal segments, or stray downloads.
+top_single_files() {
+    {
+        top_files /var/log 5
+        top_files /tmp 5
+        top_files /home 5
+    } | sort -rh -k1,1 | head -5
 }
 
 # Warn-file for the "still climbing" tier in Phase B. Gates the second-fire
@@ -37,11 +53,12 @@ phase_a_check() {
     usage=$(root_usage_pct)
     log "phase_a: usage=${usage}%"
     if [[ "$usage" -ge 85 ]]; then
-        local dirs
+        local dirs files
         dirs=$(top_dirs)
+        files=$(top_single_files)
         local msg
-        msg=$(printf '🚨 <b>Sydney disk at %s%%</b>\n\nTop directories visible to %s:\n<pre>%s</pre>\n\n<i>Watcher will notify again on recovery (&lt;75%%) and self-disable.</i>' \
-              "$usage" "${USER:-unknown}" "$dirs")
+        msg=$(printf '🚨 <b>Sydney disk at %s%%</b>\n\nTop directories visible to %s:\n<pre>%s</pre>\nLargest single files:\n<pre>%s</pre>\n<i>Watcher will notify again on recovery (&lt;75%%) and self-disable.</i>' \
+              "$usage" "${USER:-unknown}" "$dirs" "$files")
         tg "$msg"
         return 0
     fi

--- a/scripts/watchers/kanbn-upstream-watch.sh
+++ b/scripts/watchers/kanbn-upstream-watch.sh
@@ -33,6 +33,12 @@ __lib="$(dirname "$0")/lib/watcher-base.sh"
 source "$__lib"
 unset __lib
 
+__diag="$(dirname "$0")/lib/diagnose.sh"
+[[ -r "$__diag" ]] || __diag="$HOME/lib/diagnose.sh"
+# shellcheck disable=SC1090
+source "$__diag"
+unset __diag
+
 REPO="kanbn/kan"
 BASELINE_FILE="$CONFIG_DIR/$WATCHER_NAME.baseline"
 
@@ -64,8 +70,13 @@ phase_a_check() {
     log "phase_a: current=$current baseline=$baseline"
 
     if [[ "$current" != "$baseline" ]]; then
-        tg "$(printf '🆕 <b>kanbn/kan released %s</b> (was %s)\n\n<a href="https://github.com/%s/releases/tag/%s">Release notes</a>\n\nCheck if it includes the <code>card_activity.attachmentId</code> migration — if so, we can drop our manual patch.' \
-              "$current" "$baseline" "$REPO" "$current")"
+        # Inline release notes preview (~500 chars) so the alert tells you
+        # immediately whether this release is the one with the migration
+        # fix you've been waiting for, without an extra GitHub round-trip.
+        local notes
+        notes=$(github_release_notes "$REPO" "$current" 500)
+        tg "$(printf '🆕 <b>kanbn/kan released %s</b> (was %s)\n\n<a href="https://github.com/%s/releases/tag/%s">Release notes</a>\n\n<pre>%s</pre>\n\nCheck if it includes the <code>card_activity.attachmentId</code> migration — if so, we can drop our manual patch.' \
+              "$current" "$baseline" "$REPO" "$current" "$notes")"
         echo "$current" > "$BASELINE_FILE"
         return 0
     fi

--- a/scripts/watchers/lib/diagnose.sh
+++ b/scripts/watchers/lib/diagnose.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Diagnostic helpers for watcher alerts. Sourced by individual watchers
+# alongside watcher-base.sh — provides shared "what's nearby" probes
+# that enrich tg() messages without changing the alerting state machine.
+#
+# Design rule: every helper here must
+#   1. Run as the cron-owning user (typically `ubuntu` on Sydney) without
+#      sudo, docker-group membership, or any new privilege.
+#   2. Time out promptly on hangs (network probes get --max-time; shell
+#      probes use timeout if needed).
+#   3. Return a short-ish HTML-safe string suitable for inclusion in a
+#      Telegram <pre> block. Telegram's hard cap is 4096 chars per
+#      message; helpers here aim for <500 each so callers can compose
+#      multiple without truncating the primary alert body.
+#   4. Never abort the watcher run. On probe failure, return a placeholder
+#      string like "(probe failed: <reason>)" — the watcher should still
+#      fire its alert with whatever diagnostic data is available.
+#
+# Helpers:
+#   top_files <dir> [count=3]
+#       List the largest single regular files under <dir> (one level deep
+#       only — find won't descend, to keep latency bounded). Output is
+#       human-readable: "<size> <path>" per line. Useful when "top dirs"
+#       isn't enough — e.g. one runaway log file inside a noisy dir.
+#
+#   acme_probe
+#       Quick reachability check for Let's Encrypt's ACME v2 directory.
+#       Distinguishes "Caddy can't reach Let's Encrypt" from "Caddy
+#       reaching it but failing." Returns first line of the HTTP response
+#       (e.g. "HTTP/2 200") or "(unreachable: <reason>)".
+#
+#   github_release_notes <owner/repo> <tag> [maxlen=500]
+#       Fetch the body of a GitHub release and return up to <maxlen>
+#       chars, with HTML-safe escaping. Returns "(no release notes)" if
+#       the tag isn't tied to a Release (only a tag), and "(API error:
+#       <code>)" on HTTP error. Uses unauthenticated GitHub API — caller
+#       should be tolerant of rate-limit failures.
+#
+#   html_escape <text>
+#       Replace <, >, & for safe inclusion in Telegram HTML messages.
+#       Quotes are intentionally not escaped — Telegram's HTML mode
+#       doesn't treat them as special, and escaping them produces ugly
+#       &quot; renders.
+
+# Note: this lib intentionally does NOT `set -euo pipefail`. It expects to
+# be sourced into a watcher script that already has those set, and helpers
+# here use defensive fallbacks rather than letting the watcher die on a
+# probe-side failure.
+
+# top_files <dir> [count]
+top_files() {
+    local dir="$1" count="${2:-3}"
+    if [[ ! -d "$dir" ]]; then
+        echo "(top_files: $dir not a directory)"
+        return 0
+    fi
+    # find -maxdepth 1 keeps latency bounded; we only want immediately-
+    # visible files, not a recursive scan.
+    find "$dir" -maxdepth 1 -type f -printf '%s %p\n' 2>/dev/null \
+        | sort -rn \
+        | head -n "$count" \
+        | awk '{ size=$1; $1=""; sub(/^ /,""); printf "  %s  %s\n", human(size), $0 }
+               function human(b,   u, i) {
+                   u="BKMGT"; i=1
+                   while (b >= 1024 && i < length(u)) { b /= 1024; i++ }
+                   return sprintf("%6.1f%s", b, substr(u,i,1))
+               }'
+}
+
+# acme_probe
+acme_probe() {
+    local out
+    out=$(curl -sSI --max-time 5 https://acme-v02.api.letsencrypt.org/directory 2>&1) \
+        || { echo "(unreachable: ${out:-curl error})"; return 0; }
+    head -1 <<< "$out" | tr -d '\r'
+}
+
+# github_release_notes <owner/repo> <tag> [maxlen]
+github_release_notes() {
+    local repo="$1" tag="$2" maxlen="${3:-500}"
+    local resp http_code body
+    resp=$(curl -sS --max-time 10 -w '\n%{http_code}' \
+            "https://api.github.com/repos/${repo}/releases/tags/${tag}" 2>&1) \
+        || { echo "(release notes fetch failed)"; return 0; }
+    http_code=$(tail -n1 <<< "$resp")
+    body=$(sed '$d' <<< "$resp")
+    case "$http_code" in
+        200) ;;
+        404) echo "(no release notes — tag exists but no GitHub Release)"; return 0 ;;
+        *)   echo "(API error: $http_code)"; return 0 ;;
+    esac
+    local notes
+    notes=$(jq -r '.body // ""' <<< "$body" 2>/dev/null)
+    if [[ -z "$notes" ]]; then
+        echo "(release has no body)"
+        return 0
+    fi
+    # Truncate to maxlen, append "…" if cut. Then html-escape.
+    if [[ "${#notes}" -gt "$maxlen" ]]; then
+        notes="${notes:0:$maxlen}…"
+    fi
+    html_escape "$notes"
+}
+
+# html_escape <text>
+html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    printf '%s' "$s"
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/watchers/lib/diagnose.sh` — sourced alongside `watcher-base.sh` to provide shared probes for enriching tg() alerts.
- Enriches **disk-usage**, **cert-expiry**, and **kanbn-upstream** watchers with surrounding context that makes each alert ~10x more actionable.
- All helpers are sudo-free; no group changes or NOPASSWD sudoers needed for these three.

## Per-watcher enrichments

| Watcher | Was | Now adds |
|---|---|---|
| `disk-usage` | top dirs (du-aggregate) | top **single files** — catches "one runaway log file" cases that `du -sh dir/*` hides |
| `cert-expiry` | "check `docker logs caddy`" | inline ACME endpoint reachability probe — distinguishes "Caddy can't reach LE" from "Caddy reaches LE but cert renewal still fails" |
| `kanbn-upstream` | release tag + link | inline ~500 chars of release notes — see immediately whether this is the release with the `card_activity.attachmentId` migration fix |

## Deferred (sudo/docker required)

These three enrichments from the original spec need either NOPASSWD sudoers rules or `ubuntu` membership in the `docker` group. Out of scope here; tracked as a follow-up:

- `backup-recency`: tail of `/home/nick/logs/backup.log` (owned by `nick`, not readable by `ubuntu`)
- `disk-usage`: `docker system df` breakdown (needs docker socket access)
- `cert-expiry`: last `docker logs caddy` lines (needs docker socket access)
- `oci-instance`: lifecycle events from OCI work-requests API (needs additional OCI permissions in tenancy)

## Helpers shape

```bash
top_files <dir> [count=3]              # largest single files
acme_probe                              # LE v2 directory reachability
github_release_notes <repo> <tag> [maxlen=500]
html_escape <text>                      # safe HTML for Telegram <pre>
```

Helpers fail-soft — return `(probe failed: <reason>)` rather than aborting the watcher run.

## Testing
- [x] All helpers smoke-tested on Mac (`top_files`, `acme_probe`, `html_escape`, `github_release_notes` against live kanbn/kan v0.5.6 — returns release body)
- [x] All four scripts pass `shellcheck -x`
- [ ] Live alert path will be exercised on next genuine fire (low frequency by design — the watchers are silent when systems are healthy)

## Deploy
Watchers on Sydney will pick up the new `diagnose.sh` and modified scripts on next manual sync (no automated deploy for this dir today). Suggest a separate deploy step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)