### PR TITLE
feat(watchers): sudo-helper wrappers + diagnostic enrichment for backup/disk/cert

### DIFF
--- a/scripts/watchers/backup-recency-watch.sh
+++ b/scripts/watchers/backup-recency-watch.sh
@@ -31,6 +31,12 @@ __lib="$(dirname "$0")/lib/watcher-base.sh"
 source "$__lib"
 unset __lib
 
+__diag="$(dirname "$0")/lib/diagnose.sh"
+[[ -r "$__diag" ]] || __diag="$HOME/lib/diagnose.sh"
+# shellcheck disable=SC1090
+source "$__diag"
+unset __diag
+
 BACKUP_DIR="/tmp/backups"
 STALE_HOURS=25
 
@@ -71,8 +77,14 @@ phase_a_check() {
         local last_iso
         last_iso=$(date -u -d "@$epoch" +"%Y-%m-%dT%H:%MZ" 2>/dev/null \
                 || date -u -r "$epoch" +"%Y-%m-%dT%H:%MZ")
-        # shellcheck disable=SC2016  # $(pgrep …) is literal; intended to be copy-pasted on Sydney by the reader
-        tg "$(printf '🚨 <b>Backup stale: %sh since last artifact</b>\n\nLatest file in <code>%s</code>: <code>%s</code>.\nDaily 4am backup likely failed. Check <code>/home/nick/logs/backup.log</code> + <code>journalctl _PID=$(pgrep -f backup.sh)</code> on Sydney.' "$hours_old" "$BACKUP_DIR" "$last_iso")"
+        # Tail of backup.log: distinguishes "backup ran and failed
+        # mid-stream" from "backup never started" — the difference
+        # determines whether you go look at backup.sh internals (failed)
+        # or cron/systemd-timer (never started).
+        local log_tail
+        log_tail=$(html_escape "$(tail_backup_log)")
+        # shellcheck disable=SC2016  # $(pgrep …) in the message body is literal; intended to be copy-pasted on Sydney by the reader
+        tg "$(printf '🚨 <b>Backup stale: %sh since last artifact</b>\n\nLatest file in <code>%s</code>: <code>%s</code>.\n\nLast lines of <code>backup.log</code>:\n<pre>%s</pre>\n\nIf the log shows nothing recent, cron/systemd-timer didn'"'"'t fire. Otherwise look at backup.sh internals.' "$hours_old" "$BACKUP_DIR" "$last_iso" "$log_tail")"
         return 0
     fi
     return 1

--- a/scripts/watchers/cert-expiry-watch.sh
+++ b/scripts/watchers/cert-expiry-watch.sh
@@ -89,14 +89,18 @@ phase_a_check() {
     warning=$(awk -F: -v t="$WARN_DAYS" '$2 < t { print }' <<< "$lines")
     log "phase_a: probed=$probed_count under_${WARN_DAYS}d=$(nlines "$warning")"
     if [[ -n "$warning" ]]; then
-        local pretty acme
+        local pretty acme caddy_log
         pretty=$(awk -F: '{ printf "  %s: %sd\n", $1, $2 }' <<< "$warning")
         # ACME reachability diagnostic: distinguishes "Caddy can't talk
         # to Let's Encrypt" (network/firewall) from "Caddy reaches LE
         # but renewal still fails" (account/cert-config issue). One curl,
         # ~5s budget, included inline.
         acme=$(html_escape "$(acme_probe)")
-        tg "$(printf '🚨 <b>Caddy cert(s) near expiry</b> (auto-renew may have stalled)\n\n<pre>%s</pre>\nACME endpoint reachability: <code>%s</code>\n\nCheck <code>docker logs caddy 2&gt;&amp;1 | tail -100</code> on Sydney for renewal errors.' "$pretty" "$acme")"
+        # Recent Caddy renewal log lines: surfaces the actual reason
+        # renewal stalled (rate limit, account problem, DNS challenge
+        # timeout). Filtered to cert/renew/acme/error keywords.
+        caddy_log=$(html_escape "$(caddy_renew_log)")
+        tg "$(printf '🚨 <b>Caddy cert(s) near expiry</b> (auto-renew may have stalled)\n\n<pre>%s</pre>\nACME endpoint reachability: <code>%s</code>\n\nRecent caddy log (cert/renew/acme/error):\n<pre>%s</pre>' "$pretty" "$acme" "$caddy_log")"
         return 0
     fi
     return 1

--- a/scripts/watchers/disk-usage-watch.sh
+++ b/scripts/watchers/disk-usage-watch.sh
@@ -53,12 +53,13 @@ phase_a_check() {
     usage=$(root_usage_pct)
     log "phase_a: usage=${usage}%"
     if [[ "$usage" -ge 85 ]]; then
-        local dirs files
+        local dirs files docker_df
         dirs=$(top_dirs)
         files=$(top_single_files)
+        docker_df=$(docker_df_summary)
         local msg
-        msg=$(printf '🚨 <b>Sydney disk at %s%%</b>\n\nTop directories visible to %s:\n<pre>%s</pre>\nLargest single files:\n<pre>%s</pre>\n<i>Watcher will notify again on recovery (&lt;75%%) and self-disable.</i>' \
-              "$usage" "${USER:-unknown}" "$dirs" "$files")
+        msg=$(printf '🚨 <b>Sydney disk at %s%%</b>\n\nTop directories visible to %s:\n<pre>%s</pre>\nLargest single files:\n<pre>%s</pre>\nDocker storage:\n<pre>%s</pre>\n<i>Watcher will notify again on recovery (&lt;75%%) and self-disable.</i>' \
+              "$usage" "${USER:-unknown}" "$dirs" "$files" "$docker_df")
         tg "$msg"
         return 0
     fi

--- a/scripts/watchers/lib/diagnose.sh
+++ b/scripts/watchers/lib/diagnose.sh
@@ -110,3 +110,67 @@ html_escape() {
     s="${s//>/&gt;}"
     printf '%s' "$s"
 }
+
+# strip_ansi
+#   Reads stdin, writes stdout with ANSI color/SGR escape sequences
+#   removed. Useful for log files that contain shell color codes
+#   (backup.log uses them) before inclusion in a Telegram <pre> block.
+strip_ansi() {
+    sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g'
+}
+
+# --- sudo-wrapper helpers ----------------------------------------------------
+# These call read-only wrapper scripts at /usr/local/bin/watcher-diag-*,
+# whitelisted via /etc/sudoers.d/watcher-diag for NOPASSWD. The wrappers
+# live in scripts/watchers/sudo-helpers/ in the repo. If sudo isn't
+# available or the wrapper is missing, helpers fail-soft with a clear
+# placeholder so the watcher still fires its primary alert.
+
+# tail_backup_log
+#   Last 50 lines of /home/nick/logs/backup.log, ANSI-stripped.
+#   Distinguishes "backup ran but failed" from "backup never started" —
+#   the most useful single addition to backup-recency alerts.
+tail_backup_log() {
+    if ! sudo -n -l /usr/local/bin/watcher-diag-backup-tail >/dev/null 2>&1; then
+        echo "(no sudoers entry for watcher-diag-backup-tail — see scripts/watchers/sudo-helpers/README.md)"
+        return 0
+    fi
+    sudo -n /usr/local/bin/watcher-diag-backup-tail 2>&1 | strip_ansi | tail -20
+}
+
+# docker_df_summary
+#   `docker system df` formatted as TYPE/TOTAL/SIZE/RECLAIMABLE table.
+#   Surfaces "disk full because of docker bloat" cases, which the
+#   filesystem-level top_dirs/top_files probes hide (everything's in
+#   /var/lib/docker/overlay2 and looks like one giant blob).
+docker_df_summary() {
+    if ! sudo -n -l /usr/local/bin/watcher-diag-docker-df >/dev/null 2>&1; then
+        echo "(no sudoers entry for watcher-diag-docker-df)"
+        return 0
+    fi
+    sudo -n /usr/local/bin/watcher-diag-docker-df 2>&1 | head -10
+}
+
+# caddy_renew_log
+#   Last ~10 cert/renewal-related lines from caddy container logs. Tells
+#   you whether Caddy thinks renewal is happening (and what failed if
+#   anything), without an ssh round-trip.
+caddy_renew_log() {
+    if ! sudo -n -l /usr/local/bin/watcher-diag-caddy-logs >/dev/null 2>&1; then
+        echo "(no sudoers entry for watcher-diag-caddy-logs)"
+        return 0
+    fi
+    # Filter to ACME/cert-related lines specifically. The generic 'error'
+    # keyword is intentionally excluded — Caddy logs every 502 to a backend
+    # as "error", and those are not cert problems. ACME-related Caddy
+    # logs are reliably tagged with cert/renew/acme/issuance/tls.cache.
+    local out
+    out=$(sudo -n /usr/local/bin/watcher-diag-caddy-logs 2>&1 \
+          | grep -iE 'cert|renew|acme|issuance|tls\.cache' \
+          | tail -10) || true
+    if [[ -z "$out" ]]; then
+        echo "(no cert/renew/acme/issuance/tls.cache lines in last 100 caddy log lines)"
+    else
+        echo "$out"
+    fi
+}

--- a/scripts/watchers/sudo-helpers/README.md
+++ b/scripts/watchers/sudo-helpers/README.md
@@ -1,0 +1,52 @@
+# Watcher diagnostic sudo helpers
+
+Read-only wrapper scripts that watcher diagnose.sh helpers can invoke
+via narrow `sudoers` NOPASSWD entries. Deployed to `/usr/local/bin/`
+on Sydney; sudoers entry at `/etc/sudoers.d/watcher-diag`.
+
+## Why wrappers (not raw commands in sudoers)
+
+Three reasons:
+
+1. **Audit signal**: a compromised root that wanted to expand `ubuntu`'s
+   capabilities would have to modify these files (whose mtime is
+   trivially monitorable), not the sudoers config.
+2. **Argument constraint**: sudoers allows globbing args; these scripts
+   take *no* args, eliminating any "what if a watcher passes the wrong
+   flag" failure mode.
+3. **Single dispatch point**: future enrichments add a new wrapper +
+   one sudoers line, rather than expanding an existing entry.
+
+All wrappers are read-only operations. They produce diagnostic output
+and exit. They never modify state, never accept user input, never
+shell out to user-controllable paths.
+
+## Install (manual — not part of any deploy script today)
+
+```bash
+# 1. Copy wrappers to /usr/local/bin (root-owned, mode 0755)
+sudo install -m 0755 -o root -g root scripts/watchers/sudo-helpers/watcher-diag-* /usr/local/bin/
+
+# 2. Install sudoers entry (root-owned, mode 0440)
+sudo install -m 0440 -o root -g root scripts/watchers/sudo-helpers/sudoers.watcher-diag /etc/sudoers.d/watcher-diag
+
+# 3. Validate
+sudo visudo -c
+sudo -n -l -U ubuntu | grep watcher-diag
+
+# 4. Smoke-test as ubuntu
+sudo -n /usr/local/bin/watcher-diag-docker-df | head -3
+sudo -n /usr/local/bin/watcher-diag-backup-tail | tail -3
+sudo -n /usr/local/bin/watcher-diag-caddy-logs | tail -3
+```
+
+## Wrappers
+
+| Script | What | Used by |
+|---|---|---|
+| `watcher-diag-backup-tail` | Last 50 lines of `/home/nick/logs/backup.log` | `backup-recency-watch.sh` |
+| `watcher-diag-docker-df` | `docker system df` summary | `disk-usage-watch.sh` |
+| `watcher-diag-caddy-logs` | Last 100 lines of `docker logs caddy`, grepped for cert/renew | `cert-expiry-watch.sh` |
+
+To add a new wrapper: drop a new script here, add a corresponding
+NOPASSWD line in `sudoers.watcher-diag`, re-install both.

--- a/scripts/watchers/sudo-helpers/sudoers.watcher-diag
+++ b/scripts/watchers/sudo-helpers/sudoers.watcher-diag
@@ -1,0 +1,12 @@
+# NOPASSWD whitelist for diagnostic-enrichment helpers in
+# scripts/watchers/lib/diagnose.sh. Each line points at a wrapper
+# script in /usr/local/bin/ — never a raw command. Wrappers take no
+# arguments to eliminate any "wrong flag passed" failure mode.
+#
+# Source of truth: scripts/watchers/sudo-helpers/ in imagineering-infra.
+# Re-install via the procedure in that directory's README.md when
+# adding/modifying wrappers.
+
+ubuntu ALL=(root) NOPASSWD: /usr/local/bin/watcher-diag-backup-tail
+ubuntu ALL=(root) NOPASSWD: /usr/local/bin/watcher-diag-docker-df
+ubuntu ALL=(root) NOPASSWD: /usr/local/bin/watcher-diag-caddy-logs

--- a/scripts/watchers/sudo-helpers/watcher-diag-backup-tail
+++ b/scripts/watchers/sudo-helpers/watcher-diag-backup-tail
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Read-only diagnostic: last 50 lines of backup.log.
+# Invoked via sudoers NOPASSWD entry by backup-recency-watch.sh.
+exec /usr/bin/tail -n 50 /home/nick/logs/backup.log

--- a/scripts/watchers/sudo-helpers/watcher-diag-caddy-logs
+++ b/scripts/watchers/sudo-helpers/watcher-diag-caddy-logs
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Read-only diagnostic: last 100 lines of caddy container output.
+# Invoked via sudoers NOPASSWD entry by cert-expiry-watch.sh.
+# Caller is responsible for further filtering (e.g. grep cert/renew).
+exec /usr/bin/docker logs --tail 100 caddy 2>&1

--- a/scripts/watchers/sudo-helpers/watcher-diag-docker-df
+++ b/scripts/watchers/sudo-helpers/watcher-diag-docker-df
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Read-only diagnostic: docker storage breakdown.
+# Invoked via sudoers NOPASSWD entry by disk-usage-watch.sh.
+exec /usr/bin/docker system df


### PR DESCRIPTION
## Summary
Closes the deferred-enrichment gap from PR #48. Adds three narrow `sudo` wrappers + sudoers entry so the watchers running as `ubuntu` can read backup.log, docker stats, and caddy logs — without granting docker-group membership (root-equivalent) or wildcard sudo rights.

## Sudo design
Each wrapper takes **no arguments** (no glob in the sudoers rule). Sudoers grants NOPASSWD only on the wrapper paths, never raw `docker`/`tail`/`cat`. If a future compromised root expanded ubuntu's capabilities by editing a wrapper, the wrapper's mtime would be the audit signal.

| Wrapper | What | Used by |
|---|---|---|
| `watcher-diag-backup-tail` | `tail -n 50 /home/nick/logs/backup.log` | backup-recency |
| `watcher-diag-docker-df` | `docker system df` | disk-usage |
| `watcher-diag-caddy-logs` | `docker logs --tail 100 caddy 2>&1` | cert-expiry |

## Watcher enrichments

| Watcher | Adds |
|---|---|
| backup-recency | tail of backup.log → "ran but failed" vs "never started" |
| disk-usage | docker system df → catches docker bloat that `du -sh` aggregates away |
| cert-expiry | recent caddy renewal log lines (filtered to cert/renew/acme/issuance/tls.cache) → surfaces actual renewal-failure reason |

## Live testing on Sydney (2026-05-03)
All three helpers exercised against deployed wrappers:
- `tail_backup_log` → returns 20 lines of recent backup output
- `docker_df_summary` → 252 images, 64.55GB total, 52.28GB reclaimable
- `caddy_renew_log` → returns ACME info lines (e.g. "got renewal info" for kan.imagineering.cc)

Wrappers + sudoers already installed on Sydney via the procedure in `scripts/watchers/sudo-helpers/README.md`. Diagnose.sh + 3 modified watchers also already deployed and DRY_RUN-tested clean (no false alerts).

## Bonus finding (separate task)
First invocation of `tail_backup_log` immediately surfaced **two production bugs in backup.sh** that the existing watcher couldn't see:
1. GitHub upload silently broken (`ERROR: Deploy key not found at ~/.ssh/imagineering-backups-deploy, skipping GitHub backup`)
2. Dreamfinder backup looking at wrong file path (docker cp errors but backup.sh marks it "complete")

Captured as a separate task. Validates the enrichment design — the watcher's threshold logic missed both because local artifacts WERE fresh, but the GitHub mirror has been silently empty.

## Test plan
- [x] All scripts pass `shellcheck -x` (lib + watchers + sh wrappers)
- [x] Sudoers entry validates via `visudo -cf`
- [x] Live wrapper invocations produce expected diagnostic data
- [x] Live `DRY_RUN=1` runs of the 3 watchers complete without firing false alerts
- [ ] Live alert path will be exercised on next genuine fire (low frequency by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)