### PR TITLE
fix(backup): restore GitHub upload + correct Dreamfinder db path

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -10,7 +10,7 @@ RETENTION_DAYS=7
 FAILED_SERVICES=()
 
 # GitHub backup config
-GITHUB_BACKUP_REPO="git@github-backups:imagineering-cc/imagineering-backups.git"
+GITHUB_BACKUP_REPO="git@github-imagineering-backups:imagineering-cc/imagineering-backups.git"
 GITHUB_BACKUP_DIR="/tmp/imagineering-backups"
 GITHUB_REPO_SIZE_ALERT_MB=500
 
@@ -68,8 +68,15 @@ backup_pm_bot() {
 
   local backup_file="$BACKUP_DIR/pm-bot-$DATE.db"
 
-  # Copy SQLite database from container volume
-  docker cp dreamfinder:/app/data/kan-bot.db "$backup_file"
+  # Copy SQLite database from container volume.
+  # Path is /app/data/bot.db (was kan-bot.db from an earlier rename;
+  # docker cp silently produces an empty/wrong file on path mismatch
+  # which is why this bug went undetected — fail loudly instead).
+  if ! docker cp dreamfinder:/app/data/bot.db "$backup_file"; then
+    error "Dreamfinder docker cp failed — backup file is incomplete or missing"
+    rm -f "$backup_file"
+    return 1
+  fi
 
   log "Dreamfinder backup complete: pm-bot-$DATE.db"
 }
@@ -162,14 +169,17 @@ backup_downstream_server() {
 backup_to_github() {
   local services=("$@")
 
-  # Check prerequisites
+  # Check prerequisites. Both error returns are 1 (not 0) so the caller's
+  # FAILED_SERVICES tracking captures the failure — a missing deploy key
+  # silently producing local-only backups for weeks (caught 2026-05-03)
+  # is exactly the failure mode this script must surface.
   if ! command -v git &> /dev/null; then
-    error "git not installed, skipping GitHub backup"
-    return 0
+    error "git not installed, GitHub backup failed"
+    return 1
   fi
   if [ ! -f "$HOME/.ssh/imagineering-backups-deploy" ]; then
-    error "Deploy key not found at ~/.ssh/imagineering-backups-deploy, skipping GitHub backup"
-    return 0
+    error "Deploy key not found at ~/.ssh/imagineering-backups-deploy, GitHub backup failed"
+    return 1
   fi
 
   log "Pushing backups to GitHub..."
@@ -253,7 +263,7 @@ case $SERVICE in
       fi
     done
     if [ ${#SUCCEEDED[@]} -gt 0 ]; then
-      backup_to_github "${SUCCEEDED[@]}"
+      backup_to_github "${SUCCEEDED[@]}" || FAILED_SERVICES+=("github-upload")
     fi
     cleanup_old_backups
     ;;


### PR DESCRIPTION
## Summary
Two distinct bugs in `/opt/scripts/backup.sh` that have been silently breaking the daily backup pipeline since ~2026-03-21. Both surfaced by the new `tail_backup_log` diagnostic helper (PR #49) on its very first invocation. Last successful GitHub push before this fix: `672aced` on **2026-03-21** — six weeks of local-only backups.

## Bug 1: GitHub upload silently broken
- Deploy key `~/.ssh/imagineering-backups-deploy` missing on Sydney (probably lost during the box reprovision).
- Stale GH deploy key with no live counterpart.
- SSH host alias `github-backups` pointed at xdeca's key, not authorized for imagineering-backups.
- `backup_to_github()` returned `0` on missing key — silent failure mode that hid the whole problem from `FAILED_SERVICES`.

**Fix**:
- Generated fresh ed25519 keypair on Sydney as `nick`.
- Rotated GH deploy key (deleted stale `144273951`, added new `150345664` with `read_only=false`).
- New SSH host alias `github-imagineering-backups` in `~nick/.ssh/config.d/imagineering-backups`.
- `GITHUB_BACKUP_REPO` updated to use the new alias.
- Missing-key branch returns `1` now (not `0`) — silent fallthrough was the root cause of the 6-week silent failure.
- Added `FAILED_SERVICES` tracking on the `all` path's `backup_to_github` call.

## Bug 2: Dreamfinder backup wrong file path
- `docker cp dreamfinder:/app/data/kan-bot.db` — but the container path is `/app/data/bot.db` (renamed during the Matrix migration).
- docker cp printed an error; backup.sh ignored the rc and marked it "complete." Every daily backup produced an empty/non-existent file for ~6 weeks.

**Fix**:
- Path corrected to `/app/data/bot.db`.
- docker cp return code now checked; on failure: log error, remove partial file, return `1`.

## End-to-end test (Sydney, 2026-05-03)
```
$ /opt/scripts/backup.sh pm-bot
[2026-05-03 12:56:20] Backing up Dreamfinder...
[2026-05-03 12:56:20] Dreamfinder backup complete: pm-bot-2026-05-03.db
[2026-05-03 12:56:20] Pushing backups to GitHub...
[2026-05-03 12:56:24] Copied pm-bot backup → pm-bot.db
[main 0fd44e9] backup 2026-05-03
[2026-05-03 12:56:27] Backups pushed to GitHub
[2026-05-03 12:56:27] Backup complete!

$ ls -la /tmp/backups/pm-bot-2026-05-03.db
-rw-r--r-- 1 nick nick 389120 May  3 12:56 /tmp/backups/pm-bot-2026-05-03.db
```

New commit `0fd44e9` on `imagineering-cc/imagineering-backups` (was at `672aced` from 2026-03-21).

## Defense-in-depth follow-up (not in this PR)
The `backup-recency-watch.sh` watcher only checks local `/tmp/backups/` freshness — it can't see "GitHub mirror is silent." Recommend a future watcher enhancement: probe `gh api repos/imagineering-cc/imagineering-backups/commits` and alert if the most recent commit is older than 25h. Captured as a TODO in the watcher fleet inventory.

## Test plan
- [x] Shellcheck clean
- [x] Live `pm-bot` end-to-end run on Sydney (artifact + GitHub push)
- [ ] Tomorrow's 4am cron run — first scheduled fire with the fix in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)