### PR TITLE
feat(matrix): add aiko-bridge (Matrix ⟷ aiko_chat)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ oci/
 
 # Generated .env files (created from secrets.yaml during deploy)
 **/.env
+matrix/aiko-bridge-data/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "matrix/aiko-bridge"]
+	path = matrix/aiko-bridge
+	url = git@github.com:nickmeinhold/aiko-bridge.git

--- a/matrix/docker-compose.yml
+++ b/matrix/docker-compose.yml
@@ -99,6 +99,52 @@ services:
     depends_on:
       - continuwuity
 
+  # --- aiko-bridge: Matrix <-> aiko_chat (Aiko Services / MQTT) -------------
+  # Source is the matrix/aiko-bridge submodule (github.com/nickmeinhold/aiko-bridge).
+  # Config + registration + db live server-side in ./aiko-bridge-data (gitignored),
+  # generated/registered once per the bridge README (like the other mautrix bridges).
+  aiko-mosquitto:
+    image: eclipse-mosquitto:2
+    restart: always
+    volumes:
+      - ./aiko-bridge/deploy/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - aiko_mosquitto_data:/mosquitto/data
+
+  aiko-registrar:
+    build: ./aiko-bridge
+    image: aiko-bridge:latest
+    restart: always
+    environment:
+      AIKO_MQTT_HOST: aiko-mosquitto
+      AIKO_NAMESPACE: aiko
+    command: ["aiko_registrar"]
+    depends_on:
+      - aiko-mosquitto
+
+  aiko-chat:
+    image: aiko-bridge:latest
+    restart: always
+    environment:
+      AIKO_MQTT_HOST: aiko-mosquitto
+      AIKO_NAMESPACE: aiko
+    command: ["python", "-m", "aiko_chat.chat", "run"]
+    depends_on:
+      - aiko-registrar
+
+  aiko-bridge:
+    image: aiko-bridge:latest
+    restart: always
+    environment:
+      AIKO_MQTT_HOST: aiko-mosquitto
+      AIKO_NAMESPACE: aiko
+    command: ["python", "-m", "aiko_bridge", "-c", "/data/config.yaml"]
+    volumes:
+      - ./aiko-bridge-data:/data
+    depends_on:
+      - aiko-chat
+      - aiko-registrar
+      - continuwuity
+
 volumes:
   continuwuity_data:
   continuwuity_backups:
@@ -108,3 +154,4 @@ volumes:
   whatsapp_data:
   relay_data:
   relay_hf_data:
+  aiko_mosquitto_data:


### PR DESCRIPTION
Adds **aiko-bridge** — a mautrix-style Matrix ⟷ aiko_chat puppeting bridge — to the `matrix` stack.

## What
- New submodule `matrix/aiko-bridge` → [nickmeinhold/aiko-bridge](https://github.com/nickmeinhold/aiko-bridge)
- Four compose services: `aiko-mosquitto`, `aiko-registrar`, `aiko-chat`, `aiko-bridge`
- Bridges `#aiko_general:imagineering.cc` ⟷ an aiko_chat channel over the Aiko Services MQTT bus (relay mode)

## Context
`aiko_chat` (Angie / `anjsimmo`) is a chat server on Aiko Services (Andy G / `geekscape`). Built for Imagineering. Relay mode because aiko_chat's wire format carries no per-sender identity yet — per-user ghosts are gated on an upstream PR (see the bridge repo's `docs/aiko_chat_wire_extension.md`).

## Deploy notes
- Config + registration + sqlite db live server-side in `./aiko-bridge-data` (gitignored), generated/registered once — same pattern as the other mautrix bridges (config-in-volume, not in git).
- Appservice already registered on continuwuity via the admin room (`!admin appservices register`, live, no restart).

## Status
**Already deployed and verified end-to-end** on imagineering.cc — Matrix→aiko, aiko→Matrix, and the echo guard all confirmed. This PR records the running state for reproducibility (`deploy-to.sh <ip> matrix`). The continuwuity service and existing bridges are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)