### PR TITLE
feat(matrix): retarget aiko-bridge to geekscape/aiko_chat

### DIFF
--- a/matrix/docker-compose.yml
+++ b/matrix/docker-compose.yml
@@ -127,7 +127,9 @@ services:
     environment:
       AIKO_MQTT_HOST: aiko-mosquitto
       AIKO_NAMESPACE: aiko
-    command: ["python", "-m", "aiko_chat.chat", "run"]
+    # geekscape/aiko_chat bootstraps its HyperSpace (channels/users) before
+    # `aiko_chat run`; chat_start.sh does that idempotently from its working dir.
+    command: ["bash", "-c", "cd /tmp && exec bash /opt/aiko_chat/src/aiko_chat/chat_start.sh"]
     depends_on:
       - aiko-registrar
 


### PR DESCRIPTION
Bumps the aiko-bridge submodule to the geekscape-protocol version (send_message with username, per-channel topics, per-user ghosts with relay fallback + deterministic echo suppression) and switches aiko-chat to geekscape's chat_start.sh (HyperSpace bootstrap). Verified locally end-to-end against the geekscape server. Per-user ghosts activate once geekscape/aiko_chat#4 lands and the Dockerfile pin is bumped; until then the server publishes bare payloads and the bridge runs in relay mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)