### PR TITLE
fix(reconcile): unbreak nightly downstream reconciler (exit 254 since ~May 9)

### DIFF
--- a/scripts/lib/telegram.sh
+++ b/scripts/lib/telegram.sh
@@ -74,4 +74,16 @@ send_telegram_alert() {
     echo "send_telegram_alert: curl failed (rc=$curl_rc): $curl_out" >&2
     return 0  # don't propagate — caller is in an alert path already
   fi
+  # curl exits 0 for an HTTP 4xx too (it got *a* response), so a Telegram API
+  # rejection — bot restricted/kicked, closed topic, bad thread id, HTML parse
+  # error — comes back as {"ok":false,...} with rc=0 and would otherwise pass
+  # silently. That is the exact silent-drop failure mode this alert path exists
+  # to avoid, so inspect the response body. (Plain glob, no jq dependency.)
+  case "$curl_out" in
+    *'"ok":true'*) : ;;  # delivered
+    *)
+      echo "send_telegram_alert: Telegram API rejected the message (rc=0): $curl_out" >&2
+      return 0  # still don't propagate — caller is already in an alert path
+      ;;
+  esac
 }

--- a/scripts/reconcile-downstream.sh
+++ b/scripts/reconcile-downstream.sh
@@ -133,6 +133,21 @@ workspace:
 EOF
     cd downstream-server
     dart pub get
+    # Generate Drift code before running. build_runner emits the *.g.dart
+    # files the reconciler imports via the Drift schema; they are gitignored,
+    # so a fresh one-shot container has none and `dart run` aborts with a
+    # compile-time error (exit 254) — the original nightly failure since
+    # ~May 9 (imagineering #276/#360).
+    #
+    # NOTE: deliberately NO --delete-conflicting-outputs here, unlike the prod
+    # Dockerfile build stage. That image builds on dart:stable; this reconciler
+    # pins dart:3.11.5, whose newer build_runner has *removed* that flag
+    # (deleting conflicts is now the default). On 3.11.5 the removed flag makes
+    # build_runner exit non-zero AFTER writing outputs, and the inner `set -e`
+    # then aborts before the reconcile ever runs — re-creating exit 254 with a
+    # different root cause. Plain `build_runner build` exits 0. If you ever bump
+    # DART_IMAGE back to a stream where the flag is supported, you may re-add it.
+    dart run build_runner build
     exec dart run bin/reconcile_b2.dart '"$RECONCILE_ARGS"'
   '
 status=$?


### PR DESCRIPTION
## What

The nightly `reconcile-downstream` cron on the OCI box has exited **254 every night for ~a month** (imagineering #276 / #360), leaving the only DB↔B2 consistency canary blind. This unbreaks it.

## Root cause — three stacked failures, each masking the next

1. **Missing codegen.** The one-shot container ran `dart pub get` → `dart run` with no `build_runner build` between. Drift's `*.g.dart` files are gitignored, so a fresh container had none → compile error → exit 254. Added the build_runner step (mirrors the prod Dockerfile build stage).
2. **Dead flag.** `--delete-conflicting-outputs` was *removed* in the build_runner shipped with the pinned `dart:3.11.5`. On that SDK the removed flag makes build_runner exit non-zero **after** writing outputs, and the inner `set -e` aborted before the reconcile ran → still 254. Dropped the flag (comment explains the version divergence from prod's `dart:stable`).
3. **Stale source tree** *(operational, not in this diff)* — the box's rsynced `source/` was frozen at a non-compiling mid-migration commit (May 2, two days before the `updateFields`→enum migration landed). Refreshed to `origin/main` out of band. Durable fix tracked in #349.

## Also

Hardened `send_telegram_alert`: `curl` exits 0 for an HTTP 4xx (it got a response), so a Telegram API rejection (`{"ok":false}` — e.g. a restricted bot) passed **silently** — the exact silent-drop this alert path exists to prevent. Now inspects the response body and logs API-level rejections to stderr.

## Verification

Manual run on the OCI box (`/opt/scripts/reconcile-downstream.sh`) now compiles, runs, and exits **1** with a real report:
```
=== Summary ===
  OK:                11
  Data issues:       5
  Transient probes:  0
```
Both files deployed to `/opt/scripts/` (SHAs match this branch).

## Follow-ups (separate)
- **Needs Nick:** the `gremlin_xdeca_bot` is `status: restricted` (`can_send_messages: false`) in "Electron Sprints" — alerts for reconcile **and** health-check/backup/release-watch are undeliverable until it's granted send rights.
- 5 data issues the reconciler surfaced need remediation (report-only run).
- #349: box source freshness (this fix's out-of-band source refresh will drift again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)