### PR TITLE
feat(cd-bus): deploy-bus relay (SSE fan-out of CI image.published events)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@
 
 creation_rules:
   # Match secret yaml files in service and provider directories
-  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|dns|claudius|lugh|youtube-rag|tech-world-bots|notify)/.*\.yaml$
+  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|dns|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus)/.*\.yaml$
     age: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks

--- a/cd-bus/.gitignore
+++ b/cd-bus/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.dev.vars
+.wrangler/

--- a/cd-bus/README.md
+++ b/cd-bus/README.md
@@ -1,0 +1,60 @@
+# cd-bus — Imagineering deploy-bus relay
+
+Fans out `image.published` events from CI to OCI-host subscribers over **SSE**,
+so a merge-to-main reaches the running container in ~seconds without the host
+opening an inbound port. This is the keystone (component 2) of the deploy-bus.
+
+> Full design + rationale: [The Imagineering Deploy Bus](https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q)
+
+**Deployed:** https://cd-bus.nick-meinhold.workers.dev (Cloudflare Worker + Durable Object)
+
+## Routes
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `GET` | `/health` | — | liveness |
+| `POST` | `/publish` | `Bearer $PUBLISH_TOKEN` | fan an event to subscribers of `event.service` |
+| `GET` | `/events/:service` | — | SSE stream; replays the last retained event on connect |
+
+One **Durable Object instance per service** (`idFromName(service)`) holds that
+service's open SSE connections and its last-published event. The retained event
+is replayed on every (re)connect — the handshake that lets the host's poll
+backstop and this push leg converge.
+
+## Event shape
+
+```json
+{ "event": "image.published", "service": "downstream-server",
+  "image": "ghcr.io/nickmeinhold/downstream-server", "sha": "sha-6a38cea",
+  "digest": "sha256:…", "git_sha": "…", "run_url": "…" }
+```
+`service` is required; `digest` is what a subscriber pulls (deterministic).
+
+## Develop / deploy
+
+```bash
+wrangler dev          # local — NOTE: SSE-over-DO does not stream under miniflare
+                      # local dev; validate streaming against a real deploy.
+wrangler deploy
+echo "<token>" | wrangler secret put PUBLISH_TOKEN   # publish auth (prod)
+BASE=https://cd-bus.nick-meinhold.workers.dev PUBLISH_TOKEN=<token> ./smoke-test.sh
+```
+
+## Implementation notes
+
+- **Don't `await` writes to the SSE TransformStream before returning the
+  Response.** Its readable side has `highWaterMark: 0`, so a pre-return
+  `await writer.write()` deadlocks (no reader attached yet → write never
+  resolves → the DO `fetch()` never returns → no headers). Writes are
+  fire-and-forget with `.catch()` reaping dead connections.
+- **Heartbeat** via DO alarm every 25s pings open clients and reaps the dead;
+  it reschedules only while subscribers remain, so an idle channel is free.
+- **Last-event retention** is persisted to DO storage, surviving eviction.
+
+## Hardening backlog (pilot → production)
+
+- `/events` is currently **public-read** — anyone can watch deploy events
+  (image names, shas, cadence; no secrets, but info-leaky). Add a subscribe
+  token or restrict before fleet rollout.
+- Move off `*.workers.dev` to `cd-bus.imagineering.cc` (Cloudflare custom
+  domain + DNS) once past pilot.

--- a/cd-bus/README.md
+++ b/cd-bus/README.md
@@ -13,13 +13,16 @@ opening an inbound port. This is the keystone (component 2) of the deploy-bus.
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
 | `GET` | `/health` | — | liveness |
-| `POST` | `/publish` | `Bearer $PUBLISH_TOKEN` | fan an event to subscribers of `event.service` |
-| `GET` | `/events/:service` | — | SSE stream; replays the last retained event on connect |
+| `POST` | `/publish` | `Bearer $PUBLISH_TOKEN` | fan an event to subscribers of `event.service`; returns `subscribers` (attempted fan-out count — delivery is fire-and-forget). Fails closed (500) if the secret is unbound; `service` must match the same grammar as `/events/:service`. |
+| `GET` | `/events/:service` | — | SSE stream; replays the last retained event on connect unless `Last-Event-ID` proves it was already seen |
 
 One **Durable Object instance per service** (`idFromName(service)`) holds that
 service's open SSE connections and its last-published event. The retained event
-is replayed on every (re)connect — the handshake that lets the host's poll
-backstop and this push leg converge.
+is replayed on (re)connect — unless the client sends a `Last-Event-ID` header
+proving it already saw it (standard SSE resumption). This is the handshake that
+lets the host's poll backstop and this push leg converge. Event ids are
+monotonic (not bare timestamps), so id-based dedupe on the subscriber side is
+safe even across same-millisecond publishes.
 
 ## Event shape
 

--- a/cd-bus/package.json
+++ b/cd-bus/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cd-bus",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Imagineering deploy-bus relay: fans CI image.published events to OCI hosts over SSE",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "smoke": "./smoke-test.sh"
+  }
+}

--- a/cd-bus/secrets.yaml
+++ b/cd-bus/secrets.yaml
@@ -1,0 +1,16 @@
+publish_token: ENC[AES256_GCM,data:VKli+O82NHypxYI2CP8+cm+mt1PFL4uuexK/qbY2/eWhes052blSWQuTmKDqjaYeDcS1aY0kBi2CYdjw0GFMUw==,iv:gFcQD7w9SiG8oGutg0OiWnJNsRDSg2mH3S1wOcN/1P0=,tag:p9r7KpIf5dFQBuAP7l2NMA==,type:str]
+sops:
+    age:
+        - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzQ1g5VTNHZ1cxdmtRUXdx
+            WHdCc2VEbUFZenZkOXF1UFVLQjg5WW5rZ2pVCjdjRERZQTJGRGtWMS9xQXp3MWVp
+            dWJ3M3NIQmZTZ1BZeXdkck5iNVRIK1kKLS0tIEw1aUZGWktLOWNQTWNhQWx0L3JB
+            c2VCQXJiNUdhL0ptTko1bG8xRWdlVlUKD5t5oIBe+ZSRy+Dk/xB+blsHfNDQTTyR
+            V3YEOVbPKkg3zb7gyem5Wz6cL30ol2SKPSQ1D8RtAUO8lK1OGrHvNQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-12T02:16:07Z"
+    mac: ENC[AES256_GCM,data:81kQWDyDF9GUx1RzgvQ6Nz2uW6WgwiGXXePWcs8xeOuRNlieddrhaXBRvlNE/o1TIoWEhcYJyGwluN+6c2U4UldgKB4R9zVGrd3Dq9RIPtIsLfT5KL64fM5IACoDNzkatLcqnpJq1NSmLmfYPBnXegwHZ+ToxYkQootRGLgpCdc=,iv:liH89/EWBNFjKCeo+OCN/+YwkoqRfwEdNnFahAL/MuU=,tag:I1MeOxkY8i8Tx25jMloJKw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/cd-bus/smoke-test.sh
+++ b/cd-bus/smoke-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Smoke test for the CD Bus relay. Run against a local `wrangler dev`
+# (default http://localhost:8787) or a deployed URL via BASE=...
+#
+#   Terminal A:  wrangler dev
+#   Terminal B:  ./smoke-test.sh
+#
+# Covers: health, auth rejection, live fan-out (subscribe-then-publish),
+# and replay-on-connect (publish-then-subscribe gets the retained event).
+set -uo pipefail
+
+BASE="${BASE:-http://localhost:8787}"
+TOKEN="${PUBLISH_TOKEN:-dev-local-token}"
+SVC="smoke-$$"
+pass=0; fail=0
+ok(){ echo "  ✓ $1"; pass=$((pass+1)); }
+no(){ echo "  ✗ $1"; fail=$((fail+1)); }
+
+echo "== CD Bus smoke test against $BASE (service=$SVC) =="
+
+# 1. health
+[ "$(curl -fsS "$BASE/health" | jq -r .ok)" = "true" ] && ok "health" || no "health"
+
+# 2. auth: publish without the token must be rejected
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/publish" \
+  -H 'content-type: application/json' -d "{\"service\":\"$SVC\"}")
+[ "$code" = "401" ] && ok "unauthorized publish rejected (401)" || no "auth: got $code, want 401"
+
+# 3. live fan-out: subscribe in the background, then publish, expect the event
+sse_out=$(mktemp)
+( curl -sN --max-time 4 "$BASE/events/$SVC" > "$sse_out" ) &
+sub_pid=$!
+sleep 1   # let the subscription establish
+curl -fsS -X POST "$BASE/publish" \
+  -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+  -d "{\"event\":\"image.published\",\"service\":\"$SVC\",\"digest\":\"sha256:live\"}" >/dev/null
+wait $sub_pid 2>/dev/null
+grep -q '"digest":"sha256:live"' "$sse_out" && ok "live fan-out delivered" || { no "live fan-out"; echo "    --- got: ---"; sed 's/^/    /' "$sse_out"; }
+
+# 4. replay-on-connect: a NEW subscriber gets the last retained event immediately
+replay_out=$(mktemp)
+curl -sN --max-time 3 "$BASE/events/$SVC" > "$replay_out" &
+wait $! 2>/dev/null
+grep -q '"digest":"sha256:live"' "$replay_out" && ok "replay-on-connect delivered retained event" || { no "replay-on-connect"; echo "    --- got: ---"; sed 's/^/    /' "$replay_out"; }
+
+rm -f "$sse_out" "$replay_out"
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/cd-bus/smoke-test.sh
+++ b/cd-bus/smoke-test.sh
@@ -26,6 +26,13 @@ code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/publish" \
   -H 'content-type: application/json' -d "{\"service\":\"$SVC\"}")
 [ "$code" = "401" ] && ok "unauthorized publish rejected (401)" || no "auth: got $code, want 401"
 
+# 2b. service grammar: a service name that can't be subscribed to must be
+# rejected at publish time (no events into unreachable channels).
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/publish" \
+  -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+  -d '{"service":"bad/name"}')
+[ "$code" = "400" ] && ok "malformed service name rejected (400)" || no "service grammar: got $code, want 400"
+
 # 3. live fan-out: subscribe in the background, then publish, expect the event
 sse_out=$(mktemp)
 ( curl -sN --max-time 4 "$BASE/events/$SVC" > "$sse_out" ) &

--- a/cd-bus/src/index.js
+++ b/cd-bus/src/index.js
@@ -27,14 +27,28 @@ export default {
     }
 
     if (request.method === "POST" && url.pathname === "/publish") {
+      // Fail CLOSED when the secret is unbound (misdeploy / forgotten
+      // `wrangler secret put`): without this guard the comparison below
+      // would accept the literal header "Bearer undefined".
+      if (typeof env.PUBLISH_TOKEN !== "string" || env.PUBLISH_TOKEN.length === 0) {
+        return json({ error: "relay misconfigured: PUBLISH_TOKEN is not bound" }, 500);
+      }
       if ((request.headers.get("authorization") || "") !== `Bearer ${env.PUBLISH_TOKEN}`) {
         return json({ error: "unauthorized" }, 401);
       }
       let event;
       try { event = await request.json(); }
       catch { return json({ error: "body is not valid JSON" }, 400); }
-      if (!event || typeof event.service !== "string" || event.service === "") {
-        return json({ error: "event.service (non-empty string) is required" }, 400);
+      // Same grammar as the /events route below — otherwise a publish to
+      // "my/cool/image" succeeds but is impossible to subscribe to, and the
+      // retained event replays a state no host will ever see.
+      if (!event || typeof event.service !== "string" || !SERVICE_RE.test(event.service)) {
+        return json({ error: "event.service must match [A-Za-z0-9._-]+" }, 400);
+      }
+      // digest, when present, is what subscribers deploy — reject junk at the
+      // boundary rather than persisting it for replay.
+      if ("digest" in event && typeof event.digest !== "string") {
+        return json({ error: "event.digest must be a string when present" }, 400);
       }
       // Route to the per-service Durable Object and return its result verbatim.
       const stub = env.BUS.get(env.BUS.idFromName(event.service));
@@ -42,10 +56,11 @@ export default {
     }
 
     // Service names: GHCR-image-name shaped (alnum, dot, underscore, hyphen).
-    const m = url.pathname.match(/^\/events\/([A-Za-z0-9._-]+)$/);
-    if (request.method === "GET" && m) {
+    const m = url.pathname.match(/^\/events\/(.+)$/);
+    if (request.method === "GET" && m && SERVICE_RE.test(m[1])) {
       const stub = env.BUS.get(env.BUS.idFromName(m[1]));
-      return stub.fetch("https://do/subscribe");
+      // Forward headers so the DO can honor Last-Event-ID on reconnect.
+      return stub.fetch(new Request("https://do/subscribe", { headers: request.headers }));
     }
 
     return json({ error: "not found" }, 404);
@@ -69,7 +84,12 @@ export class ServiceChannel {
       // Persist the last event so a subscriber connecting after a DO eviction
       // (or after host downtime) still receives the most recent state. This is
       // the replay handshake between the push (SSE) and pull (poll) legs.
-      const id = Date.now();
+      //
+      // The id is MONOTONIC, not just a timestamp: two publishes inside the
+      // same millisecond must not mint the same id, because subscribers dedupe
+      // replays by id — a collision would silently swallow the second event.
+      const prev = await this.state.storage.get("last");
+      const id = Math.max(Date.now(), (prev?.id ?? 0) + 1);
       await this.state.storage.put("last", { id, event });
       const frame = sseFrame(id, event);
       // Do NOT await the per-client writes: a TransformStream's readable side
@@ -79,7 +99,9 @@ export class ServiceChannel {
       for (const w of targets) {
         w.write(frame).catch(() => this.sessions.delete(w)); // dead connection, drop it
       }
-      return json({ ok: true, service: event.service, delivered: targets.length });
+      // `subscribers`, not `delivered`: writes are fire-and-forget, so this
+      // counts attempted fan-out targets — actual delivery is unobservable here.
+      return json({ ok: true, service: event.service, subscribers: targets.length });
     }
 
     if (url.pathname === "/subscribe") {
@@ -100,9 +122,13 @@ export class ServiceChannel {
       });
 
       // Replay the last retained event immediately, so a freshly (re)connected
-      // host converges to current state without waiting for the next publish.
+      // host converges to current state without waiting for the next publish —
+      // UNLESS the client proves it already saw it via Last-Event-ID (standard
+      // SSE resumption; the worker route forwards request headers through).
       const last = await this.state.storage.get("last");
-      writer.write(last ? sseFrame(last.id, last.event) : enc(": connected\n\n"))
+      const seenId = request.headers.get("last-event-id");
+      const replay = last && String(last.id) !== seenId;
+      writer.write(replay ? sseFrame(last.id, last.event) : enc(": connected\n\n"))
         .catch(() => this.sessions.delete(writer));
 
       // Heartbeat keeps the connection warm through proxies and lets us reap
@@ -129,7 +155,10 @@ export class ServiceChannel {
       w.write(frame).catch(() => this.sessions.delete(w)); // non-blocking; reap dead
     }
     // Reschedule only while someone is listening, so an idle channel costs
-    // nothing.
+    // nothing. Because reaping happens in async .catch() handlers, the size
+    // check can race one tick behind reality — worst case is a single extra
+    // "ghost" alarm 25s later that finds zero sessions and stops. Bounded,
+    // accepted.
     if (this.sessions.size > 0) {
       await this.state.storage.setAlarm(Date.now() + HEARTBEAT_MS);
     }
@@ -137,6 +166,10 @@ export class ServiceChannel {
 }
 
 const HEARTBEAT_MS = 25_000;
+// One grammar for service names on BOTH the publish and subscribe sides —
+// GHCR-image-name shaped. Asymmetry here would let events be published into
+// channels no subscriber can reach.
+const SERVICE_RE = /^[A-Za-z0-9._-]+$/;
 const encoder = new TextEncoder();
 const enc = (s) => encoder.encode(s);
 // SSE frame: `id:` enables Last-Event-ID resumption; `data:` carries the JSON.

--- a/cd-bus/src/index.js
+++ b/cd-bus/src/index.js
@@ -1,0 +1,148 @@
+// CD Bus relay
+// ============
+// Fans out `image.published` events from CI to OCI-host subscribers over SSE,
+// so a merge-to-main reaches the running container in ~seconds without the
+// host ever opening an inbound port. Design + rationale:
+// https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q
+//
+// Routes:
+//   POST /publish           Bearer PUBLISH_TOKEN. Body is the event JSON
+//                           (must include `service`). Fans out to that
+//                           service's subscribers; returns delivered count.
+//   GET  /events/:service   SSE stream. Replays the last retained event on
+//                           connect (the replay leg that complements the
+//                           host's poll backstop), then streams live events.
+//   GET  /health            Liveness.
+//
+// Secure by direction: this relay is the only internet-facing component. It
+// holds nothing but the verify-side of PUBLISH_TOKEN, can only emit deploy
+// events, and the host still only ever pulls named GHCR digests in response.
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/health") {
+      return json({ ok: true, service: "cd-bus" });
+    }
+
+    if (request.method === "POST" && url.pathname === "/publish") {
+      if ((request.headers.get("authorization") || "") !== `Bearer ${env.PUBLISH_TOKEN}`) {
+        return json({ error: "unauthorized" }, 401);
+      }
+      let event;
+      try { event = await request.json(); }
+      catch { return json({ error: "body is not valid JSON" }, 400); }
+      if (!event || typeof event.service !== "string" || event.service === "") {
+        return json({ error: "event.service (non-empty string) is required" }, 400);
+      }
+      // Route to the per-service Durable Object and return its result verbatim.
+      const stub = env.BUS.get(env.BUS.idFromName(event.service));
+      return stub.fetch("https://do/publish", { method: "POST", body: JSON.stringify(event) });
+    }
+
+    // Service names: GHCR-image-name shaped (alnum, dot, underscore, hyphen).
+    const m = url.pathname.match(/^\/events\/([A-Za-z0-9._-]+)$/);
+    if (request.method === "GET" && m) {
+      const stub = env.BUS.get(env.BUS.idFromName(m[1]));
+      return stub.fetch("https://do/subscribe");
+    }
+
+    return json({ error: "not found" }, 404);
+  },
+};
+
+// One instance per service (keyed by idFromName(service)). Durable Objects are
+// single-threaded per instance, so the in-memory session Set needs no locking.
+export class ServiceChannel {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.sessions = new Set(); // active SSE writers for this service
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/publish") {
+      const event = await request.json();
+      // Persist the last event so a subscriber connecting after a DO eviction
+      // (or after host downtime) still receives the most recent state. This is
+      // the replay handshake between the push (SSE) and pull (poll) legs.
+      const id = Date.now();
+      await this.state.storage.put("last", { id, event });
+      const frame = sseFrame(id, event);
+      // Do NOT await the per-client writes: a TransformStream's readable side
+      // has highWaterMark 0, so awaiting a write to a slow/backpressured client
+      // would stall the whole fan-out. Fire-and-forget; reap on failure.
+      const targets = [...this.sessions];
+      for (const w of targets) {
+        w.write(frame).catch(() => this.sessions.delete(w)); // dead connection, drop it
+      }
+      return json({ ok: true, service: event.service, delivered: targets.length });
+    }
+
+    if (url.pathname === "/subscribe") {
+      const { readable, writable } = new TransformStream();
+      const writer = writable.getWriter();
+      this.sessions.add(writer);
+
+      // Build the response FIRST and return it without awaiting any write. The
+      // TransformStream readable side has highWaterMark 0, so awaiting a write
+      // before a reader attaches would deadlock (the reader only attaches once
+      // this Response is handed back to the runtime). Fire writes async.
+      const response = new Response(readable, {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache, no-transform",
+          "x-accel-buffering": "no",
+        },
+      });
+
+      // Replay the last retained event immediately, so a freshly (re)connected
+      // host converges to current state without waiting for the next publish.
+      const last = await this.state.storage.get("last");
+      writer.write(last ? sseFrame(last.id, last.event) : enc(": connected\n\n"))
+        .catch(() => this.sessions.delete(writer));
+
+      // Heartbeat keeps the connection warm through proxies and lets us reap
+      // dead writers; a subscriber that cannot hold the stream becomes a
+      // failed systemd unit on the host, which is alertable (the observability
+      // win — a dead deployer is loud, not silent).
+      await this.armHeartbeat();
+
+      return response;
+    }
+
+    return json({ error: "not found" }, 404);
+  }
+
+  async armHeartbeat() {
+    if ((await this.state.storage.getAlarm()) === null) {
+      await this.state.storage.setAlarm(Date.now() + HEARTBEAT_MS);
+    }
+  }
+
+  async alarm() {
+    const frame = enc(`: ping ${Date.now()}\n\n`);
+    for (const w of [...this.sessions]) {
+      w.write(frame).catch(() => this.sessions.delete(w)); // non-blocking; reap dead
+    }
+    // Reschedule only while someone is listening, so an idle channel costs
+    // nothing.
+    if (this.sessions.size > 0) {
+      await this.state.storage.setAlarm(Date.now() + HEARTBEAT_MS);
+    }
+  }
+}
+
+const HEARTBEAT_MS = 25_000;
+const encoder = new TextEncoder();
+const enc = (s) => encoder.encode(s);
+// SSE frame: `id:` enables Last-Event-ID resumption; `data:` carries the JSON.
+const sseFrame = (id, event) => enc(`id: ${id}\ndata: ${JSON.stringify(event)}\n\n`);
+const json = (obj, status = 200) =>
+  new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });

--- a/cd-bus/wrangler.jsonc
+++ b/cd-bus/wrangler.jsonc
@@ -1,0 +1,24 @@
+{
+  // CD Bus relay — fans out image.published events from CI to OCI-host
+  // subscribers over SSE. See cd-bus/README.md and the design doc:
+  // https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q
+  "name": "cd-bus",
+  "main": "src/index.js",
+  "compatibility_date": "2025-05-01",
+  "observability": { "enabled": true },
+
+  // One Durable Object instance per service holds that service's open SSE
+  // connections and its last-published event (for replay on reconnect).
+  "durable_objects": {
+    "bindings": [
+      { "name": "BUS", "class_name": "ServiceChannel" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["ServiceChannel"] }
+  ]
+
+  // PUBLISH_TOKEN is a secret, set out-of-band:
+  //   wrangler secret put PUBLISH_TOKEN
+  // For local `wrangler dev`, it is read from .dev.vars (gitignored).
+}


### PR DESCRIPTION
## What

The **keystone** of the [Imagineering Deploy Bus](https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q): a Cloudflare Worker + Durable Object that fans CI `image.published` events to OCI-host subscribers over **SSE**. Net-new `cd-bus/` dir; touches nothing else.

- `POST /publish` (Bearer `PUBLISH_TOKEN`) → fan event to subscribers of `event.service`
- `GET /events/:service` → SSE stream; replays the last retained event on connect
- `GET /health`

One Durable Object per service holds open connections + the last event (persisted, replayed on reconnect — the push/poll convergence handshake).

## Why

Replaces silent-failure-prone per-service deploy hacks (dead Watchtower) with a reactive, **secure-by-direction** bus: the host stays strictly outbound (no inbound port, no Docker socket, no prod SSH key). Motivated by the 13-day silent CD outage (claude-tasks #168) and the month-blind reconciler (#276) — both failures of *observability*, which the bus designs in.

## Status

**Deployed + verified.** `https://cd-bus.nick-meinhold.workers.dev`; smoke test green against production workerd (health, auth-rejection, live fan-out, replay-on-connect). `PUBLISH_TOKEN` secret set out-of-band.

This is the first pilot slice. Remaining (separate PRs): CI emit step in build workflows, the per-service host subscriber units + generalized poll, journald→Telegram observability.

## Notes for review

- SSE-over-DO does **not** stream under miniflare local dev (subrequest buffering); validate against a real deploy. Documented in the README.
- Implementation gotcha captured: never `await` writes to the SSE TransformStream before returning the Response (readable HWM 0 → deadlock).
- **Hardening backlog**: `/events` is currently public-read (deploy metadata, no secrets); add a subscribe token + move to `cd-bus.imagineering.cc` before fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)