### PR TITLE
fix(reconcile): point Telegram alerts at Nick's DM (durable source-of-truth)

### DIFF
--- a/backups/secrets.yaml
+++ b/backups/secrets.yaml
@@ -1,7 +1,7 @@
 gcs_bucket: ENC[AES256_GCM,data:O/VR5E+2L3FlSRAKjdW6ePHXZgg=,iv:MWXKFOsz+ISnL3AlSbFSIohzlDUTtkncrfA7htZw+10=,tag:Gf9YwXR+h8/oU7KIqG7OZg==,type:str]
 gcs_project: ENC[AES256_GCM,data:QAGPwWnATbUSFPWj9Q==,iv:7f7zaUeg5aJFsP6atXrk8p49ac227Xmxx6s8tXzDXek=,tag:e7cl6gEnxZqIquhLYIiBSw==,type:str]
 telegram_bot_token: ""
-telegram_chat_id: ""
+telegram_chat_id: ENC[AES256_GCM,data:g1u/Xtu68LUNPg==,iv:AVKDjpjq12cBt0D6gyiy6ZzmNSbwcTMBjiQtzFEfbKI=,tag:IbnGEiavN75ZXVe6lve8Mg==,type:str]
 telegram_thread_id: ""
 sops:
     age:
@@ -14,7 +14,7 @@ sops:
             amFOYms1d2pkcExBWEVOS0htdTV6Um8Kol+t7uWZUkKtZXeeE4ah/hsvi7sK+q3X
             o/CiZ+LzqxDkxoltKhyp+vO/3LBKKHSxq5LAuIn+aiabd82Oy87LHQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-06T09:15:41Z"
-    mac: ENC[AES256_GCM,data:WTeVZJDu/NetIWGRV8CADuu7oYhKpQCu2hF5XwI9RuXCFhvC2hqo2mxrBT5sTIluFThOU+om2eTuHtV7k0/pQK28GfMG2UpSPMpwaHhNkFm18jjvz18b3yDVNgZbeKFC6DHPfn3WAWxZl+fthRB0cZhN52AQNd5ByZu6Fc8Jy+0=,iv:j5PQv9Z5bM5L2MRLHUhJBbBaUC2L2rxWRDLihjb+RhU=,tag:IoKWdHCWFLz/SmR0ctKW7Q==,type:str]
+    lastmodified: "2026-06-06T22:43:24Z"
+    mac: ENC[AES256_GCM,data:mEvjKo1Op3W7RgQ9ZIbpTxnDhtmoEuS4YNlbyPsQKjBakUDJuArDlgqSlY3SOwq4nq1lkaY9jLFpxM/ZvIXZMl3NZrcKZOwo/2GgXjCht9iXyAMj65SAJVjltDHKnnZ1V8mOd4JtkNbjl1mkHXMp16pQA+kVwWBiI/7UXGt7dgc=,iv:ci0LMbyqxxB6QCKVRJUM/Z0Hfh57M6fzeacFRe81D7s=,tag:+A/dpethMFAx10byPRjfPA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## What
`backups/secrets.yaml` had `telegram_chat_id: ""`. `deploy-to.sh` decrypts this to regenerate `/etc/downstream-secrets/telegram.env`, so every redeploy would write an **empty** chat_id — silently disabling all four alert channels that share that env file (reconcile, health-check, backup, release-watch). The working chat id was only ever hand-set on the box, so any redeploy reverted to silent failure (the exact failure class that hid the month-long reconciler outage).

## Change
One field in the SOPS-encrypted secrets: `telegram_chat_id` → Nick's personal Telegram DM (`2122439699`); `telegram_thread_id` stays empty (DMs have no topics). `gremlin_xdeca_bot` can already DM Nick (verified `ok:true` live). Value remains encrypted at rest.

## Why DM, not the group
The bot is `status:restricted` (`can_send_messages:false`) in the *Electron Sprints* supergroup. Per Nick's call, alerts go to his DM instead — no group-admin dependency.

## Effect
Makes the live box hand-patch durable: redeploys now generate the correct DM target. Closes the **monitoring half** of the reconciler fix (#276). Supersedes the stale 'grant gremlin rights in Electron Sprints' follow-up in the reconciler handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)