### PR TITLE
fix(contact): harden form relay against bot flood (origin + rate limit + daily cap)

### DIFF
--- a/imagineering-contact-us/server.py
+++ b/imagineering-contact-us/server.py
@@ -2,15 +2,28 @@
 
 Accepts POST with name/email/message, sends via SMTP, redirects back.
 Zero dependencies — stdlib only.
+
+Abuse controls (added after the 2026-06-08 form-flood incident, where a bot
+fired ~800 submissions and exhausted the shared Brevo SMTP quota):
+  * Origin/Referer allowlist  — rejects header-less direct-POST bots
+  * Per-IP sliding-window rate limit
+  * Global daily send cap      — circuit breaker protecting the Brevo quota
+  * Honeypot field (pre-existing)
+
+These run *upstream* of Brevo on purpose: Brevo can't distinguish this abuse
+from legitimate notifications (same trusted recipients, valid DKIM/SPF from our
+own domain), so the only place to stop it is here, before a send is issued.
 """
 
 import os
 import sys
+import time
 import smtplib
 import threading
+from collections import deque
 from email.message import EmailMessage
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlparse
 
 SMTP_HOST = os.environ["SMTP_HOST"]
 SMTP_PORT = int(os.environ.get("SMTP_PORT", "587"))
@@ -20,6 +33,84 @@ SMTP_FROM = os.environ.get("SMTP_FROM_EMAIL", "noreply@imagineering.cc")
 CONTACT_TO = os.environ.get("CONTACT_TO", "langer.robin@gmail.com")
 SITE_URL = os.environ.get("SITE_URL", "https://imagineering.cc")
 MAX_BODY = 10 * 1024  # 10 KB
+
+# --- Abuse controls (all tunable via env) ---
+# Per-IP: at most RATE_MAX successful-shaped submissions per RATE_WINDOW seconds.
+RATE_MAX = int(os.environ.get("RATE_MAX", "3"))
+RATE_WINDOW = int(os.environ.get("RATE_WINDOW", "3600"))  # 1 hour
+# Global: hard ceiling on sends per rolling 24h — protects the Brevo quota even
+# under a distributed (many-IP) flood.
+GLOBAL_DAILY_MAX = int(os.environ.get("GLOBAL_DAILY_MAX", "50"))
+# Require the request to originate from our own site. Set ENFORCE_ORIGIN=0 to
+# disable (e.g. for curl-based testing).
+ENFORCE_ORIGIN = os.environ.get("ENFORCE_ORIGIN", "1") == "1"
+# Allowed origins, comma-separated. Defaults to SITE_URL + its apex/www variants.
+_default_origins = ",".join(
+    {
+        SITE_URL,
+        SITE_URL.replace("https://www.", "https://"),
+        SITE_URL.replace("https://", "https://www."),
+    }
+)
+ALLOWED_ORIGINS = tuple(
+    o.strip().rstrip("/")
+    for o in os.environ.get("ALLOWED_ORIGINS", _default_origins).split(",")
+    if o.strip()
+)
+
+
+class RateLimiter:
+    """In-memory sliding-window limiter — per-IP and a global daily cap.
+
+    Stdlib-only and thread-safe. State is per-process (the relay is a single
+    container), so a restart resets the windows — acceptable for a nuisance
+    control whose job is to blunt bursts, not to be a distributed quota.
+    """
+
+    def __init__(self, per_ip_max, per_ip_window, global_max, global_window=86400):
+        self._per_ip_max = per_ip_max
+        self._per_ip_window = per_ip_window
+        self._global_max = global_max
+        self._global_window = global_window
+        self._ip_hits = {}              # ip -> deque[timestamps]
+        self._global_hits = deque()     # timestamps across all IPs
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _prune(dq, now, window):
+        while dq and now - dq[0] > window:
+            dq.popleft()
+
+    def check_and_record(self, ip, now=None):
+        """Return (allowed: bool, reason: str). Records the hit if allowed."""
+        now = now if now is not None else time.time()
+        with self._lock:
+            # Global cap first — cheapest guard against quota exhaustion.
+            self._prune(self._global_hits, now, self._global_window)
+            if len(self._global_hits) >= self._global_max:
+                return False, "global-daily-cap"
+
+            dq = self._ip_hits.get(ip)
+            if dq is None:
+                dq = deque()
+                self._ip_hits[ip] = dq
+            self._prune(dq, now, self._per_ip_window)
+            if len(dq) >= self._per_ip_max:
+                return False, "per-ip-rate"
+
+            dq.append(now)
+            self._global_hits.append(now)
+
+            # Opportunistic memory hygiene: drop IPs whose windows have aged out.
+            if len(self._ip_hits) > 10_000:
+                stale = [k for k, v in self._ip_hits.items() if not v]
+                for k in stale:
+                    del self._ip_hits[k]
+
+            return True, "ok"
+
+
+limiter = RateLimiter(RATE_MAX, RATE_WINDOW, GLOBAL_DAILY_MAX)
 
 
 def _send_email(msg, sender_email, sender_name):
@@ -35,18 +126,55 @@ def _send_email(msg, sender_email, sender_name):
 
 
 class ContactHandler(BaseHTTPRequestHandler):
+    def _client_ip(self):
+        """Real client IP. Behind Caddy, trust the first X-Forwarded-For hop."""
+        xff = self.headers.get("X-Forwarded-For", "")
+        if xff:
+            return xff.split(",")[0].strip()
+        return self.client_address[0]
+
+    def _origin_ok(self):
+        """True if the request demonstrably came from our own site.
+
+        Browsers send `Origin` on cross-/same-origin POSTs and `Referer` on
+        classic form submits; scripted direct-POST bots typically send neither.
+        Requiring one to match our allowlist blocks the header-less case for free.
+        """
+        if not ENFORCE_ORIGIN:
+            return True
+        origin = self.headers.get("Origin", "").rstrip("/")
+        if origin:
+            return origin in ALLOWED_ORIGINS
+        referer = self.headers.get("Referer", "")
+        if referer:
+            p = urlparse(referer)
+            base = f"{p.scheme}://{p.netloc}".rstrip("/")
+            return base in ALLOWED_ORIGINS
+        # Neither header present — not a real browser form submit.
+        return False
+
     def do_POST(self):
-        # Reject oversized bodies
+        ip = self._client_ip()
+
+        # Reject oversized bodies (drain so the socket closes cleanly).
         length = int(self.headers.get("Content-Length", 0))
         if length > MAX_BODY:
+            print(f"[contact] reject oversized body from {ip}", file=sys.stderr)
             self._respond(ok=False)
+            return
+
+        # Origin/Referer allowlist — kills naive direct-POST bots.
+        if not self._origin_ok():
+            print(f"[contact] reject bad-origin from {ip}", file=sys.stderr)
+            self._respond(ok=False, status=403)
             return
 
         body = self.rfile.read(length).decode("utf-8")
         fields = parse_qs(body, max_num_fields=10)
 
-        # Honeypot — if filled, a bot submitted it
+        # Honeypot — if filled, a bot submitted it. Pretend success, send nothing.
         if fields.get("_honey", [""])[0]:
+            print(f"[contact] honeypot tripped from {ip}", file=sys.stderr)
             self._respond(ok=True)
             return
 
@@ -56,6 +184,13 @@ class ContactHandler(BaseHTTPRequestHandler):
 
         if not all([name, email, message]):
             self._respond(ok=False)
+            return
+
+        # Rate limit — per-IP window + global daily cap — before we spend a send.
+        allowed, reason = limiter.check_and_record(ip)
+        if not allowed:
+            print(f"[contact] rate-limited ({reason}) from {ip}", file=sys.stderr)
+            self._respond(ok=False, status=429)
             return
 
         msg = EmailMessage()
@@ -83,15 +218,20 @@ class ContactHandler(BaseHTTPRequestHandler):
             self.send_response(405)
             self.end_headers()
 
-    def _respond(self, ok=True):
-        """JSON for fetch, redirect for plain form POST."""
+    def _respond(self, ok=True, status=None):
+        """JSON for fetch, redirect for plain form POST.
+
+        `status` overrides the HTTP code for the JSON path (e.g. 429/403) so
+        callers can see *why* they were refused; the browser-redirect path keeps
+        its 303 + ?error so a human just lands back on the page.
+        """
         if "application/json" in (self.headers.get("Accept", "")):
-            self.send_response(200)
+            self.send_response(status or 200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Access-Control-Allow-Origin", SITE_URL)
             self.end_headers()
-            status = "sent" if ok else "error"
-            self.wfile.write(f'{{"status":"{status}"}}'.encode())
+            payload = "sent" if ok else "error"
+            self.wfile.write(f'{{"status":"{payload}"}}'.encode())
         else:
             query = "?sent=1" if ok else "?error=1"
             self.send_response(303)
@@ -106,5 +246,10 @@ class ContactHandler(BaseHTTPRequestHandler):
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", "8000"))
     server = HTTPServer(("0.0.0.0", port), ContactHandler)
-    print(f"Contact form relay listening on :{port}", file=sys.stderr)
+    print(
+        f"Contact form relay listening on :{port} "
+        f"(rate {RATE_MAX}/{RATE_WINDOW}s per IP, "
+        f"global {GLOBAL_DAILY_MAX}/day, enforce_origin={ENFORCE_ORIGIN})",
+        file=sys.stderr,
+    )
     server.serve_forever()

--- a/imagineering-contact-us/server.py
+++ b/imagineering-contact-us/server.py
@@ -101,8 +101,13 @@ class RateLimiter:
             dq.append(now)
             self._global_hits.append(now)
 
-            # Opportunistic memory hygiene: drop IPs whose windows have aged out.
+            # Opportunistic memory hygiene: drop IPs whose windows have aged
+            # out. We must *prune each deque first* — a dormant IP's deque
+            # still holds its old timestamps, so `if not v` alone would never
+            # find it empty and the dict would grow unbounded (~global_max/day).
             if len(self._ip_hits) > 10_000:
+                for v in self._ip_hits.values():
+                    self._prune(v, now, self._per_ip_window)
                 stale = [k for k, v in self._ip_hits.items() if not v]
                 for k in stale:
                     del self._ip_hits[k]
@@ -127,10 +132,17 @@ def _send_email(msg, sender_email, sender_name):
 
 class ContactHandler(BaseHTTPRequestHandler):
     def _client_ip(self):
-        """Real client IP. Behind Caddy, trust the first X-Forwarded-For hop."""
+        """Real client IP for rate-limiting.
+
+        Caddy (our sole edge proxy, no `trusted_proxies` config) *appends* the
+        real peer IP to any client-supplied X-Forwarded-For. So the RIGHT-most
+        entry is the one Caddy stamped and the only one a client can't forge —
+        taking the left-most (`[0]`) would let a bot rotate a spoofed token to
+        evade the per-IP limit entirely.
+        """
         xff = self.headers.get("X-Forwarded-For", "")
         if xff:
-            return xff.split(",")[0].strip()
+            return xff.split(",")[-1].strip()
         return self.client_address[0]
 
     def _origin_ok(self):
@@ -169,8 +181,15 @@ class ContactHandler(BaseHTTPRequestHandler):
             self._respond(ok=False, status=403)
             return
 
-        body = self.rfile.read(length).decode("utf-8")
-        fields = parse_qs(body, max_num_fields=10)
+        # Malformed bodies (non-UTF-8, or >10 fields tripping parse_qs) get a
+        # clean 400 instead of an uncaught 500 in the logs.
+        try:
+            body = self.rfile.read(length).decode("utf-8")
+            fields = parse_qs(body, max_num_fields=10)
+        except (UnicodeDecodeError, ValueError):
+            print(f"[contact] reject malformed body from {ip}", file=sys.stderr)
+            self._respond(ok=False, status=400)
+            return
 
         # Honeypot — if filled, a bot submitted it. Pretend success, send nothing.
         if fields.get("_honey", [""])[0]:
@@ -249,7 +268,7 @@ if __name__ == "__main__":
     print(
         f"Contact form relay listening on :{port} "
         f"(rate {RATE_MAX}/{RATE_WINDOW}s per IP, "
-        f"global {GLOBAL_DAILY_MAX}/day, enforce_origin={ENFORCE_ORIGIN})",
+        f"global {GLOBAL_DAILY_MAX}/rolling-24h, enforce_origin={ENFORCE_ORIGIN})",
         file=sys.stderr,
     )
     server.serve_forever()


### PR DESCRIPTION
## What & why

A scanner bot flooded the public contact form (`POST /api/contact`) on **2026-06-08** with ~800 sequential submissions (`Spam1`…`Spam797`), each relayed as a Brevo SMTP send. Result: hundreds of emails to Nick + Robin, and the **shared Brevo quota exhausted** (12:29:33 "credit limit reached") — which silently broke transactional mail for Outline and Kan.bn too.

**Not a breach.** The relay is a zero-dependency SMTP forwarder with **no database**, so the `DROP TABLE` / SQLi payloads in the junk were inert text. The real problem: the endpoint was an open, unauthenticated send cannon, and **Brevo can't catch it** — the sends are valid DKIM/SPF mail from our own domain to our own trusted recipients, indistinguishable from legitimate notifications. The only place to stop it is upstream, at the relay.

The live container was stopped as an emergency brake during triage; this PR makes it safe to bring back.

## Changes (`imagineering-contact-us/server.py`, stdlib-only)

| Guard | Behaviour | Default |
|---|---|---|
| **Origin/Referer allowlist** | 403 before reading body if request didn't come from our site — kills header-less direct-POST bots (today's exact flood shape) | `imagineering.cc` + `www.` |
| **Per-IP rate limit** | sliding window, 429 on exceed | 3 / hour |
| **Global daily cap** | circuit breaker protecting the Brevo quota even under a distributed many-IP flood | 50 / day |
| Honeypot | retained | — |

All tunable via env: `RATE_MAX`, `RATE_WINDOW`, `GLOBAL_DAILY_MAX`, `ENFORCE_ORIGIN`, `ALLOWED_ORIGINS`. Rejections logged to stderr.

## Verification

- **Unit tests**: per-IP window slide, per-IP isolation across IPs, global daily cap, default origin allowlist.
- **8-path HTTP smoke test**: no-origin→403, bad-origin→403, valid→sent, 2nd valid→sent, 3rd over-limit→429, honeypot→silent-ok, referer-fallback→sent, health→200. Confirmed only legitimate requests attempt an SMTP send.

## Follow-up (not in this PR)

- Cloudflare Turnstile for defense-in-depth (touches `website/` frontend).
- Drain/verify Brevo backlog (sends queued after the credit cap may flush on renewal).
- Container-name drift: repo compose says `imagineering-contact-us`, prod runs `img-contact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)