### PR TITLE
fix(contact): pin container_name to img-contact for canonical-dir migration

### DIFF
--- a/imagineering-contact-us/docker-compose.yml
+++ b/imagineering-contact-us/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
   imagineering-contact-us:
     build: .
-    container_name: imagineering-contact-us
+    # Container keeps the img-* fleet convention (matches the CLAUDE.md service
+    # table and Caddy notes) even though the compose service / dir is the
+    # canonical imagineering-contact-us.
+    container_name: img-contact
     restart: unless-stopped
     environment:
       - SMTP_HOST=${SMTP_HOST}


### PR DESCRIPTION
## Why

Prod still runs the contact relay from the **pre-rename** `~/apps/contact/` (project `contact`, container `img-contact`) — a leftover from PRs #12-14 (April) that renamed `contact/` → `imagineering-contact-us/` in the repo but never ran the cutover deploy. `deploy-to.sh`'s `deploy_contact()` already targets `~/apps/imagineering-contact-us/`, so the repo is canonical; only prod is stranded.

## This PR (1 line + comment)

Pins the compose `container_name` to `img-contact` (it currently says `imagineering-contact-us`). Keeps the `img-*` fleet convention and the existing CLAUDE.md service-table name, so after migration: **dir = `imagineering-contact-us`** (canonical, what the deploy script uses), **container = `img-contact`** (convention + docs unchanged), **port 3014** (Caddy route unchanged).

## Operational cutover (post-merge, separate step)

1. `cd ~/apps/contact && docker compose down` (removes old container + network)
2. `./scripts/deploy-to.sh 149.118.69.221 imagineering-contact-us` (SOPS-decrypts secrets, rsyncs to `~/apps/imagineering-contact-us/`, builds, starts `img-contact` on 3014)
3. `rm -rf ~/apps/contact`
4. Verify: header-less POST to `imagineering.cc/api/contact` → 403 / no email (relay already hardened by #61)

Brief (~20s) form downtime during the cutover. Resolves the contact half of the shadow-stack cleanup (cf. #361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)