### PR TITLE
fix(contact): commit Turnstile secret to encrypted secrets.yaml

### DIFF
--- a/imagineering-contact-us/secrets.yaml
+++ b/imagineering-contact-us/secrets.yaml
@@ -4,6 +4,7 @@ smtp_username: ENC[AES256_GCM,data:Ze3Zt/HA24bMWl6HmrDdyrnmgAIGeIDZ,iv:X94eWFDOa
 smtp_password: ENC[AES256_GCM,data:wgURK0DIYgD05EGeey+8p8ol+TM/tTWmRTZaqP6iNkJ+CkE8rO82juaje27Tp74sv1TJLbXcJRDEN+OFd5awGHSMw8M1J+9gnK3UYx1AE7IQR9sH/vicwn4E,iv:ybxfIK6hqBhSc7jcJE/0++yKrbkoSgdq3GIuw8bpwCg=,tag:Dld97Vagfd2aPVmhcbNSfw==,type:str]
 smtp_from_email: ENC[AES256_GCM,data:9RMvZBEsblfG+kBTxxn6btPSNqbOKU4=,iv:gDdLLY+GyJ1Mp/pEE82xrFylC3Vue2jM1cgoi86ourA=,tag:bdyhr6j0ogqZ6fd+2ut2SA==,type:str]
 contact_to: ENC[AES256_GCM,data:wdpdRjiJQXk7JmUclJb2401QTVthsPhqKOOh9xJR8XPOGp46KQr0xlCK8a0ZPDM=,iv:EYTvkDF+NCvrLwliU1qbVLT1yj++ydQ6EDv6guQNAN8=,tag:i+JGrXHQag00EDQGFANlfA==,type:str]
+turnstile_secret: ENC[AES256_GCM,data:td/vWENrwjP3H17wZSQaH3sqisbZfVqKB/VykjZ1g/LK03g=,iv:kEZbd2648wXAoTIscAQi56PM9pq9VTUbIiLDKPBNrRE=,tag:Y3TUkA5liwrVAF6WMwYYfg==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -15,7 +16,7 @@ sops:
             Z0R1azdNT3Y4TkVld3ozR3NmTXpwcGMKedxDHacAyZlcJh0an/v4NtngWPbKMe0Q
             VFfArfPhcuHGDBCzWrRVxauVPYsKwzADYQ067wRn9KEc77+f4Ko27Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-29T21:15:18Z"
-    mac: ENC[AES256_GCM,data:gIVtAw/pqVeDBK3Dg3yeIt8yLiDro9Y97Jw2vCeAvhJ3wvGn6QlhZ6xCljYahbk09ltSRqm+nF4wFxRxAUT+BUAUZdyTI+Qt9Wx3UVswTltYWf5/eWaHL/TCG9wzyRTDaIcjTEwDFiBBSBcTjpVIRUsgtpnOFT0HAykDCVEskQE=,iv:25n/7o7CmMZ330spjfXB2dEANfeoEtOT3maprMtoqDg=,tag:ug1BsLNVo7aEUhc+69Qn3Q==,type:str]
+    lastmodified: "2026-06-08T23:35:31Z"
+    mac: ENC[AES256_GCM,data:rEmey58aMP126ZujCGBgvIHNLZCPVxUyWUhoIlnAJ8/+kVvcZHAfdy4KlJkIPD/GTk1aqWwqRyprW7KhqsD25hvZzaeBtZrqQ4nbWlriq302uMoR03r/IBf+0RM85Io5cZgCgTFVxGRaj/431+LsVfye8fKab5qxR6d9Gr0+1kw=,iv:m1yXgxCQmL0bUBQTKkouB0eGA6PpV0c8aQbFBAVA/Fk=,tag:HO89h526vmt6ccpyDZcZRA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Why

The `turnstile_secret` key was added to the SOPS-encrypted `imagineering-contact-us/secrets.yaml` on 2026-06-08 during the contact-form hardening (PR #63), but the encrypted file change was never committed — **prod had the secret, git didn't**.

Failure mode this closes: a fresh clone + `./scripts/deploy-to.sh ... contact` would regenerate `.env` with `TURNSTILE_SECRET=` (deploy_contact coalesces a missing key to empty string), silently redeploying with Turnstile verification **off** — reopening the 2026-06-08 bot-flood hole.

## What

One file: the re-encrypted `secrets.yaml` with the `turnstile_secret` key added (SOPS mac/lastmodified updated accordingly). No plaintext appears in the diff — values are AES256-GCM blobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)