### PR TITLE
feat(dreamfinder): wire TELEGRAM_MANAGEMENT_ROOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,7 +453,9 @@ across Kan.bn, Outline, Radicale, and Playwright. No slash commands — natural 
 | `OUTLINE_API_KEY` | Outline API key |
 | `RADICALE_BASE_URL` | Radicale CalDAV URL |
 | `BRIDGE_BOT_IDS` | Bridge appservice bot MXIDs excluded from DM member counting (portal-aware isDm) |
-| `WHATSAPP_MANAGEMENT_ROOM` | River's WhatsApp-bridge management room; enables the `start_private_chat` tool |
+| `WHATSAPP_MANAGEMENT_ROOM` | River's WhatsApp-bridge management room; adds `whatsapp` to `start_private_chat`'s platform enum |
+| `TELEGRAM_MANAGEMENT_ROOM` | River's Telegram-bridge management room; adds `telegram` to the enum |
+| `SIGNAL_MANAGEMENT_ROOM` / `DISCORD_MANAGEMENT_ROOM` | Same pattern; unset until those bridge logins exist |
 
 ## Setup
 

--- a/dreamfinder/docker-compose.yml
+++ b/dreamfinder/docker-compose.yml
@@ -36,8 +36,13 @@ services:
       # against the live bridge registrations (2026-06-11). Also keeps the
       # bot from treating bridge MANAGEMENT rooms (bot + bridge bot) as DMs.
       - BRIDGE_BOT_IDS=${BRIDGE_BOT_IDS:-@whatsappbot:imagineering.cc,@signalbot:imagineering.cc,@telegrambot:imagineering.cc,@discordbot:imagineering.cc}
-      # River's WhatsApp-bridge management room — enables start_private_chat.
+      # River's per-platform bridge management rooms — each one configured
+      # adds that platform to start_private_chat's enum (dreamfinder#103:
+      # config presence IS platform existence). Signal/Discord stay unset
+      # until their bridge logins exist (Signal: SIM re-registration;
+      # Discord: account creation — both Nick's hands).
       - WHATSAPP_MANAGEMENT_ROOM=${WHATSAPP_MANAGEMENT_ROOM:-!JUo0oTBHrPUJOq76WrqjAO3Ioc6rbT4cOujGUPxJPc4}
+      - TELEGRAM_MANAGEMENT_ROOM=${TELEGRAM_MANAGEMENT_ROOM:-!xJfXtfQlhHWzgxxTaxRVFcCp6BDjikWjysvB4xrxGyU}
       - CALENDAR_URL=${CALENDAR_URL:-}
       - EVENT_TIMEZONE=${EVENT_TIMEZONE:-}
       - DEPLOY_ANNOUNCE_GROUP_ID=${DEPLOY_ANNOUNCE_GROUP_ID:-}


### PR DESCRIPTION
Companion to [dreamfinder#103](https://github.com/imagineering-cc/dreamfinder/pull/103) (merged): `start_private_chat` is now platform-parameterized — config presence IS platform existence.

- `TELEGRAM_MANAGEMENT_ROOM` default = `!xJfXtfQlhHWzgxxTaxRVFcCp6BDjikWjysvB4xrxGyU` (pre-staged as River, TG loop verified live 2026-06-12; uid 8927028624)
- CLAUDE.md config table updated; Signal/Discord rows documented as unset-until-login (Nick's-hands gates)

Deploy plan: `./scripts/deploy-to.sh 149.118.69.221 pm-bot` after merge (pulls latest dreamfinder main = #103), then live-verify the Telegram loop via River.

🤖 Generated with [Claude Code](https://claude.com/claude-code)