### PR TITLE
feat(galaxy): host Mautrix Galaxy at galaxy.imagineering.cc

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -57,6 +57,13 @@ imagineering.cc {
     }
 }
 
+# --- Mautrix Galaxy (standalone three.js teaching world, shareable) ---
+
+galaxy.imagineering.cc {
+    root * /srv/galaxy
+    file_server
+}
+
 # --- Invite page (QR slide for meetups + shareable join URL) ---
 
 invite.imagineering.cc {

--- a/caddy/docker-compose.yml
+++ b/caddy/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - caddy_config:/config
       - /home/nick/apps/site:/srv/site:ro
       - /home/nick/apps/invite:/srv/invite:ro
+      - /home/nick/apps/galaxy:/srv/galaxy:ro
       - /srv/tech-world:/srv/tech-world:ro
 
 volumes:

--- a/galaxy/index.html
+++ b/galaxy/index.html
@@ -1,0 +1,891 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mautrix Galaxy — the Continuwuity Observatory</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #06070d; overflow: hidden; font-family: "Avenir Next", "Segoe UI", system-ui, sans-serif; }
+  canvas { display: block; }
+
+  #hud { position: fixed; inset: 0; pointer-events: none; color: #e8ecf5; }
+  #room-label {
+    position: absolute; top: 16px; left: 18px;
+    font-size: 0.95rem; font-weight: 600; color: #e8b84b;
+    text-shadow: 0 2px 8px rgba(0,0,0,0.8);
+  }
+  #room-sub { position: absolute; top: 38px; left: 18px; font-size: 0.72rem; color: #aab2c8; text-shadow: 0 2px 8px rgba(0,0,0,0.8); }
+  #storm-counter {
+    display: none;
+    position: absolute; top: 16px; right: 18px;
+    font-size: 0.9rem; font-weight: 700; color: #f25f5c;
+    text-shadow: 0 2px 8px rgba(0,0,0,0.9);
+  }
+  #crosshair {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    width: 6px; height: 6px; border-radius: 50%;
+    background: rgba(232, 184, 75, 0.9);
+    box-shadow: 0 0 8px rgba(0,0,0,0.6);
+  }
+  #prompt {
+    position: absolute; bottom: 88px; left: 50%; transform: translateX(-50%);
+    font-size: 0.88rem; color: #ffe89c; text-shadow: 0 2px 8px rgba(0,0,0,0.9);
+    background: rgba(8, 9, 16, 0.65); padding: 7px 16px; border-radius: 999px;
+    border: 1px solid rgba(232, 184, 75, 0.5);
+    display: none;
+  }
+  #lore {
+    position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%);
+    max-width: 680px; width: 90vw;
+    font-size: 0.85rem; line-height: 1.55;
+    background: rgba(8, 9, 16, 0.84); padding: 12px 18px; border-radius: 12px;
+    border-left: 3px solid #e8b84b;
+    opacity: 0; transition: opacity 0.4s;
+  }
+  #lore b { color: #e8b84b; } #lore code { color: #9fe8c8; background: #0b0d12; padding: 0 5px; border-radius: 4px; }
+
+  #intro {
+    position: fixed; inset: 0; z-index: 10;
+    background: rgba(6, 7, 13, 0.93);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    color: #d8dce8; text-align: center; gap: 16px; cursor: pointer;
+  }
+  #intro h1 { color: #e8b84b; letter-spacing: 0.05em; font-size: 1.7rem; }
+  #intro .sub { font-style: italic; color: #8b91a5; }
+  #intro .controls { font-size: 0.85rem; line-height: 2; }
+  #intro .controls b { color: #0dbd8b; }
+  #intro .start { margin-top: 10px; color: #e8b84b; border: 1px solid #e8b84b; border-radius: 999px; padding: 10px 28px; }
+</style>
+</head>
+<body>
+
+<div id="intro">
+  <h1>🌌 MAUTRIX GALAXY</h1>
+  <div class="sub">The Continuwuity Observatory — where the superbridge orbits</div>
+  <div class="controls">
+    <b>WASD</b> walk (all the way around a world) &nbsp;·&nbsp; <b>mouse</b> look &nbsp;·&nbsp; <b>space</b> jump &nbsp;·&nbsp; <b>E</b> interact<br>
+    Worlds are rooms. Pipes are plumbing. Wormholes are megabridge portals.<br>
+    The ghosts you'll see are <code style="color:#9fe8c8">@_relay_*</code> puppets, carrying mail through subspace.
+  </div>
+  <div class="start">Click to drift in</div>
+</div>
+
+<div id="hud">
+  <div id="room-label"></div>
+  <div id="room-sub"></div>
+  <div id="storm-counter">⚠ echoes: <span id="echo-n">0</span></div>
+  <div id="crosshair"></div>
+  <div id="prompt"></div>
+  <div id="lore"></div>
+</div>
+
+<script type="importmap">
+{ "imports": { "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js" } }
+</script>
+<script type="module">
+import * as THREE from "three";
+
+/* ============================================================
+   MAUTRIX GALAXY — a spherical-gravity teaching cosmos
+   (Mario Galaxy energy: planetoids, launch stars, wormholes).
+
+   The metaphor map (architecture → game):
+     homeserver        → the galaxy / observatory itself
+     Matrix rooms      → planetoids; membership = which world you stand on
+                          (you cannot WALK to another room — you are
+                           launched, piped, or admitted)
+     plumbing          → green pipes arcing between worlds YOU own,
+                          with launch stars to ride alongside your mail
+     megabridge portal → WORMHOLES — the only way into bridge-owned
+                          worlds; no pipe, no launch star, their terms
+     messages          → envelopes, colour-tagged by platform
+     relay puppets     → ghosts that dive INTO a planet and surface on
+                          the hub (appservices travel subspace, beneath
+                          the rooms)
+     loop prevention   → three ward-stones that end the Echo Storm
+   ============================================================ */
+
+const v = (x, y, z) => new THREE.Vector3(x, y, z);
+
+// ---------- palette ----------
+const C = {
+  gold: 0xe8b84b, matrix: 0x0dbd8b, discord: 0x5865f2, telegram: 0x29a9eb,
+  whatsapp: 0x25d366, signal: 0x3a76f0, pipe: 0x1a9c4b, ghost: 0xe8ecf5,
+  cursed: 0xf25f5c, rock: 0x2e3344, rock2: 0x394056,
+};
+
+// ---------- renderer / scene ----------
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x06070d);
+const camera = new THREE.PerspectiveCamera(74, innerWidth / innerHeight, 0.1, 600);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(innerWidth, innerHeight);
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+document.body.appendChild(renderer.domElement);
+addEventListener("resize", () => {
+  camera.aspect = innerWidth / innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth, innerHeight);
+});
+
+scene.add(new THREE.HemisphereLight(0xcfd8ff, 0x10121c, 0.55));
+const sun = new THREE.DirectionalLight(0xfff2d0, 1.4);
+sun.position.set(60, 90, 40);
+scene.add(sun);
+function lamp(pos, color = 0xffe0a0, intensity = 30, dist = 30) {
+  const l = new THREE.PointLight(color, intensity, dist, 1.8);
+  l.position.copy(pos);
+  scene.add(l);
+}
+
+// ---------- starfield + a distant federation galaxy ----------
+{
+  const N = 2200, pts = new Float32Array(N * 3);
+  for (let i = 0; i < N; i++) {
+    const d = 180 + Math.random() * 240;
+    const th = Math.random() * Math.PI * 2, ph = Math.acos(2 * Math.random() - 1);
+    pts[i * 3] = d * Math.sin(ph) * Math.cos(th);
+    pts[i * 3 + 1] = d * Math.cos(ph);
+    pts[i * 3 + 2] = d * Math.sin(ph) * Math.sin(th);
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(pts, 3));
+  scene.add(new THREE.Points(g, new THREE.PointsMaterial({ color: 0xbfc8e8, size: 0.7, sizeAttenuation: false })));
+}
+{ // spiral galaxy far off — federation lives out there
+  const N = 900, pts = new Float32Array(N * 3);
+  for (let i = 0; i < N; i++) {
+    const arm = (i % 3) * (Math.PI * 2 / 3);
+    const t = (i / N) * 5;
+    const r = 2 + t * 7 + Math.random() * 2.5;
+    const a = arm + t * 1.7 + Math.random() * 0.25;
+    pts[i * 3] = -150 + Math.cos(a) * r;
+    pts[i * 3 + 1] = 85 + (Math.random() - 0.5) * 3;
+    pts[i * 3 + 2] = -200 + Math.sin(a) * r;
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(pts, 3));
+  scene.add(new THREE.Points(g, new THREE.PointsMaterial({ color: 0xb9a5f5, size: 1.1, sizeAttenuation: false, transparent: true, opacity: 0.8 })));
+}
+
+// ---------- nebula skybox ----------
+// A painted sky: vertical depth gradient + soft nebula blooms in the
+// palette of the five platforms. Backside sphere, drawn before everything.
+{
+  const cv = document.createElement("canvas");
+  cv.width = 1024; cv.height = 512;
+  const g = cv.getContext("2d");
+  const grad = g.createLinearGradient(0, 0, 0, 512);
+  grad.addColorStop(0, "#0c0e20");
+  grad.addColorStop(0.45, "#0a0c16");
+  grad.addColorStop(0.78, "#120a20");
+  grad.addColorStop(1, "#06070d");
+  g.fillStyle = grad; g.fillRect(0, 0, 1024, 512);
+  const blobs = [
+    [180, 150, 200, "rgba(106, 79, 196, 0.18)"],   // violet — the deep field
+    [330, 340, 160, "rgba(13, 189, 139, 0.10)"],   // matrix green
+    [700, 120, 230, "rgba(58, 118, 240, 0.14)"],   // signal blue
+    [870, 360, 180, "rgba(232, 184, 75, 0.08)"],   // gold dust
+    [520, 250, 280, "rgba(140, 90, 200, 0.09)"],   // wide violet wash
+    [80, 420, 150, "rgba(37, 211, 102, 0.06)"],    // whatsapp green, faint
+  ];
+  for (const [x, y, r, c] of blobs) {
+    const rg = g.createRadialGradient(x, y, 0, x, y, r);
+    rg.addColorStop(0, c); rg.addColorStop(1, "rgba(0,0,0,0)");
+    g.fillStyle = rg;
+    g.fillRect(x - r, y - r, r * 2, r * 2);
+  }
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  const sky = new THREE.Mesh(new THREE.SphereGeometry(460, 32, 20),
+    new THREE.MeshBasicMaterial({ map: tex, side: THREE.BackSide, depthWrite: false }));
+  sky.renderOrder = -1;
+  scene.add(sky);
+}
+
+// ---------- particle trails ----------
+// Soft additive puffs left behind by envelopes (their stripe colour) and
+// ghosts (pale wisps). Shrink + fade, then disposed.
+const trailParticles = [];
+const softDot = (() => {
+  const cv = document.createElement("canvas");
+  cv.width = cv.height = 64;
+  const g = cv.getContext("2d");
+  const rg = g.createRadialGradient(32, 32, 0, 32, 32, 32);
+  rg.addColorStop(0, "rgba(255,255,255,1)");
+  rg.addColorStop(0.4, "rgba(255,255,255,0.5)");
+  rg.addColorStop(1, "rgba(255,255,255,0)");
+  g.fillStyle = rg; g.fillRect(0, 0, 64, 64);
+  return new THREE.CanvasTexture(cv);
+})();
+function puff(pos, color, scale = 0.45, life = 0.65) {
+  const m = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: softDot, color, transparent: true, opacity: 0.85,
+    blending: THREE.AdditiveBlending, depthWrite: false,
+  }));
+  m.position.copy(pos);
+  m.scale.setScalar(scale);
+  scene.add(m);
+  trailParticles.push({ m, life, maxLife: life });
+}
+
+// ---------- planetoids (rooms) ----------
+// base/accent = high/low terrain tones · glow = atmosphere rim · flora = decoration set
+const PLANETS = {
+  admin:    { c: v(0, 3, 36),     r: 5,   base: 0x8d96b4, accent: 0x5a6280, glow: 0xe8b84b, flora: "stone",  seed: 11, name: "Admin Planetoid", sub: "#admins · the registrar's desk" },
+  hub:      { c: v(0, 0, 0),      r: 11,  base: 0x47b06f, accent: 0x7a5b3a, glow: 0x9fd8ff, flora: "meadow", seed: 23, name: "The Hub World", sub: "#superbridge — one world, five galaxies" },
+  discord:  { c: v(-44, 10, -12), r: 7,   base: 0x6a74e8, accent: 0x3c4290, glow: 0x8b97ff, flora: "crystal", seed: 37, name: "Discord Planetoid", sub: "plumbed · standalone Go bridge" },
+  telegram: { c: v(44, -8, -12),  r: 7,   base: 0x4fb6e0, accent: 0x27607e, glow: 0x6fd2f2, flora: "crystal", seed: 41, name: "Telegram Planetoid", sub: "plumbed · bridgev2 — mind the receiver" },
+  whatsapp: { c: v(-38, 34, -86), r: 6.5, base: 0x3fae5f, accent: 0x1d6638, glow: 0x7fe8a8, flora: "jungle", seed: 53, name: "WhatsApp Portal World", sub: "bridge-owned · wormhole-only · doorless" },
+  signal:   { c: v(38, -30, -86), r: 6.5, base: 0x6f93e8, accent: 0x32477e, glow: 0x9ab8ff, flora: "ice",    seed: 67, name: "Signal Portal World", sub: "bridge-owned · wormhole-only · doorless" },
+};
+const mat = c => new THREE.MeshLambertMaterial({ color: c });
+
+// --- deterministic terrain noise -------------------------------------
+// Layered trig noise: a pure function of surface DIRECTION, so the mesh,
+// the props, and the player's feet all agree on where the ground is.
+function mulberry32(seed) {
+  return () => {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+for (const p of Object.values(PLANETS)) {
+  const rng = mulberry32(p.seed);
+  const waves = [];
+  for (let k = 0; k < 5; k++) {
+    const u = v(rng() * 2 - 1, rng() * 2 - 1, rng() * 2 - 1).normalize();
+    waves.push({ u, f: 2 + rng() * 4.5, ph: rng() * Math.PI * 2, w: 1 / (k * 0.6 + 1) });
+  }
+  const wsum = waves.reduce((s, w) => s + w.w, 0);
+  p.noise = dir => waves.reduce((s, w) => s + Math.sin(dir.dot(w.u) * w.f * Math.PI + w.ph) * w.w, 0) / wsum;
+  p.amp = p.r * 0.085;
+  p.rng = rng;
+}
+/** Ground radius (from planet centre) under a given surface direction. */
+const terrain = (p, dir) => p.r + p.amp * p.noise(dir.clone().normalize());
+const surfacePoint = (p, dir, h = 0) =>
+  p.c.clone().addScaledVector(dir.clone().normalize(), terrain(p, dir) + h);
+
+// --- build each world: lumpy flat-shaded mesh + atmosphere + flora ----
+const _tmpDir = new THREE.Vector3();
+for (const p of Object.values(PLANETS)) {
+  const geo = new THREE.IcosahedronGeometry(p.r, 5);
+  const pos = geo.attributes.position;
+  const colors = new Float32Array(pos.count * 3);
+  const cBase = new THREE.Color(p.base), cAcc = new THREE.Color(p.accent), cTmp = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    _tmpDir.fromBufferAttribute(pos, i).normalize();
+    const n = p.noise(_tmpDir);                       // [-1, 1]
+    _tmpDir.multiplyScalar(p.r + p.amp * n);
+    pos.setXYZ(i, _tmpDir.x, _tmpDir.y, _tmpDir.z);
+    // low ground → accent (dirt/depths), high ground → base (grass/peaks)
+    const t = Math.min(1, Math.max(0, n * 0.5 + 0.5));
+    cTmp.lerpColors(cAcc, cBase, t * t * (3 - 2 * t));
+    colors.set([cTmp.r, cTmp.g, cTmp.b], i * 3);
+  }
+  geo.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  geo.computeVertexNormals();
+  const m = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({
+    vertexColors: true, flatShading: true, roughness: 0.95, metalness: 0.0,
+  }));
+  m.position.copy(p.c);
+  scene.add(m);
+
+  // atmosphere: a soft additive rim, Mario Galaxy's halo
+  const halo = new THREE.Mesh(new THREE.SphereGeometry(p.r * 1.16, 28, 18),
+    new THREE.MeshBasicMaterial({ color: p.glow, transparent: true, opacity: 0.13,
+      side: THREE.BackSide, blending: THREE.AdditiveBlending, depthWrite: false }));
+  halo.position.copy(p.c);
+  scene.add(halo);
+}
+
+// --- flora & props, scattered deterministically per world -------------
+function prop(p, dir, mesh, lift = 0) {
+  const n = dir.clone().normalize();
+  mesh.position.copy(surfacePoint(p, n, lift));
+  mesh.quaternion.setFromUnitVectors(v(0, 1, 0), n);
+  // random spin around local up so rows of props don't all face one way
+  mesh.rotateY(p.rng() * Math.PI * 2);
+  scene.add(mesh);
+  return mesh;
+}
+const FLORA = {
+  meadow(p, dir) {
+    const pick = p.rng();
+    if (pick < 0.45) {  // beacon tower — the hub relays for five galaxies
+      const g = new THREE.Group();
+      g.add(new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.16, 1.6, 6), mat(0x8b91a5)));
+      const tip = new THREE.Mesh(new THREE.SphereGeometry(0.16, 8, 8),
+        new THREE.MeshLambertMaterial({ color: 0xffe89c, emissive: 0xe8b84b, emissiveIntensity: 0.8 }));
+      tip.position.y = 0.9; g.add(tip);
+      return prop(p, dir, g, 0.7);
+    }
+    const tuft = new THREE.Mesh(new THREE.ConeGeometry(0.22, 0.55, 5),
+      new THREE.MeshLambertMaterial({ color: pick < 0.75 ? 0x5fd488 : 0xe8b84b }));
+    return prop(p, dir, tuft, 0.25);
+  },
+  jungle(p, dir) {
+    const g = new THREE.Group();
+    g.add(new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.18, 0.9, 6), mat(0x5a4026)));
+    const layers = 2 + Math.floor(p.rng() * 2);
+    for (let i = 0; i < layers; i++) {
+      const leaf = new THREE.Mesh(new THREE.ConeGeometry(0.75 - i * 0.2, 0.7, 7), mat(0x2fae5f));
+      leaf.position.y = 0.65 + i * 0.45;
+      g.add(leaf);
+    }
+    return prop(p, dir, g, 0.45);
+  },
+  ice(p, dir) {
+    const h = 0.6 + p.rng() * 1.3;
+    const shard = new THREE.Mesh(new THREE.ConeGeometry(0.18 + p.rng() * 0.16, h, 5),
+      new THREE.MeshLambertMaterial({ color: 0x9ab8ff, emissive: 0x3a76f0, emissiveIntensity: 0.35,
+        transparent: true, opacity: 0.9 }));
+    shard.rotation.x = (p.rng() - 0.5) * 0.5;
+    return prop(p, dir, shard, h * 0.4);
+  },
+  crystal(p, dir) {
+    const h = 0.5 + p.rng() * 1.1;
+    const c = p === PLANETS.discord ? 0x8b97ff : 0x6fd2f2;
+    const shard = new THREE.Mesh(new THREE.OctahedronGeometry(0.28 + p.rng() * 0.2),
+      new THREE.MeshLambertMaterial({ color: c, emissive: c, emissiveIntensity: 0.45 }));
+    shard.scale.y = 1.6 + p.rng();
+    return prop(p, dir, shard, h * 0.35);
+  },
+  stone(p, dir) {
+    const rock = new THREE.Mesh(new THREE.DodecahedronGeometry(0.25 + p.rng() * 0.45), mat(C.rock2));
+    return prop(p, dir, rock, 0.1);
+  },
+};
+for (const p of Object.values(PLANETS)) {
+  const count = Math.round(p.r * 3.4);
+  for (let i = 0; i < count; i++) {
+    const dir = v(p.rng() * 2 - 1, p.rng() * 2 - 1, p.rng() * 2 - 1);
+    if (dir.lengthSq() < 0.05) continue;
+    dir.normalize();
+    if (dir.dot(v(0, 1, 0)) > 0.86) continue;   // keep the polar landmark areas clear
+    FLORA[p.flora](p, dir);
+    // every world also gets a few plain rocks for grit
+    if (i % 5 === 0) FLORA.stone(p, v(p.rng() * 2 - 1, p.rng() * 2 - 1, p.rng() * 2 - 1).normalize());
+  }
+}
+
+/** Stand `obj` on a planet surface: position at dir, +Y aligned to the normal. */
+function placeOnPlanet(obj, p, dir, h = 0) {
+  const n = dir.clone().normalize();
+  obj.position.copy(surfacePoint(p, n, h));
+  obj.quaternion.setFromUnitVectors(v(0, 1, 0), n);
+  scene.add(obj);
+  return obj;
+}
+function boxOnPlanet(w, hgt, d, color, p, dir, lift = 0) {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(w, hgt, d), mat(color));
+  // seat 0.2 into the ground so edges don't float on sloped terrain
+  return placeOnPlanet(m, p, dir, hgt / 2 + lift - 0.2);
+}
+
+// ---------- signage (billboards — always face the player) ----------
+const billboards = [];
+function sign(p, dir, h, lines, fg = "#e8b84b", bg = "#161927") {
+  const cv = document.createElement("canvas");
+  cv.width = 512; cv.height = 256;
+  const g = cv.getContext("2d");
+  g.fillStyle = bg; g.fillRect(0, 0, 512, 256);
+  g.strokeStyle = fg; g.lineWidth = 8; g.strokeRect(8, 8, 496, 240);
+  g.fillStyle = fg; g.textAlign = "center";
+  lines.forEach((ln, n) => {
+    g.font = n === 0 ? "bold 42px Avenir Next, sans-serif" : "26px Avenir Next, sans-serif";
+    g.fillText(ln, 256, 92 + n * 52);
+  });
+  const m = new THREE.Mesh(new THREE.PlaneGeometry(3.4, 1.7),
+    new THREE.MeshBasicMaterial({ map: new THREE.CanvasTexture(cv), transparent: false }));
+  m.position.copy(surfacePoint(p, dir, h));
+  scene.add(m);
+  billboards.push(m);
+  return m;
+}
+
+// ---------- furniture ----------
+// Admin planetoid: the registrar's desk (player spawns facing it)
+boxOnPlanet(2.4, 0.9, 1.1, 0x4a3b22, PLANETS.admin, v(0, 0.35, -1));
+sign(PLANETS.admin, v(0, 0.8, -1), 3.2, ["CONTINUWUITY OBSERVATORY", "#admins desk", "server name is permanent"]);
+
+// Hub world: the mail table at its north pole, where everything lands
+const HUB_UP = v(0, 1, 0);
+boxOnPlanet(6, 0.85, 2, 0x4a3b22, PLANETS.hub, HUB_UP);
+sign(PLANETS.hub, v(0.45, 1, 0.28), 3.4, ["THE HUB WORLD", "#superbridge", "one world, five galaxies"]);
+const hubTableTop = () => surfacePoint(PLANETS.hub, v((Math.random() - 0.5) * 0.18, 1, (Math.random() - 0.5) * 0.12), 1.15);
+
+sign(PLANETS.discord, v(0, 1, 0), 3, ["DISCORD PLANETOID", "plumbed: !discord bridge 9001"], "#8b97ff");
+sign(PLANETS.telegram, v(0, 1, 0), 3, ["TELEGRAM PLANETOID", "!tg bridge <bot_tgid> <chat_id>"], "#6fcaf2");
+sign(PLANETS.whatsapp, v(0, 1, 0.4), 3, ["WHATSAPP PORTAL WORLD", "the megabridge owns this world"], "#7fe8a8", "#10241a");
+sign(PLANETS.signal, v(0, 1, 0.4), 3, ["SIGNAL PORTAL WORLD", "the megabridge owns this world"], "#9ab8ff", "#131c30");
+
+// Portal-world mail tables (where local envelopes appear for ghosts)
+boxOnPlanet(2.4, 0.85, 1.3, 0x4a3b22, PLANETS.whatsapp, v(0.3, 1, -0.2));
+boxOnPlanet(2.4, 0.85, 1.3, 0x4a3b22, PLANETS.signal, v(0.3, 1, -0.2));
+
+lamp(surfacePoint(PLANETS.hub, HUB_UP, 5));
+lamp(surfacePoint(PLANETS.admin, v(0, 1, 0), 4), 0xffe0a0, 16, 18);
+lamp(surfacePoint(PLANETS.whatsapp, v(0, 1, 0), 4), 0x7fe8a8, 16, 18);
+lamp(surfacePoint(PLANETS.signal, v(0, 1, 0), 4), 0x9ab8ff, 16, 18);
+
+// ---------- plumbing: pipes arcing through space (hub ↔ discord/telegram) ----------
+function pipeBetween(pa, da, pb, db, bulge = 10) {
+  const a = surfacePoint(pa, da, 0.2), b = surfacePoint(pb, db, 0.2);
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const out = mid.clone().sub(pa.c.clone().add(pb.c).multiplyScalar(0.5)).normalize();
+  mid.addScaledVector(out, bulge);
+  const curve = new THREE.QuadraticBezierCurve3(a, mid, b);
+  const tube = new THREE.Mesh(new THREE.TubeGeometry(curve, 40, 0.32, 10),
+    new THREE.MeshLambertMaterial({ color: C.pipe, emissive: C.pipe, emissiveIntensity: 0.12, transparent: true, opacity: 0.92 }));
+  scene.add(tube);
+  // pipe mouths
+  for (const [p, d] of [[pa, da], [pb, db]]) {
+    const rim = new THREE.Mesh(new THREE.TorusGeometry(0.5, 0.14, 10, 20), mat(C.pipe));
+    placeOnPlanet(rim, p, d, 0.4);
+    rim.rotateX(Math.PI / 2);
+  }
+  return curve;
+}
+const dirHubToDiscord = PLANETS.discord.c.clone().sub(PLANETS.hub.c).normalize();
+const dirHubToTelegram = PLANETS.telegram.c.clone().sub(PLANETS.hub.c).normalize();
+const DISCORD_PIPE = pipeBetween(PLANETS.hub, dirHubToDiscord, PLANETS.discord, dirHubToDiscord.clone().negate(), 9);
+const TELEGRAM_PIPE = pipeBetween(PLANETS.hub, dirHubToTelegram, PLANETS.telegram, dirHubToTelegram.clone().negate(), 9);
+
+// set-relay lever beside the Discord pipe mouth on the hub
+const leverDir = dirHubToDiscord.clone().add(v(0, 0.45, 0)).normalize();
+boxOnPlanet(0.5, 1.0, 0.5, 0x4a3b22, PLANETS.hub, leverDir);
+const leverStick = boxOnPlanet(0.12, 0.9, 0.12, 0xaab2c8, PLANETS.hub, leverDir, 0.8);
+leverStick.rotateZ(0.6);
+let relayOn = false;
+
+// ---------- launch stars (ride alongside your plumbed mail) ----------
+const launchMeshes = [];
+function launchStar(p, dir, target, targetDir, label) {
+  const star = new THREE.Mesh(new THREE.OctahedronGeometry(0.55),
+    new THREE.MeshLambertMaterial({ color: C.gold, emissive: C.gold, emissiveIntensity: 0.7 }));
+  placeOnPlanet(star, p, dir, 1.3);
+  launchMeshes.push(star);
+  interactables.push({
+    posFn: () => surfacePoint(p, dir, 1.3), r: 2.6, label,
+    act: () => beginFlight(p, dir, target, targetDir),
+  });
+}
+
+// ---------- wormholes (megabridge portals — their terms, no pipes) ----------
+const wormholes = [];
+function wormhole(pos, color, label, act) {
+  const grp = new THREE.Group();
+  const ring1 = new THREE.Mesh(new THREE.TorusGeometry(1.6, 0.12, 12, 40),
+    new THREE.MeshLambertMaterial({ color, emissive: color, emissiveIntensity: 0.9 }));
+  const ring2 = ring1.clone(); ring2.scale.setScalar(0.72);
+  const disc = new THREE.Mesh(new THREE.CircleGeometry(1.45, 36),
+    new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.22, side: THREE.DoubleSide }));
+  grp.add(ring1, ring2, disc);
+  grp.position.copy(pos);
+  scene.add(grp);
+  wormholes.push(grp);
+  billboards.push(grp);   // swirl always faces you
+  interactables.push({ posFn: () => pos, r: 2.8, label, act });
+  return grp;
+}
+
+// ---------- envelopes ----------
+const envelopes = [];
+function makeEnvelope(color) {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.BoxGeometry(0.46, 0.1, 0.3), mat(0xf2f4fa));
+  const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.48, 0.045, 0.32),
+    new THREE.MeshLambertMaterial({ color, emissive: color, emissiveIntensity: 0.45 }));
+  stripe.position.y = 0.06;
+  g.add(body, stripe);
+  scene.add(g);
+  return g;
+}
+function postEnvelope(color, path, speed = 7) {
+  envelopes.push({ m: makeEnvelope(color), color, path, t: 0, seg: 0, speed, emit: 0 });
+}
+/** Mail rides a pipe INTO the hub: follow the curve wing→hub, then hop to the table.
+    (Pipe curves are built hub→wing, so we walk them reversed.) */
+function pipeDelivery(curve, color) {
+  const pts = curve.getPoints(36).reverse();
+  pts.push(hubTableTop());
+  postEnvelope(color, pts);
+}
+
+// ---------- ghosts (@_relay_* puppets, via subspace) ----------
+const ghosts = [];
+function makeGhost() {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(new THREE.SphereGeometry(0.42, 18, 14),
+    new THREE.MeshLambertMaterial({ color: C.ghost, transparent: true, opacity: 0.5, emissive: 0x8890b0, emissiveIntensity: 0.3 }));
+  body.scale.y = 1.25; g.add(body);
+  [[-0.14, 0.12, 0.36], [0.14, 0.12, 0.36]].forEach(p => {
+    const e = new THREE.Mesh(new THREE.SphereGeometry(0.06, 8, 8), new THREE.MeshBasicMaterial({ color: 0x1a1d28 }));
+    e.position.set(...p); g.add(e);
+  });
+  scene.add(g);
+  return g;
+}
+/** Rise on the portal world, collect an envelope, dive INTO the planet
+    (subspace!), surface on the hub, deliver, depart. */
+function ghostFerry(fromPlanet, color, hubDir) {
+  const tableDir = v(0.3, 1, -0.2).normalize();
+  const from = surfacePoint(fromPlanet, tableDir, 1.2);
+  const inside = surfacePoint(fromPlanet, tableDir, -2.5);
+  const hubInside = surfacePoint(PLANETS.hub, hubDir, -2.5);
+  const hubOut = surfacePoint(PLANETS.hub, hubDir, 1.2);
+  const g = makeGhost();
+  const env = makeEnvelope(color); env.visible = false;
+  ghosts.push({ g, env, color, phase: 0, t: 0,
+    path: [inside, from, from.clone(), inside.clone(), hubInside, hubOut, hubTableTop(), hubInside.clone()] });
+}
+const GHOST_DIR_WA = v(-0.7, 0.7, 0.2).normalize();
+const GHOST_DIR_SG = v(0.7, 0.7, 0.2).normalize();
+
+// ---------- traffic ----------
+setInterval(() => pipeDelivery(DISCORD_PIPE, relayOn ? C.discord : 0x8b91a5), 4600);
+setInterval(() => pipeDelivery(TELEGRAM_PIPE, C.telegram), 6200);
+setInterval(() => postEnvelope(relayOn ? C.matrix : 0x8b91a5, [hubTableTop(), ...DISCORD_PIPE.getPoints(36)]), 7900);
+setInterval(() => ghostFerry(PLANETS.whatsapp, C.whatsapp, GHOST_DIR_WA), 7200);
+setInterval(() => ghostFerry(PLANETS.signal, C.signal, GHOST_DIR_SG), 9800);
+
+// ---------- echo storm ----------
+let storm = false;
+const echoes = [];
+let lastDup = 0;
+const cursed = boxOnPlanet(0.5, 0.12, 0.34, C.cursed, PLANETS.hub, v(0.22, 1, 0.1), 1.0);
+cursed.material.emissive = new THREE.Color(C.cursed);
+const WARD_DEFS = [
+  { dir: v(-0.45, 1, 0.15), label: "Ward I — ignore @_relay_* puppets" },
+  { dir: v(0.45, 1, 0.15),  label: "Ward II — ignore bridge bots & ghosts" },
+  { dir: v(0, 1, -0.5),     label: "Ward III — ignore “Name:” attributed mail" },
+];
+const wards = WARD_DEFS.map(d => {
+  const m = boxOnPlanet(0.6, 1.6, 0.6, 0x6a4fc4, PLANETS.hub, d.dir.clone().normalize());
+  m.material.emissive = new THREE.Color(0x6a4fc4);
+  m.material.emissiveIntensity = 0;
+  m.visible = false;
+  return { ...d, mesh: m, lit: false };
+});
+function startStorm() {
+  if (storm) return;
+  storm = true;
+  cursed.visible = false;
+  document.getElementById("storm-counter").style.display = "block";
+  wards.forEach(w => { w.mesh.visible = true; w.lit = false; w.mesh.material.emissiveIntensity = 0; });
+  spawnEcho(surfacePoint(PLANETS.hub, HUB_UP, 2));
+  lore("⚠ <b>THE ECHO STORM.</b> The relay heard its own voice across the void and answered it. Every echo spawns an echo. " +
+       "Three ward-stones have risen around the mail table — light <b>all three layers of loop prevention</b> to end it.");
+}
+function spawnEcho(pos) {
+  const m = makeEnvelope(C.cursed);
+  m.position.copy(pos);
+  echoes.push({ m, vel: v((Math.random() - 0.5) * 6, (Math.random() - 0.5) * 6, (Math.random() - 0.5) * 6) });
+}
+function endStorm() {
+  storm = false;
+  echoes.forEach(e => scene.remove(e.m));
+  echoes.length = 0;
+  document.getElementById("storm-counter").style.display = "none";
+  setTimeout(() => wards.forEach(w => w.mesh.visible = false), 4000);
+  lore("🕯 <b>The storm dies.</b> Three layers, one law: a bridge must know its own voice — its puppets, its peers, " +
+       "and mail already spoken once — and refuse to repeat it. In the real relay this is <code>loop_prevention.py</code>: " +
+       "pure functions, three checks, and the silence stays the good kind.");
+}
+
+// ---------- lore HUD ----------
+const lore = (html, ms = 10000) => {
+  const L = document.getElementById("lore");
+  L.innerHTML = html;
+  L.style.opacity = 1;
+  clearTimeout(lore._t);
+  lore._t = setTimeout(() => L.style.opacity = 0, ms);
+};
+
+// ---------- interactables ----------
+const interactables = [];
+interactables.push(
+  { posFn: () => surfacePoint(PLANETS.admin, v(0, 0.35, -1), 1), r: 2.6, label: "read the registrar's desk", act: () =>
+      lore("🌌 <b>This observatory is the homeserver</b> — Continuwuity, one Rust process, RocksDB humming in the core. " +
+           "Every planetoid you can see is a Matrix room, and <b>standing on one is membership</b>. At this desk you'd speak " +
+           "<code>!admin appservices register</code> — the observatory licenses new ghosts in chat. No restart. No re-launch.") },
+  { posFn: () => surfacePoint(PLANETS.hub, HUB_UP, 1.2), r: 3, label: "inspect the mail table", when: () => !storm || true, act: () =>
+      lore("📬 <b>The Hub World.</b> All mail in the galaxy lands on this table. Pipes carry Discord and Telegram envelopes " +
+           "(<b>plumbing</b> — connections YOU laid, between worlds you own); ghosts surface with WhatsApp and Signal mail " +
+           "(<b>the relay appservice</b> — because wormhole-worlds accept no pipes). One world, five galaxies.") },
+  { posFn: () => surfacePoint(PLANETS.hub, dirHubToDiscord, 1), r: 2.6, label: "read the Discord pipe mouth", act: () =>
+      lore("🟢 <b>A pipe is plumbing.</b> <code>!discord bridge 9001</code> laid this line between a world you own and a channel " +
+           "out in Discord space. The elder Go bridge still speaks pipe; the megabridge generation refuses — that's why two of " +
+           "these worlds have no pipes at all.") },
+  { posFn: () => surfacePoint(PLANETS.telegram, v(0, 1, 0), 1), r: 3, label: "read the Telegram plaque", act: () =>
+      lore("🟦 <b>Telegram's pipe survived the bridgev2 rewrite</b> — with a new law: every pipe has a <b>receiver</b>, the login " +
+           "it was laid through, and only the receiver may relay. Lay it bot-first — <code>!tg bridge &lt;bot_tgid&gt; &lt;chat_id&gt;</code> — " +
+           "or the pipe is yours personally, forever, and <code>set-relay</code> will refuse you.") },
+  { posFn: () => surfacePoint(PLANETS.hub, leverDir, 1), r: 2.2, label: "pull the set-relay lever", act: () => {
+      relayOn = !relayOn;
+      leverStick.rotation.z += relayOn ? -1.2 : 1.2;
+      lore(relayOn
+        ? "✨ <b>set-relay ON.</b> Watch the Discord pipe: envelopes now arrive wearing their sender's colours — webhook relay gives every Matrix voice a Discord face."
+        : "🤖 <b>set-relay OFF.</b> Grey envelopes again: everything arrives as <i>matrix-bridge-bot reading mail aloud</i>."); } },
+  { posFn: () => cursed.position, r: 1.8, label: "touch the cursed envelope", when: () => !storm && cursed.visible, act: startStorm },
+);
+wards.forEach(w => interactables.push({
+  posFn: () => w.mesh.position, r: 2, label: `light ${w.label}`,
+  when: () => storm && !w.lit,
+  act: () => {
+    w.lit = true;
+    w.mesh.material.emissiveIntensity = 0.9;
+    const left = wards.filter(x => !x.lit).length;
+    if (!left) endStorm();
+    else lore(`🛡 <b>${w.label}</b> lit. ${left} ward${left > 1 ? "s" : ""} remain.`);
+  },
+}));
+
+// Launch stars: admin ↔ hub, hub ↔ discord, hub ↔ telegram (plumbed worlds only!)
+launchStar(PLANETS.admin, v(0, 0.6, 1), PLANETS.hub, v(0, 0.7, 1), "launch to the Hub World");
+launchStar(PLANETS.hub, v(0, 0.7, 1), PLANETS.admin, v(0, 0.6, 1), "launch to the Admin Planetoid");
+launchStar(PLANETS.hub, dirHubToDiscord.clone().add(v(0, -0.5, 0)).normalize(), PLANETS.discord, dirHubToDiscord.clone().negate(), "ride the plumbing to Discord");
+launchStar(PLANETS.discord, dirHubToDiscord.clone().negate().add(v(0, 0.5, 0)).normalize(), PLANETS.hub, dirHubToDiscord, "ride the plumbing back to the Hub");
+launchStar(PLANETS.hub, dirHubToTelegram.clone().add(v(0, -0.5, 0)).normalize(), PLANETS.telegram, dirHubToTelegram.clone().negate(), "ride the plumbing to Telegram");
+launchStar(PLANETS.telegram, dirHubToTelegram.clone().negate().add(v(0, 0.5, 0)).normalize(), PLANETS.hub, dirHubToTelegram, "ride the plumbing back to the Hub");
+
+// Wormholes: the ONLY route to portal worlds. Floating off the hub, on the bridge's terms.
+wormhole(surfacePoint(PLANETS.hub, v(-0.8, 0.5, -0.6).normalize(), 4.5), C.whatsapp, "enter the WhatsApp wormhole", () => {
+  arriveAt(PLANETS.whatsapp, v(0, 1, 1).normalize());
+  lore("🕳 <b>You are inside a portal world.</b> The megabridge spun this planet itself and OWNS it — name, terrain, guest list, " +
+       "all state-synced from the WhatsApp group. Notice: <b>no pipes, no launch stars</b>. You arrived by wormhole, on the " +
+       "bridge's terms. That is why the hub needed ghosts.");
+});
+wormhole(surfacePoint(PLANETS.hub, v(0.8, 0.5, -0.6).normalize(), 4.5), C.signal, "enter the Signal wormhole", () => {
+  arriveAt(PLANETS.signal, v(0, 1, 1).normalize());
+  lore("🕳 <b>The Signal portal world.</b> Same megabridge, same law: portal-only, bridge-owned, pipeless. Watch the mail table — " +
+       "when an envelope appears, a ghost will rise, collect it, and dive <i>into the planet</i>. Appservices travel subspace, " +
+       "beneath the rooms.");
+});
+wormhole(surfacePoint(PLANETS.whatsapp, v(0, 0.4, -1).normalize(), 4), C.whatsapp, "wormhole back to the Hub World", () => arriveAt(PLANETS.hub, HUB_UP));
+wormhole(surfacePoint(PLANETS.signal, v(0, 0.4, -1).normalize(), 4), C.signal, "wormhole back to the Hub World", () => arriveAt(PLANETS.hub, HUB_UP));
+
+// ---------- player: spherical gravity ----------
+const player = {
+  planet: PLANETS.admin,
+  pos: surfacePoint(PLANETS.admin, v(0, 0.2, 1), 1.7),
+  forward: v(0, 0, -1),
+  pitch: 0, vy: 0, grounded: true,
+  flight: null,   // {curve, t, dur, to, toDir}
+};
+function arriveAt(planet, dir) {
+  player.planet = planet;
+  player.pos = surfacePoint(planet, dir, 1.7);
+  player.vy = 0;
+  player.flight = null;
+}
+function beginFlight(fromPlanet, fromDir, toPlanet, toDir) {
+  const a = player.pos.clone();
+  const b = surfacePoint(toPlanet, toDir, 1.7);
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const lift = mid.clone().sub(fromPlanet.c.clone().add(toPlanet.c).multiplyScalar(0.5)).normalize();
+  mid.addScaledVector(lift, 16);
+  player.flight = { curve: new THREE.QuadraticBezierCurve3(a, mid, b), t: 0, dur: 2.4, to: toPlanet, toDir };
+}
+
+const keys = {};
+addEventListener("keydown", e => {
+  keys[e.code] = true;
+  if (e.code === "KeyE") tryInteract();
+  if (e.code === "Space" && player.grounded && !player.flight) { player.vy = 5.4; player.grounded = false; }
+});
+addEventListener("keyup", e => keys[e.code] = false);
+
+const intro = document.getElementById("intro");
+intro.addEventListener("click", () => renderer.domElement.requestPointerLock());
+document.addEventListener("pointerlockchange", () => {
+  intro.style.display = document.pointerLockElement ? "none" : "flex";
+});
+let mouseDX = 0, mouseDY = 0;
+addEventListener("mousemove", e => {
+  if (!document.pointerLockElement) return;
+  mouseDX += e.movementX; mouseDY += e.movementY;
+});
+
+function updatePlayer(dt) {
+  if (player.flight) {   // riding a launch star
+    const f = player.flight;
+    f.t = Math.min(1, f.t + dt / f.dur);
+    player.pos.copy(f.curve.getPoint(f.t));
+    const gravC = f.t < 0.5 ? player.planet.c : f.to.c;
+    const up = player.pos.clone().sub(gravC).normalize();
+    const tan = f.curve.getTangent(f.t);
+    camera.up.lerp(up, 0.12).normalize();
+    camera.position.copy(player.pos);
+    camera.lookAt(player.pos.clone().add(tan));
+    if (f.t >= 1) {
+      const land = f.to;
+      player.planet = land;
+      const n = player.pos.clone().sub(land.c).normalize();
+      player.forward = tan.clone().addScaledVector(n, -tan.dot(n)).normalize();
+      player.vy = 0; player.flight = null;
+    }
+    return;
+  }
+
+  const P = player.planet;
+  let up = player.pos.clone().sub(P.c).normalize();
+
+  // mouse look: yaw spins `forward` around the local up; pitch is separate
+  if (mouseDX || mouseDY) {
+    player.forward.applyAxisAngle(up, -mouseDX * 0.0022);
+    player.pitch = Math.max(-1.35, Math.min(1.35, player.pitch - mouseDY * 0.0022));
+    mouseDX = mouseDY = 0;
+  }
+  // keep forward tangent to the sphere as we wander around it
+  player.forward.addScaledVector(up, -player.forward.dot(up)).normalize();
+  const right = player.forward.clone().cross(up); // forward×up = right (looking along forward)
+  const dir = v(0, 0, 0);
+  if (keys.KeyW) dir.add(player.forward);
+  if (keys.KeyS) dir.sub(player.forward);
+  if (keys.KeyD) dir.add(right);
+  if (keys.KeyA) dir.sub(right);
+  if (dir.lengthSq()) player.pos.addScaledVector(dir.normalize(), 5.6 * dt);
+
+  // radial gravity: fall toward the planet's heart, land on the rolling terrain
+  player.vy -= 13 * dt;
+  let h = player.pos.distanceTo(P.c) + player.vy * dt;
+  up = player.pos.clone().sub(P.c).normalize();
+  const minH = terrain(P, up) + 1.7;   // ground height under our feet, not the nominal radius
+  if (h <= minH) { h = minH; player.vy = 0; player.grounded = true; }
+  player.pos.copy(P.c).addScaledVector(up, h);
+
+  camera.position.copy(player.pos);
+  camera.up.copy(up);
+  camera.lookAt(player.pos.clone()
+    .addScaledVector(player.forward, Math.cos(player.pitch))
+    .addScaledVector(up, Math.sin(player.pitch)));
+}
+
+function nearestInteractable() {
+  for (const it of interactables) {
+    if (it.when && !it.when()) continue;
+    if (player.pos.distanceToSquared(it.posFn()) < it.r * it.r) return it;
+  }
+  return null;
+}
+function tryInteract() { nearestInteractable()?.act(); }
+
+// ---------- main loop ----------
+const promptEl = document.getElementById("prompt");
+const clock = new THREE.Clock();
+function tick() {
+  requestAnimationFrame(tick);
+  const dt = Math.min(clock.getDelta(), 0.05);
+
+  if (document.pointerLockElement || player.flight) updatePlayer(dt);
+  else { camera.position.copy(player.pos); }
+
+  // envelopes along waypoint paths
+  for (let n = envelopes.length - 1; n >= 0; n--) {
+    const e = envelopes[n];
+    const a = e.path[e.seg], b = e.path[e.seg + 1];
+    if (!b) { scene.remove(e.m); envelopes.splice(n, 1); continue; }
+    const L = a.distanceTo(b) || 0.001;
+    e.t += (e.speed * dt) / L;
+    if (e.t >= 1) { e.t = 0; e.seg++; } else e.m.position.lerpVectors(a, b, e.t);
+    e.m.rotation.y += dt * 2;
+    // comet trail in the envelope's platform colour
+    e.emit = (e.emit || 0) + dt;
+    if (e.emit > 0.06) { e.emit = 0; puff(e.m.position, e.color || 0xffffff); }
+  }
+
+  // ghosts through subspace
+  for (let n = ghosts.length - 1; n >= 0; n--) {
+    const gh = ghosts[n];
+    const a = gh.path[gh.phase], b = gh.path[gh.phase + 1];
+    if (!b) { scene.remove(gh.g); scene.remove(gh.env); ghosts.splice(n, 1); continue; }
+    const L = a.distanceTo(b) || 0.001;
+    gh.t += (3.2 * dt) / L;
+    if (gh.t >= 1) {
+      gh.t = 0; gh.phase++;
+      if (gh.phase === 2) gh.env.visible = true;
+      if (gh.phase === 7) {
+        gh.env.visible = false;
+        const drop = makeEnvelope(gh.color);
+        drop.position.copy(gh.g.position);
+        envelopes.push({ m: drop, color: gh.color, path: [drop.position.clone(), hubTableTop()], t: 0, seg: 0, speed: 2.5, emit: 0 });
+      }
+    } else {
+      gh.g.position.lerpVectors(a, b, gh.t);
+      gh.env.position.copy(gh.g.position).add(v(0, -0.15, 0.3));
+      // squash & stretch (the ghost breathes as it drifts) + face the way it's going
+      const wob = Math.sin(performance.now() / 140 + n * 1.7);
+      gh.g.scale.set(1 - wob * 0.05, 1 + wob * 0.09, 1 - wob * 0.05);
+      gh.g.lookAt(b);
+      gh.g.rotateY(Math.PI);   // eyes sit on +Z; lookAt points -Z at the target
+      // pale wisp trail
+      gh.emit = (gh.emit || 0) + dt;
+      if (gh.emit > 0.12) { gh.emit = 0; puff(gh.g.position, 0xbfc8e8, 0.6, 0.8); }
+    }
+  }
+
+  // trail particles: fade + shrink, then dispose
+  for (let n = trailParticles.length - 1; n >= 0; n--) {
+    const p = trailParticles[n];
+    p.life -= dt;
+    if (p.life <= 0) { scene.remove(p.m); p.m.material.dispose(); trailParticles.splice(n, 1); continue; }
+    p.m.material.opacity = 0.85 * (p.life / p.maxLife);
+    p.m.scale.multiplyScalar(1 - dt * 1.1);
+  }
+
+  // echo storm: bounce inside a shell around the hub world
+  if (storm) {
+    for (const e of echoes) {
+      e.m.position.addScaledVector(e.vel, dt);
+      const rel = e.m.position.clone().sub(PLANETS.hub.c);
+      const d = rel.length(), nrm = rel.normalize();
+      const lo = PLANETS.hub.r + PLANETS.hub.amp + 0.6, hi = PLANETS.hub.r + 6;
+      if (d < lo || d > hi) {
+        e.vel.addScaledVector(nrm, -2 * e.vel.dot(nrm));
+        e.m.position.copy(PLANETS.hub.c).addScaledVector(nrm, Math.max(lo, Math.min(hi, d)));
+      }
+      e.m.rotation.x += dt * 3; e.m.rotation.y += dt * 4;
+    }
+    if (performance.now() - lastDup > 1500 && echoes.length < 60) {
+      lastDup = performance.now();
+      spawnEcho(echoes[Math.floor(Math.random() * echoes.length)].m.position.clone());
+    }
+    document.getElementById("echo-n").textContent = echoes.length;
+  }
+  cursed.material.emissiveIntensity = cursed.visible ? 0.4 + 0.3 * Math.sin(performance.now() / 250) : 0;
+
+  // ambience: spinning launch stars, swirling wormholes, billboards facing you
+  for (const s of launchMeshes) s.rotation.y += dt * 2.2;
+  for (const w of wormholes) { w.children[0].rotation.z += dt * 1.6; w.children[1].rotation.z -= dt * 2.4; }
+  for (const b of billboards) b.quaternion.copy(camera.quaternion);
+
+  // HUD
+  document.getElementById("room-label").textContent = "📍 " + player.planet.name + (player.flight ? " → in transit" : "");
+  document.getElementById("room-sub").textContent = player.planet.sub;
+  const near = document.pointerLockElement && !player.flight ? nearestInteractable() : null;
+  promptEl.style.display = near ? "block" : "none";
+  if (near) promptEl.textContent = "[E] " + near.label;
+
+  renderer.render(scene, camera);
+}
+tick();
+
+// Debug/screenshot hook: lets headless verification reposition the view
+// (outside pointer lock the engine copies camera.position from player.pos
+// but leaves orientation alone, so a one-off lookAt sticks).
+window.__galaxy = { player, camera, scene, PLANETS, v };
+
+setTimeout(() => lore(
+  "🌌 Welcome to <b>Mautrix Galaxy</b>. Every planetoid is a Matrix room — standing on one is membership. " +
+  "Pipes between worlds are <b>plumbing</b>; the swirling <b>wormholes</b> are megabridge portals (no pipes allowed); " +
+  "the ghosts are <code>@_relay_*</code> puppets carrying mail through subspace. Start at the registrar's desk, " +
+  "then ride the launch star to the Hub World.", 13000), 800);
+</script>
+</body>
+</html>

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -11,7 +11,7 @@ export SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
 if [ -z "$1" ]; then
   echo "Usage: $0 <ip> [service]"
   echo "  ip: VPS IP address or hostname"
-  echo "  service: all|caddy|site|invite|outline|kanbn|radicale|matrix|claudius|imagineering-contact-us|backups|scripts (default: all)"
+  echo "  service: all|caddy|site|invite|galaxy|outline|kanbn|radicale|matrix|claudius|imagineering-contact-us|backups|scripts (default: all)"
   exit 1
 fi
 
@@ -129,6 +129,29 @@ deploy_invite() {
     ssh "$REMOTE" "mkdir -p ~/apps/invite"
     rsync -avz --delete "$INVITE_SRC/" "$REMOTE":apps/invite/
     echo "Invite deployed to ~/apps/invite (mounted into Caddy as /srv/invite)"
+}
+
+deploy_galaxy() {
+    # Mautrix Galaxy — a standalone three.js teaching world (spherical gravity,
+    # planets = bridge platforms) served at galaxy.imagineering.cc. Self-contained
+    # single HTML file; the only runtime dependency is three.js from a CDN.
+    # Source lives in this repo (galaxy/index.html), recovered from the retired
+    # Bridgekeeper's Primer game so it can be shared on its own.
+    #
+    # Destination is ~/apps/galaxy — the Caddy container bind-mounts
+    # /home/nick/apps/galaxy -> /srv/galaxy:ro (see caddy/docker-compose.yml),
+    # same convention as the invite mount.
+    local GALAXY_SRC="$REPO_ROOT/galaxy"
+
+    if [ ! -f "$GALAXY_SRC/index.html" ]; then
+        echo "ERROR: galaxy/index.html not found at $GALAXY_SRC"
+        return 1
+    fi
+
+    echo "Deploying galaxy.imagineering.cc..."
+    ssh "$REMOTE" "mkdir -p ~/apps/galaxy"
+    rsync -avz --delete "$GALAXY_SRC/" "$REMOTE":apps/galaxy/
+    echo "Galaxy deployed to ~/apps/galaxy (mounted into Caddy as /srv/galaxy)"
 }
 
 deploy_contact() {
@@ -1054,6 +1077,7 @@ case $SERVICE in
         deploy_service caddy
         deploy_site
         deploy_invite
+        deploy_galaxy
         deploy_outline
         deploy_kanbn
         deploy_radicale
@@ -1092,6 +1116,9 @@ case $SERVICE in
     invite)
         deploy_invite
         ;;
+    galaxy)
+        deploy_galaxy
+        ;;
     imagineering-contact-us|contact)
         deploy_contact
         ;;
@@ -1121,7 +1148,7 @@ case $SERVICE in
         ;;
     *)
         echo "Unknown service: $SERVICE"
-        echo "Usage: $0 <ip> [all|caddy|outline|kanbn|radicale|dreamfinder|embodied-dreamfinder|livekit|matrix|claudius|lugh|youtube-rag|imagineering-contact-us|backups|scripts|site|invite]"
+        echo "Usage: $0 <ip> [all|caddy|outline|kanbn|radicale|dreamfinder|embodied-dreamfinder|livekit|matrix|claudius|lugh|youtube-rag|imagineering-contact-us|backups|scripts|site|invite|galaxy]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Recovers the standalone three.js galaxy world from the retired Bridgekeeper's Primer game and hosts it at a shareable URL. Single self-contained HTML file, `file_server` off `/srv/galaxy` (invite pattern), plus a `galaxy` deploy target. Intentional share — Nick wants to send the link to a friend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)