### PR TITLE
feat(alerts): reroute cron alerts through local notify proxy

### DIFF
--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -67,8 +67,40 @@ deploy_scripts() {
         echo "  Add telegram_bot_token, telegram_chat_id, telegram_thread_id to enable alerts"
     fi
 
+    # Install the notify-secrets envfile (root:nick 0640) — the credential
+    # lib/telegram.sh actually uses since alerts were rerouted through the
+    # local notify proxy (claude-tasks#441: gremlin_xdeca_bot is muted in
+    # its target group, so direct Telegram sends were silently dropped).
+    # telegram.env above is kept for now: xdeca's release-watch and other
+    # non-lib consumers still hold those creds; retiring it is a separate
+    # subtractive pass.
+    local NOTIFY_SECRETS="$REPO_ROOT/notify/secrets.yaml"
+    if [ -f "$NOTIFY_SECRETS" ] && sops -d "$NOTIFY_SECRETS" | yq -e '.notify_api_key' > /dev/null 2>&1; then
+        echo "Installing /etc/downstream-secrets/notify.env..."
+        local NOTIFY_KEY
+        NOTIFY_KEY=$(sops -d "$NOTIFY_SECRETS" | yq -r '.notify_api_key')
+        # Build locally, scp, install with restrictive perms — same
+        # pattern as telegram.env above. The file is consumed by bash
+        # `source` (not docker compose's dotenv parser), so %q gives the
+        # correct shell-quoting even if the key ever contains
+        # shell-significant bytes.
+        local NOTIFY_TMP
+        NOTIFY_TMP=$(mktemp)
+        printf 'NOTIFY_API_KEY=%q\n' "$NOTIFY_KEY" > "$NOTIFY_TMP"
+        chmod 0600 "$NOTIFY_TMP"
+        scp -q "$NOTIFY_TMP" "$REMOTE":/tmp/notify.env
+        ssh "$REMOTE" "sudo mkdir -p /etc/downstream-secrets && \
+            sudo install -m 0640 -o root -g nick /tmp/notify.env /etc/downstream-secrets/notify.env && \
+            rm -f /tmp/notify.env"
+        rm -f "$NOTIFY_TMP"
+        echo "  Notify envfile installed (mode 0640 root:nick)"
+    else
+        echo "NOTE: No notify_api_key in notify/secrets.yaml — cron alerts disabled"
+        echo "  lib/telegram.sh will no-op until /etc/downstream-secrets/notify.env exists"
+    fi
+
     # Set up health check cron. Tokens are NOT inlined here any more — the
-    # script reads /etc/downstream-secrets/telegram.env via lib/telegram.sh.
+    # script reads /etc/downstream-secrets/notify.env via lib/telegram.sh.
     echo "Installing /etc/cron.d/health-check..."
     ssh "$REMOTE" "mkdir -p ~/logs && printf '%s\n' \
         'SHELL=/bin/bash' \

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -70,8 +70,8 @@ done < <(docker ps -a --filter "status=exited" --filter "status=restarting" --fo
 
 # Send alert if any issues found
 if [ ${#issues[@]} -gt 0 ]; then
-    if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
-        echo "$(date '+%Y-%m-%d %H:%M:%S') ALERT but missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID"
+    if [ -z "$NOTIFY_API_KEY" ]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') ALERT but missing NOTIFY_API_KEY"
         printf '  - %s\n' "${issues[@]}"
         exit 1
     fi

--- a/scripts/lib/telegram.sh
+++ b/scripts/lib/telegram.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
-# Shared Telegram alert helper, sourced by infra cron scripts.
+# Shared alert helper, sourced by infra cron scripts.
 #
 # Provides:
 #   telegram_html_escape <string>      -> echoes input with &, <, > escaped for HTML mode
-#   send_telegram_alert <html_message> -> POST to Telegram with parse_mode=HTML
+#   send_telegram_alert <html_message> -> POST to the notify proxy with parse_mode=HTML
 #
-# Configuration: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, TELEGRAM_THREAD_ID
-# (the last is optional). If not already in the environment, this lib tries
-# to source /etc/downstream-secrets/telegram.env (root:nick 0640) so the
-# token never has to be inlined into world-readable cron entries.
+# Alerts are delivered via the local notify service (the `notify` container
+# on 127.0.0.1:8090, publicly notify.imagineering.cc), which forwards to
+# Telegram with its own bot token. This replaced direct Telegram Bot API
+# calls as gremlin_xdeca_bot: that bot is muted in its target group (status
+# "restricted", can_send_messages=false), so every alert was silently
+# dropped (claude-tasks#441). Routing through notify gives crons the same
+# alert path the watcher fleet already uses, landing in Nick's personal
+# chat.
+#
+# The default NOTIFY_URL is deliberately the LOCAL listener, not the public
+# Caddy-fronted hostname: health-check alerts fire precisely when Caddy or
+# containers are down, so the alert path must not depend on Caddy.
+#
+# Configuration: NOTIFY_API_KEY (required), NOTIFY_URL (optional, defaults
+# to the local listener). If not already in the environment, this lib tries
+# to source /etc/downstream-secrets/notify.env (root:nick 0640) so the key
+# never has to be inlined into world-readable cron entries.
 #
 # Silent no-op if creds are missing — a missing-secret deploy shouldn't turn
 # every cron into a stderr spammer.
@@ -19,18 +32,17 @@
 # when we most need the alert. HTML mode requires escaping only `&`, `<`,
 # `>` — much smaller failure surface.
 
-# Source the secrets file if present and the vars aren't already set.
+# Source the secrets file if present and the key isn't already set.
 # Done at source-time, not at function-call-time, so each script only pays
 # the cost once (and behavior is predictable in `set -u` consumers).
-if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] && [ -r /etc/downstream-secrets/telegram.env ]; then
+if [ -z "${NOTIFY_API_KEY:-}" ] && [ -r /etc/downstream-secrets/notify.env ]; then
   # shellcheck disable=SC1091
-  . /etc/downstream-secrets/telegram.env
+  . /etc/downstream-secrets/notify.env
 fi
 
 # Default exports so consumers can use `${VAR:-}` or `set -u` safely.
-TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
-TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-}"
-TELEGRAM_THREAD_ID="${TELEGRAM_THREAD_ID:-}"
+NOTIFY_API_KEY="${NOTIFY_API_KEY:-}"
+NOTIFY_URL="${NOTIFY_URL:-http://127.0.0.1:8090}"
 
 # Escape &, <, > for Telegram HTML mode. Order matters: & must be first so
 # the literal ampersands inserted by &lt; / &gt; aren't double-escaped.
@@ -43,46 +55,61 @@ telegram_html_escape() {
   printf '%s' "$s"
 }
 
-# Send a Telegram alert. Silent no-op if creds are not configured (the
-# common dev/test path); but if creds ARE present and curl fails, log to
-# stderr — a silent communication failure for a system-critical alert is
-# exactly the failure mode we don't want.
+# Escape a string for embedding inside a JSON string literal. Pure bash +
+# tr (no jq dependency — this runs from cron, where a missing binary would
+# silently kill the alert path). Handles the characters that realistically
+# appear in alert text: backslash, double-quote, newline, carriage return,
+# tab. Any remaining ASCII control chars (rare — e.g. from a binary log
+# tail) are stripped rather than \u-encoded: losing an unprintable byte
+# from an alert is fine; breaking the JSON is not.
+notify_json_escape() {
+  local s=${1:-}
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037'
+}
+
+# Send an alert via the notify proxy. Silent no-op if creds are not
+# configured (the common dev/test path); but if creds ARE present and the
+# send fails, log to stderr — a silent communication failure for a
+# system-critical alert is exactly the failure mode we don't want.
 # Argument is the message body in Telegram HTML format. Caller is
 # responsible for escaping any dynamic content via telegram_html_escape.
 send_telegram_alert() {
   local message="$1"
-  if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
-    echo "Telegram alert skipped (TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set)"
+  if [ -z "$NOTIFY_API_KEY" ]; then
+    echo "Telegram alert skipped (NOTIFY_API_KEY not set)"
     return 0
   fi
-  local -a args=(
-    -sS --max-time 10 -X POST
-    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage"
-    -d "chat_id=$TELEGRAM_CHAT_ID"
-    -d "parse_mode=HTML"
-    --data-urlencode "text=$message"
-  )
-  if [ -n "$TELEGRAM_THREAD_ID" ]; then
-    args+=(-d "message_thread_id=$TELEGRAM_THREAD_ID")
-  fi
+  local payload
+  payload=$(printf '{"message": "%s", "parse_mode": "HTML"}' \
+    "$(notify_json_escape "$message")")
   # Capture curl output. On non-zero exit, emit a one-line stderr message
   # so the cron job's log carries a breadcrumb for the post-mortem.
   local curl_out curl_rc
-  curl_out=$(curl "${args[@]}" 2>&1) || curl_rc=$?
+  curl_out=$(curl -sS --max-time 10 -X POST "$NOTIFY_URL/send" \
+    -H "Authorization: Bearer $NOTIFY_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>&1) || curl_rc=$?
   curl_rc=${curl_rc:-0}
   if [ "$curl_rc" -ne 0 ]; then
     echo "send_telegram_alert: curl failed (rc=$curl_rc): $curl_out" >&2
     return 0  # don't propagate — caller is in an alert path already
   fi
-  # curl exits 0 for an HTTP 4xx too (it got *a* response), so a Telegram API
-  # rejection — bot restricted/kicked, closed topic, bad thread id, HTML parse
-  # error — comes back as {"ok":false,...} with rc=0 and would otherwise pass
-  # silently. That is the exact silent-drop failure mode this alert path exists
-  # to avoid, so inspect the response body. (Plain glob, no jq dependency.)
+  # curl exits 0 for an HTTP 4xx/5xx too (it got *a* response), so a
+  # rejection — bad API key, or a Telegram-side refusal relayed by notify —
+  # comes back with rc=0 and would otherwise pass silently. That is the
+  # exact silent-drop failure mode this alert path exists to avoid, so
+  # inspect the response body. notify relays Telegram's response verbatim
+  # on success, and Python's json.dumps puts a space after the colon, so
+  # match both spellings. (Plain glob, no jq dependency.)
   case "$curl_out" in
-    *'"ok":true'*) : ;;  # delivered
+    *'"ok": true'* | *'"ok":true'*) : ;;  # delivered to Telegram
     *)
-      echo "send_telegram_alert: Telegram API rejected the message (rc=0): $curl_out" >&2
+      echo "send_telegram_alert: notify rejected the message (rc=0): $curl_out" >&2
       return 0  # still don't propagate — caller is already in an alert path
       ;;
   esac

--- a/scripts/lib/telegram.sh
+++ b/scripts/lib/telegram.sh
@@ -18,6 +18,16 @@
 # Caddy-fronted hostname: health-check alerts fire precisely when Caddy or
 # containers are down, so the alert path must not depend on Caddy.
 #
+# NARROWED FAILURE MODEL (known, accepted): the notify container is itself
+# a container on this host. If Docker or notify is down, the alert is lost
+# (stderr breadcrumb in the cron log only) — this path cannot announce the
+# death of its own transport. Mitigations: the docker-watchdog cron
+# restarts dead containers, and host-level liveness is watched externally
+# (Melbourne peer watcher). A direct-Telegram fallback was considered and
+# rejected: the only other bot creds on this box belong to a bot that is
+# muted in its target group, which is the silent-drop failure this lib
+# exists to fix.
+#
 # Configuration: NOTIFY_API_KEY (required), NOTIFY_URL (optional, defaults
 # to the local listener). If not already in the environment, this lib tries
 # to source /etc/downstream-secrets/notify.env (root:nick 0640) so the key
@@ -89,9 +99,13 @@ send_telegram_alert() {
     "$(notify_json_escape "$message")")
   # Capture curl output. On non-zero exit, emit a one-line stderr message
   # so the cron job's log carries a breadcrumb for the post-mortem.
+  # The Authorization header is fed via process substitution (-H @file)
+  # rather than argv, so the API key never appears in `ps` output or
+  # /proc/*/cmdline while the send is in flight. The payload stays in
+  # argv — alert text is operational, not secret.
   local curl_out curl_rc
   curl_out=$(curl -sS --max-time 10 -X POST "$NOTIFY_URL/send" \
-    -H "Authorization: Bearer $NOTIFY_API_KEY" \
+    -H @<(printf 'Authorization: Bearer %s\n' "$NOTIFY_API_KEY") \
     -H "Content-Type: application/json" \
     -d "$payload" 2>&1) || curl_rc=$?
   curl_rc=${curl_rc:-0}

--- a/scripts/watchers/README.md
+++ b/scripts/watchers/README.md
@@ -149,10 +149,11 @@ notify without holding the bot token. See
 The template inlines the `tg()` helper rather than sourcing it from
 `scripts/lib/`, on purpose: a watcher should be a single self-contained
 file you can `scp` to the target box without dragging the repo. The
-existing `scripts/lib/telegram.sh` is a different abstraction — it talks
-*directly* to the Telegram bot API (needs `TELEGRAM_BOT_TOKEN`); use it
-when you need MarkdownV2 escaping or threaded replies. For watchers,
-prefer `notify.imagineering.cc`.
+existing `scripts/lib/telegram.sh` now also routes through notify (it
+talks to the LOCAL listener on `127.0.0.1:8090` and sources
+`/etc/downstream-secrets/notify.env`) — it exists for repo-deployed cron
+scripts that want the shared HTML-escape helper. For watchers, keep the
+inlined `tg()` + `notify.imagineering.cc`.
 
 Credentials live at `~/.config/imagineering/notify-credentials` on the
 Sydney box (mode 0600, exports `NOTIFY_URL` and `NOTIFY_API_KEY`). The


### PR DESCRIPTION
## Why

All five repo-managed alert crons (`backup`, `health-check`, `backup-downstream`, `health-check-downstream`, `reconcile-downstream`) deliver via the shared `scripts/lib/telegram.sh`, which called the Telegram Bot API directly as **gremlin_xdeca_bot** — a bot that is **muted** in its target group (`status=restricted`, `can_send_messages=false`). Every alert was silently dropped (claude-tasks#441). The DB↔B2 reconcile canary is currently exiting 1 with real findings and nobody hears it.

## What

- `send_telegram_alert()` now POSTs to the **notify** service (`http://127.0.0.1:8090/send`, Bearer auth) — the same path the watcher fleet already uses. Alerts land in Nick's personal Telegram chat via the dreams-bot.
  - **Localhost on purpose**, not `notify.imagineering.cc`: health-check alerts fire exactly when Caddy/containers are down, so the alert path must not route through Caddy.
  - Function names + lib filename unchanged → the `nickmeinhold/downstream` consumers that source `/opt/scripts/lib/telegram.sh` at runtime need zero changes.
  - Pure-bash JSON escaping (no jq dependency in a cron alert path); control bytes stripped rather than \u-encoded. Success check matches both `"ok":true` and Python json.dumps' `"ok": true`.
- `deploy_scripts` installs `/etc/downstream-secrets/notify.env` (root:nick 0640) from `notify/secrets.yaml`, **%q shell-quoted** — the file is bash-`source`d, so shell quoting (not dotenv quoting) is the correct discipline (forward-applies claude-tasks#685's lesson to the new file).
- `telegram.env` generation is **kept**: xdeca's `release-watch` and other non-lib consumers still use those creds. Retiring it is a separate subtractive pass.

## Verification done locally

- shellcheck clean (lib has zero findings; deploy-to.sh SC2029 infos pre-exist on main)
- Adversarial round-trip: message with quotes/backslash/newline/tab/control-byte → valid JSON, content preserved
- No-creds path → silent no-op, rc 0; dead-notify path → stderr breadcrumb, rc 0 (safe under `set -e` callers)

## Post-merge

Deploy via `./scripts/deploy-to.sh 149.118.69.221 scripts`, then fire a real alert and confirm it lands on Nick's phone (transmitted ≠ delivered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)