### PR TITLE
fix(deploy): safe-quote interpolated secrets in deploy-to.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,10 @@ jobs:
 
       # ubuntu-latest ships docker + yq, so the dotenv check runs against the
       # real container runtime and the yq check against real mikefarah yq.
+      # REQUIRE_ALL=1 turns a missing tool into a hard failure rather than a
+      # vacuous skip, so a future runner-image change that drops yq/docker
+      # fails loudly instead of passing green with the checks silently skipped.
       - name: Run secret-quoting round-trip tests
+        env:
+          REQUIRE_ALL: "1"
         run: ./scripts/test-secret-quoting.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,14 @@ jobs:
           yamllint -d "{extends: relaxed, rules: {line-length: {max: 150}}}" \
             .github/workflows/*.yml \
             */docker-compose.yml
+
+  secret-quoting:
+    name: Secret Quoting Round-trip
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ubuntu-latest ships docker + yq, so the dotenv check runs against the
+      # real container runtime and the yq check against real mikefarah yq.
+      - name: Run secret-quoting round-trip tests
+        run: ./scripts/test-secret-quoting.sh

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -20,6 +20,48 @@ SERVICE=${2:-all}
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REMOTE="nick@$IP"
 
+# ---------------------------------------------------------------------------
+# Secret-safe value quoting helpers (defense-in-depth).
+#
+# Generated config files interpolate decrypted secrets. A secret containing
+# shell- or YAML-significant bytes (quotes, $, #, &, /, \, whitespace,
+# newlines) must not corrupt the file or inject into the consumer. Two
+# consumers, two quoting regimes:
+#
+#   shell_env_line  — for envfiles consumed by bash `source`/`.`
+#                     (e.g. /etc/downstream-secrets/telegram.env via
+#                     lib/telegram.sh, /etc/imagineering-secrets/matrix.env
+#                     via backup.sh). Uses printf %q so the line re-evaluates
+#                     to the exact original bytes when sourced.
+#
+#   dotenv_quote    — for `.env` files consumed by docker compose's compose-go
+#                     dotenv parser. Wraps in double quotes and escapes the
+#                     four bytes that parser treats specially inside a
+#                     double-quoted value: \  "  $  and a literal newline.
+#                     Verified to round-trip to the actual container runtime.
+#
+# Both verified byte-exact against an adversarial value containing
+# `" $ # & / \` backtick, whitespace and a newline (see scripts/test-secret-quoting.sh).
+# ---------------------------------------------------------------------------
+
+# Emit a `KEY=<quoted-value>` line safe for a bash-sourced envfile.
+# Usage: shell_env_line KEY "$value"  -> prints the full line (no trailing newline added by caller's printf needed)
+shell_env_line() {
+    # %q renders the value in a form that bash re-reads as the identical bytes.
+    printf '%s=%q\n' "$1" "$2"
+}
+
+# Quote a single value for a docker-compose dotenv file (double-quoted form).
+# Usage: dotenv_quote "$value"  -> prints `"...escaped..."`
+dotenv_quote() {
+    local v=$1
+    v=${v//\\/\\\\}      # backslash first: \  -> \\
+    v=${v//\"/\\\"}      # "  -> \"
+    v=${v//\$/\\\$}      # $  -> \$   (suppress compose variable interpolation)
+    v=${v//$'\n'/\\n}    # literal newline -> \n escape
+    printf '"%s"' "$v"
+}
+
 echo "Deploying to $REMOTE..."
 
 deploy_scripts() {
@@ -46,13 +88,19 @@ deploy_scripts() {
         # ~/.bash_history or `ps` output.
         local SECRETS_TMP
         SECRETS_TMP=$(mktemp)
+        # Clean up the 0600 plaintext temp file on ANY exit (incl. set -e
+        # aborts mid-scp/ssh) — locally and best-effort on the remote /tmp.
+        # shellcheck disable=SC2064  # expand SECRETS_TMP now, intentional
+        trap "rm -f '$SECRETS_TMP'; ssh '$REMOTE' 'rm -f /tmp/telegram.env' 2>/dev/null || true" EXIT
         # Strip null/empty values so the envfile is clean (e.g. THREAD_ID
-        # is optional and may legitimately be missing).
+        # is optional and may legitimately be missing). Values are shell-quoted
+        # (printf %q via shell_env_line) so a token with shell-significant bytes
+        # survives `source` intact and cannot inject.
         {
-            printf 'TELEGRAM_BOT_TOKEN=%s\n' "$BOT_TOKEN"
-            printf 'TELEGRAM_CHAT_ID=%s\n'   "$CHAT_ID"
+            shell_env_line TELEGRAM_BOT_TOKEN "$BOT_TOKEN"
+            shell_env_line TELEGRAM_CHAT_ID   "$CHAT_ID"
             if [ -n "$THREAD_ID" ] && [ "$THREAD_ID" != "null" ]; then
-                printf 'TELEGRAM_THREAD_ID=%s\n' "$THREAD_ID"
+                shell_env_line TELEGRAM_THREAD_ID "$THREAD_ID"
             fi
         } > "$SECRETS_TMP"
         chmod 0600 "$SECRETS_TMP"
@@ -61,6 +109,7 @@ deploy_scripts() {
             sudo install -m 0640 -o root -g nick /tmp/telegram.env /etc/downstream-secrets/telegram.env && \
             rm -f /tmp/telegram.env"
         rm -f "$SECRETS_TMP"
+        trap - EXIT
         echo "  Telegram envfile installed (mode 0640 root:nick)"
     else
         echo "NOTE: No Telegram credentials in backups/secrets.yaml — alerts disabled"
@@ -167,22 +216,28 @@ deploy_contact() {
     fi
 
     # Generate .env from encrypted secrets. Decrypt once into a variable so we
-    # can run two yq passes without re-decrypting (and without echoing plaintext).
+    # can read each field without re-decrypting (and without echoing plaintext).
+    # Each value goes through dotenv_quote so a secret with dotenv-significant
+    # bytes (", $, \, newline) round-trips through docker compose intact rather
+    # than corrupting the file or triggering variable interpolation.
     echo "Generating .env from encrypted secrets..."
     local CONTACT_PLAINTEXT
     CONTACT_PLAINTEXT=$(sops -d "$CONTACT_SECRETS")
-    echo "$CONTACT_PLAINTEXT" | yq -r '"# Contact Form Configuration (auto-generated from secrets.yaml)
-SMTP_HOST=\(.smtp_host)
-SMTP_PORT=\(.smtp_port)
-SMTP_USERNAME=\(.smtp_username)
-SMTP_PASSWORD=\(.smtp_password)
-SMTP_FROM_EMAIL=\(.smtp_from_email)
-CONTACT_TO=\(.contact_to)"' > "$REPO_ROOT/imagineering-contact-us/.env"
-    # Turnstile secret appended in a separate pass: yq string-interpolation can't
-    # embed the `// ""` empty-string default (the nested quotes break parsing),
-    # so coalesce here. Empty when the key is absent => verification stays off.
-    echo "TURNSTILE_SECRET=$(echo "$CONTACT_PLAINTEXT" | yq -r '.turnstile_secret // ""')" \
-        >> "$REPO_ROOT/imagineering-contact-us/.env"
+    # Read a field from the decrypted YAML; missing keys yq-print as "null",
+    # which we map to empty so absent => empty value (matches prior behavior
+    # for turnstile_secret, and is harmless for the required SMTP fields).
+    contact_field() { echo "$CONTACT_PLAINTEXT" | yq -r "$1 // \"\""; }
+    {
+        echo "# Contact Form Configuration (auto-generated from secrets.yaml)"
+        printf 'SMTP_HOST=%s\n'        "$(dotenv_quote "$(contact_field '.smtp_host')")"
+        printf 'SMTP_PORT=%s\n'        "$(dotenv_quote "$(contact_field '.smtp_port')")"
+        printf 'SMTP_USERNAME=%s\n'    "$(dotenv_quote "$(contact_field '.smtp_username')")"
+        printf 'SMTP_PASSWORD=%s\n'    "$(dotenv_quote "$(contact_field '.smtp_password')")"
+        printf 'SMTP_FROM_EMAIL=%s\n'  "$(dotenv_quote "$(contact_field '.smtp_from_email')")"
+        printf 'CONTACT_TO=%s\n'       "$(dotenv_quote "$(contact_field '.contact_to')")"
+        # Empty when the key is absent => Turnstile verification stays off.
+        printf 'TURNSTILE_SECRET=%s\n' "$(dotenv_quote "$(contact_field '.turnstile_secret')")"
+    } > "$REPO_ROOT/imagineering-contact-us/.env"
 
     # Deploy files
     ssh "$REMOTE" "mkdir -p ~/apps/imagineering-contact-us"
@@ -384,9 +439,15 @@ SSHEOF'
         fi
         local MATRIX_SECRETS_TMP
         MATRIX_SECRETS_TMP=$(mktemp)
+        # Clean up the 0600 plaintext temp file on ANY exit (incl. set -e
+        # aborts mid-scp/ssh) — locally and best-effort on the remote /tmp.
+        # shellcheck disable=SC2064  # expand MATRIX_SECRETS_TMP now, intentional
+        trap "rm -f '$MATRIX_SECRETS_TMP'; ssh '$REMOTE' 'rm -f /tmp/matrix.env' 2>/dev/null || true" EXIT
+        # Values shell-quoted (printf %q) so an admin token / age recipient
+        # with shell-significant bytes survives `source` in backup.sh intact.
         {
-            printf 'MATRIX_ADMIN_TOKEN=%s\n' "$ADMIN_TOKEN"
-            printf 'AGE_RECIPIENT=%s\n'      "$AGE_RECIPIENT"
+            shell_env_line MATRIX_ADMIN_TOKEN "$ADMIN_TOKEN"
+            shell_env_line AGE_RECIPIENT      "$AGE_RECIPIENT"
         } > "$MATRIX_SECRETS_TMP"
         chmod 0600 "$MATRIX_SECRETS_TMP"
         scp -q "$MATRIX_SECRETS_TMP" "$REMOTE":/tmp/matrix.env
@@ -394,6 +455,7 @@ SSHEOF'
             sudo install -m 0640 -o root -g nick /tmp/matrix.env /etc/imagineering-secrets/matrix.env && \
             rm -f /tmp/matrix.env"
         rm -f "$MATRIX_SECRETS_TMP"
+        trap - EXIT
         echo "  Matrix envfile installed (mode 0640 root:nick)"
     else
         echo "NOTE: matrix_admin_token not found in $MATRIX_SECRETS — Continuwuity backup disabled"
@@ -663,15 +725,25 @@ deploy_livekit() {
     API_SECRET=$(sops -d "$LK_SECRETS" | yq -r '.livekit_api_secret')
     EXTERNAL_IP=$(sops -d "$LK_SECRETS" | yq -r '.external_ip')
 
-    # Generate livekit.yaml with real credentials and IP
-    sed -e "s/LIVEKIT_API_KEY/$API_KEY/" \
-        -e "s/LIVEKIT_API_SECRET/$API_SECRET/" \
-        "$REPO_ROOT/livekit/livekit.yaml" > "$REPO_ROOT/livekit/livekit-generated.yaml"
+    # Generate livekit.yaml with real credentials and IP.
+    #
+    # Use yq strenv templating, NOT sed: a secret containing sed-significant
+    # bytes (/, &, \) or YAML-significant bytes (:, #, ", newline) would corrupt
+    # the config or inject YAML under the old `sed s/PLACEHOLDER/$secret/`
+    # approach. strenv reads the value from the environment (never the command
+    # line, so it can't leak via `ps`/history) and yq emits it as a properly
+    # quoted YAML scalar. The template `keys:` map has exactly one placeholder
+    # entry (LIVEKIT_API_KEY: LIVEKIT_API_SECRET); we replace the whole map with
+    # the real key->secret pair, and set rtc.node_ip when an external IP is given.
+    LK_KEY="$API_KEY" LK_SECRET="$API_SECRET" yq eval '
+        .keys = {} |
+        .keys[strenv(LK_KEY)] = strenv(LK_SECRET)
+    ' "$REPO_ROOT/livekit/livekit.yaml" > "$REPO_ROOT/livekit/livekit-generated.yaml"
 
     # Inject node_ip if external IP is set
     if [ -n "$EXTERNAL_IP" ] && [ "$EXTERNAL_IP" != "null" ]; then
-        sed -i'' -e "/use_external_ip: true/a\\
-  node_ip: $EXTERNAL_IP" "$REPO_ROOT/livekit/livekit-generated.yaml"
+        LK_IP="$EXTERNAL_IP" yq eval -i '.rtc.node_ip = strenv(LK_IP)' \
+            "$REPO_ROOT/livekit/livekit-generated.yaml"
     fi
 
     # Deploy files

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -90,8 +90,15 @@ deploy_scripts() {
         SECRETS_TMP=$(mktemp)
         # Clean up the 0600 plaintext temp file on ANY exit (incl. set -e
         # aborts mid-scp/ssh) — locally and best-effort on the remote /tmp.
+        # ConnectTimeout bounds the remote leg: the abort case is often an
+        # unreachable host, and the trap must not hang ~120s on a dead TCP
+        # connect. Save any pre-existing EXIT trap and restore it on success
+        # rather than clearing unconditionally, so an outer trap (none today)
+        # would survive.
+        local SECRETS_PREV_TRAP
+        SECRETS_PREV_TRAP=$(trap -p EXIT)
         # shellcheck disable=SC2064  # expand SECRETS_TMP now, intentional
-        trap "rm -f '$SECRETS_TMP'; ssh '$REMOTE' 'rm -f /tmp/telegram.env' 2>/dev/null || true" EXIT
+        trap "rm -f '$SECRETS_TMP'; ssh -o ConnectTimeout=5 '$REMOTE' 'rm -f /tmp/telegram.env' 2>/dev/null || true" EXIT
         # Strip null/empty values so the envfile is clean (e.g. THREAD_ID
         # is optional and may legitimately be missing). Values are shell-quoted
         # (printf %q via shell_env_line) so a token with shell-significant bytes
@@ -109,7 +116,8 @@ deploy_scripts() {
             sudo install -m 0640 -o root -g nick /tmp/telegram.env /etc/downstream-secrets/telegram.env && \
             rm -f /tmp/telegram.env"
         rm -f "$SECRETS_TMP"
-        trap - EXIT
+        # Restore the prior EXIT trap (empty string clears, if none existed).
+        eval "${SECRETS_PREV_TRAP:-trap - EXIT}"
         echo "  Telegram envfile installed (mode 0640 root:nick)"
     else
         echo "NOTE: No Telegram credentials in backups/secrets.yaml — alerts disabled"
@@ -441,8 +449,12 @@ SSHEOF'
         MATRIX_SECRETS_TMP=$(mktemp)
         # Clean up the 0600 plaintext temp file on ANY exit (incl. set -e
         # aborts mid-scp/ssh) — locally and best-effort on the remote /tmp.
+        # ConnectTimeout bounds the remote leg (see deploy_scripts note).
+        # Save/restore any pre-existing EXIT trap rather than clearing blindly.
+        local MATRIX_PREV_TRAP
+        MATRIX_PREV_TRAP=$(trap -p EXIT)
         # shellcheck disable=SC2064  # expand MATRIX_SECRETS_TMP now, intentional
-        trap "rm -f '$MATRIX_SECRETS_TMP'; ssh '$REMOTE' 'rm -f /tmp/matrix.env' 2>/dev/null || true" EXIT
+        trap "rm -f '$MATRIX_SECRETS_TMP'; ssh -o ConnectTimeout=5 '$REMOTE' 'rm -f /tmp/matrix.env' 2>/dev/null || true" EXIT
         # Values shell-quoted (printf %q) so an admin token / age recipient
         # with shell-significant bytes survives `source` in backup.sh intact.
         {
@@ -455,7 +467,8 @@ SSHEOF'
             sudo install -m 0640 -o root -g nick /tmp/matrix.env /etc/imagineering-secrets/matrix.env && \
             rm -f /tmp/matrix.env"
         rm -f "$MATRIX_SECRETS_TMP"
-        trap - EXIT
+        # Restore the prior EXIT trap (empty string clears, if none existed).
+        eval "${MATRIX_PREV_TRAP:-trap - EXIT}"
         echo "  Matrix envfile installed (mode 0640 root:nick)"
     else
         echo "NOTE: matrix_admin_token not found in $MATRIX_SECRETS — Continuwuity backup disabled"

--- a/scripts/test-secret-quoting.sh
+++ b/scripts/test-secret-quoting.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Round-trip tests for the secret-quoting helpers in deploy-to.sh.
+#
+# Each generated config file in deploy-to.sh interpolates decrypted secrets.
+# These tests prove an adversarial value — containing every byte that is
+# significant to one of the consumers (" $ # & / \ backtick, whitespace, and a
+# newline) — survives the quote -> write -> parse round-trip byte-for-byte.
+#
+# Three consumers, three checks:
+#   1. bash `source`            (shell_env_line / printf %q)
+#   2. docker compose dotenv    (dotenv_quote)
+#   3. yq YAML scalar           (yq strenv templating, used for livekit.yaml)
+#
+# The dotenv check uses `docker compose` when available (authoritative, reads
+# the value the container actually receives). When docker is absent (e.g. CI),
+# it falls back to a yamllint-free structural assertion that the line is a
+# well-formed double-quoted dotenv value. Shell and yq checks need no docker.
+#
+# Exit non-zero on any mismatch so CI fails loudly.
+
+set -euo pipefail
+
+# --- The helpers under test (kept byte-identical to deploy-to.sh) -----------
+# If these drift from deploy-to.sh the tests are meaningless, so they are
+# duplicated deliberately and a guard below greps deploy-to.sh to confirm the
+# function names still exist there.
+
+shell_env_line() {
+    printf '%s=%q\n' "$1" "$2"
+}
+
+dotenv_quote() {
+    local v=$1
+    v=${v//\\/\\\\}
+    v=${v//\"/\\\"}
+    v=${v//\$/\\\$}
+    v=${v//$'\n'/\\n}
+    printf '"%s"' "$v"
+}
+
+# --- Adversarial fixture ----------------------------------------------------
+# Every byte here is significant to at least one consumer.
+ADV=$'a"b$c#d&e/f\\g`h i: literal\nsecond-line*x'
+
+PASS=0
+FAIL=0
+ok()   { echo "  ok   - $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL - $1"; FAIL=$((FAIL + 1)); }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# --- 1. Shell-source round-trip --------------------------------------------
+echo "[1] bash source round-trip (shell_env_line / printf %q)"
+shell_env_line SECRET "$ADV" > "$WORK/shell.env"
+# Source in a clean subshell and compare exact bytes.
+# shellcheck disable=SC1091  # runtime-generated path, nothing to follow
+GOT=$(set -e; . "$WORK/shell.env"; printf '%s' "$SECRET")
+if [ "$GOT" = "$ADV" ]; then ok "sourced value matches original"; else
+    bad "sourced value differs"; printf '    exp: %q\n    got: %q\n' "$ADV" "$GOT"
+fi
+
+# --- 2. dotenv round-trip ---------------------------------------------------
+echo "[2] docker compose dotenv round-trip (dotenv_quote)"
+printf 'VAL=%s\n' "$(dotenv_quote "$ADV")" > "$WORK/.env"
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    cat > "$WORK/docker-compose.yml" <<'YML'
+services:
+  t:
+    image: alpine
+    environment:
+      VAL: ${VAL}
+YML
+    # Authoritative: run the container and read the raw bytes it receives.
+    if (cd "$WORK" && docker compose run --rm -T t sh -c 'printf "%s" "$VAL"' 2>/dev/null) > "$WORK/got.bin"; then
+        (cd "$WORK" && docker compose down >/dev/null 2>&1 || true)
+        if cmp -s "$WORK/got.bin" <(printf '%s' "$ADV"); then
+            ok "container runtime value matches original"
+        else
+            bad "container runtime value differs"
+        fi
+    else
+        echo "  skip - docker present but 'compose run' failed (no daemon?); doing structural check"
+        # Structural fallback.
+        if grep -q '^VAL=".*"$' "$WORK/.env"; then
+            ok "dotenv line is well-formed double-quoted"
+        else
+            bad "dotenv line malformed"
+        fi
+    fi
+else
+    echo "  skip - docker unavailable; structural check only"
+    # Without docker we can still assert the quoting is well-formed: the value
+    # is wrapped in double quotes and contains no UNescaped " inside.
+    line=$(cat "$WORK/.env")
+    body=${line#VAL=}
+    if [ "${body:0:1}" = '"' ] && [ "${body: -1}" = '"' ]; then
+        inner=${body:1:${#body}-2}
+        # No bare (unescaped) double-quote should remain in the inner body.
+        if printf '%s' "$inner" | grep -qP '(?<!\\)"'; then
+            bad "dotenv inner body has an unescaped double-quote"
+        else
+            ok "dotenv line is well-formed double-quoted"
+        fi
+    else
+        bad "dotenv value is not double-quoted"
+    fi
+fi
+
+# --- 3. yq YAML round-trip (livekit templating) ----------------------------
+echo "[3] yq strenv YAML round-trip"
+if command -v yq >/dev/null 2>&1; then
+    cat > "$WORK/livekit.yaml" <<'YML'
+keys:
+  LIVEKIT_API_KEY: LIVEKIT_API_SECRET
+rtc:
+  use_external_ip: true
+YML
+    LK_KEY="key-${ADV}" LK_SECRET="$ADV" yq eval '
+        .keys = {} |
+        .keys[strenv(LK_KEY)] = strenv(LK_SECRET)
+    ' "$WORK/livekit.yaml" > "$WORK/livekit-gen.yaml"
+    GOT_SECRET=$(yq -r '.keys.[]' "$WORK/livekit-gen.yaml")
+    GOT_KEY=$(yq -r '.keys | keys | .[0]' "$WORK/livekit-gen.yaml")
+    if [ "$GOT_SECRET" = "$ADV" ]; then ok "yq secret value round-trips"; else bad "yq secret differs"; fi
+    if [ "$GOT_KEY" = "key-${ADV}" ]; then ok "yq key name round-trips"; else bad "yq key differs"; fi
+else
+    echo "  skip - yq unavailable"
+fi
+
+# --- 4. Drift guard: the helpers must still exist in deploy-to.sh -----------
+echo "[4] deploy-to.sh still defines the helpers"
+DEPLOY="$(cd "$(dirname "$0")" && pwd)/deploy-to.sh"
+for fn in shell_env_line dotenv_quote; do
+    if grep -qE "^${fn}\(\) \{" "$DEPLOY"; then ok "$fn defined in deploy-to.sh"; else
+        bad "$fn missing from deploy-to.sh (tests would be stale)"
+    fi
+done
+
+echo ""
+echo "secret-quoting tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-secret-quoting.sh
+++ b/scripts/test-secret-quoting.sh
@@ -42,10 +42,20 @@ dotenv_quote() {
 # Every byte here is significant to at least one consumer.
 ADV=$'a"b$c#d&e/f\\g`h i: literal\nsecond-line*x'
 
+# REQUIRE_ALL=1 (set by CI) forbids vacuous passes: if docker or yq is missing,
+# their checks fail instead of degrading to a structural-only / skipped check.
+# This keeps CI from silently going green on a runner image that drops a tool.
+REQUIRE_ALL=${REQUIRE_ALL:-0}
+
 PASS=0
 FAIL=0
 ok()   { echo "  ok   - $1"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL - $1"; FAIL=$((FAIL + 1)); }
+# Either skip (local convenience) or hard-fail (REQUIRE_ALL, i.e. CI).
+skip_or_fail() {
+    if [ "$REQUIRE_ALL" = "1" ]; then bad "$1 (REQUIRE_ALL set — tool must be present in CI)";
+    else echo "  skip - $1"; fi
+}
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -80,7 +90,7 @@ YML
             bad "container runtime value differs"
         fi
     else
-        echo "  skip - docker present but 'compose run' failed (no daemon?); doing structural check"
+        skip_or_fail "docker present but 'compose run' failed (no daemon?); structural check only"
         # Structural fallback.
         if grep -q '^VAL=".*"$' "$WORK/.env"; then
             ok "dotenv line is well-formed double-quoted"
@@ -89,7 +99,7 @@ YML
         fi
     fi
 else
-    echo "  skip - docker unavailable; structural check only"
+    skip_or_fail "docker unavailable; structural check only"
     # Without docker we can still assert the quoting is well-formed: the value
     # is wrapped in double quotes and contains no UNescaped " inside.
     line=$(cat "$WORK/.env")
@@ -125,7 +135,7 @@ YML
     if [ "$GOT_SECRET" = "$ADV" ]; then ok "yq secret value round-trips"; else bad "yq secret differs"; fi
     if [ "$GOT_KEY" = "key-${ADV}" ]; then ok "yq key name round-trips"; else bad "yq key differs"; fi
 else
-    echo "  skip - yq unavailable"
+    skip_or_fail "yq unavailable"
 fi
 
 # --- 4. Drift guard: the helpers must still exist in deploy-to.sh -----------


### PR DESCRIPTION
## What

Defense-in-depth quoting for every place `deploy-to.sh` interpolates a decrypted secret into a generated config file. A secret containing shell- or YAML-significant bytes (`" $ # & / \` backtick, whitespace, newlines) could previously corrupt the generated file or inject into its consumer. **No behavioral change for today's well-formed secrets.**

Closes the imagineering-infra cage-match deferred items (#685 / #605 / #686 / #732 item 2).

## Four fixes (one file/region)

1. **Bash-sourced envfiles** — `telegram.env` (deploy_scripts) + `matrix.env` (deploy_backups) are consumed by `.`/`source` (lib/telegram.sh, backup.sh), so they need **shell** quoting. Values now render via `printf %q` (`shell_env_line` helper). Previously a token with shell-significant bytes could change the sourced value or execute.

2. **deploy_contact dotenv** — every value (all SMTP_* + TURNSTILE_SECRET) now routes through a new `dotenv_quote` helper (double-quote + escape `\ " $` newline) verified to round-trip through compose-go's dotenv parser to the **real container runtime**.

3. **deploy_livekit YAML** — replaces `sed s/PLACEHOLDER/$secret/` into `livekit.yaml` with **yq strenv** templating (secret passed via env, never the command line). A sed-/YAML-significant secret can no longer corrupt or inject YAML.

4. **Temp-file traps** — deploy_scripts + deploy_backups add `EXIT` traps that remove the `0600` plaintext temp files (local + best-effort remote `/tmp`) even when `set -e` aborts mid-scp/ssh.

## Verification

- `scripts/test-secret-quoting.sh` (now run in CI) proves an adversarial value containing `" $ # & / \` backtick, whitespace **and a newline** round-trips **byte-exact** through all three consumers:
  - bash `source` (printf %q)
  - docker compose dotenv → actual container runtime
  - yq strenv YAML scalar
- shellcheck clean (all levels), yamllint clean.
- **No production deploy** — code-only change, verified locally + CI only.

```
[1] bash source round-trip          ok - sourced value matches original
[2] docker compose dotenv round-trip ok - container runtime value matches original
[3] yq strenv YAML round-trip        ok - secret + key round-trip
[4] drift guard                      ok - helpers still defined in deploy-to.sh
secret-quoting tests: 6 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)