### PR TITLE
feat(cd-bus): custom domain cd-bus.imagineering.cc

### DIFF
--- a/cd-bus/README.md
+++ b/cd-bus/README.md
@@ -6,7 +6,10 @@ opening an inbound port. This is the keystone (component 2) of the deploy-bus.
 
 > Full design + rationale: [The Imagineering Deploy Bus](https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q)
 
-**Deployed:** https://cd-bus.nick-meinhold.workers.dev (Cloudflare Worker + Durable Object)
+**Deployed:** https://cd-bus.imagineering.cc (Cloudflare Worker + Durable Object).
+The legacy `https://cd-bus.nick-meinhold.workers.dev` host stays live in parallel
+until every subscriber's `BUS_URL` has moved to the custom domain, then retires
+(`workers_dev: false`).
 
 ## Routes
 
@@ -103,8 +106,8 @@ public (pilot) mode instantly.
 - [x] **Constant-time token compare** on `/publish` (and `/events`) — done.
 - [x] **Subscribe-auth on `/events`** — implemented as enforce-when-bound; flip
   on via the runbook above before fleet rollout (claude-tasks #16).
-- [ ] **Custom domain** — move off `*.workers.dev` to `cd-bus.imagineering.cc`
-  (Cloudflare custom domain + DNS; zone `1444f67680d10386df2a55e5f016e2b2`).
-  Needs a `wrangler deploy` under Nick's Cloudflare OAuth + a DNS record, then
-  update the announce job URL and every subscriber's `BUS_URL`. Deploy-gated;
-  not in the worker source.
+- [x] **Custom domain** — `cd-bus.imagineering.cc` is live (declarative
+  `custom_domain` route in `wrangler.jsonc`; zone `1444f67680d10386df2a55e5f016e2b2`).
+  `workers.dev` is kept live alongside it (`workers_dev: true`) until subscribers
+  migrate. **Still TODO to fully cut over:** update the CI announce job URL and
+  every subscriber's `BUS_URL` to the custom domain, then set `workers_dev: false`.

--- a/cd-bus/wrangler.jsonc
+++ b/cd-bus/wrangler.jsonc
@@ -3,9 +3,36 @@
   // subscribers over SSE. See cd-bus/README.md and the design doc:
   // https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q
   "name": "cd-bus",
+  // The imagineering Cloudflare account (Nick's token can see >1 account, so
+  // pin it explicitly — otherwise `wrangler deploy` fails in non-interactive
+  // mode). Matches the zone account in the root CLAUDE.md.
+  "account_id": "fc0bb404a04968a041ca7d8475e2ffad",
   "main": "src/index.js",
   "compatibility_date": "2025-05-01",
   "observability": { "enabled": true },
+
+  // Keep the *.workers.dev route LIVE alongside the custom domain. The live
+  // downstream pilot still subscribes via the workers.dev URL; omitting this
+  // makes `wrangler deploy` disable workers.dev by default and 1042 the live
+  // SSE leg. Retire this (drop to false) only AFTER every subscriber's
+  // BUS_URL has moved to cd-bus.imagineering.cc.
+  "workers_dev": true,
+  // No per-version preview URLs — they're ephemeral public endpoints we don't
+  // need for a relay, and minimizing internet-facing surface is the point of
+  // the hardening pass.
+  "preview_urls": false,
+
+  // Custom domain (replaces the *.workers.dev host). Declared here so the
+  // binding is reproducible: `wrangler deploy` provisions the proxied DNS
+  // record + edge cert for this hostname in the imagineering.cc zone
+  // (1444f67680d10386df2a55e5f016e2b2) and routes it to this Worker. The
+  // specific `cd-bus` record overrides the zone's wildcard A record.
+  // NOTE: adding a custom domain alone is NOT non-breaking — `wrangler deploy`
+  // disables workers.dev unless `workers_dev: true` is set above (it is). Both
+  // must be declared together to add the domain without dropping the live leg.
+  "routes": [
+    { "pattern": "cd-bus.imagineering.cc", "custom_domain": true }
+  ],
 
   // One Durable Object instance per service holds that service's open SSE
   // connections and its last-published event (for replay on reconnect).


### PR DESCRIPTION
## What

Moves the deploy-bus relay onto the custom domain **`cd-bus.imagineering.cc`** via a declarative Workers `custom_domain` route, replacing the `*.workers.dev` host as the canonical URL. Part of the cd-bus hardening pass (claude-tasks #712), which unblocks the fleet rollout (#714).

This is **Phase 1** of Path A. Phase 2 (the subscribe-auth flip + moving the downstream subscriber's `BUS_URL` to the new domain) is separate and touches the live OCI host — it will be its own change.

## Changes
- `wrangler.jsonc`: pin `account_id` (token sees >1 CF account), add `custom_domain` route, keep `workers_dev: true`, set `preview_urls: false`.
- `README.md`: reflect the now-live custom domain + remaining cutover steps.

## Already deployed + verified
This config is the source-of-truth record of a deploy already applied via `wrangler deploy` (Cloudflare Workers deploy = wrangler, not merge). Verified live:
- `https://cd-bus.imagineering.cc/health` → `{"ok":true}` (DNS resolves to CF proxy, overriding the zone wildcard A record)
- `https://cd-bus.nick-meinhold.workers.dev/health` → `{"ok":true}` (legacy host kept live for the unmigrated pilot)

## ⚠️ Incident note (caught + fixed in-flight)
The first deploy with only the custom-domain route **disabled workers.dev by default** (wrangler's default), 1042-ing the live downstream SSE leg for ~2-3 min. Deploys kept flowing via the poll + SSH backstop (below the subscriber unit's ~5-min page threshold). Fixed by declaring `workers_dev: true`; both routes verified healthy. The "non-breaking" assumption was wrong — corrected in the config comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)