### PR TITLE
feat(cd-bus): fleet template — reactive CD for any OCI-host service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
           additional_files: '.githooks/pre-commit'
           severity: warning
 
+      # The deploy-bus fleet template (cd-bus/fleet/) ships its own shell
+      # scripts; scandir above only covers ./scripts, so lint cd-bus/ too —
+      # otherwise "Shell Linting" would be green while not covering them.
+      - name: Run ShellCheck (cd-bus)
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './cd-bus'
+          severity: warning
+
   yaml-lint:
     name: YAML Linting
     runs-on: ubuntu-latest

--- a/cd-bus/fleet/README.md
+++ b/cd-bus/fleet/README.md
@@ -1,0 +1,109 @@
+# cd-bus fleet template — reactive CD for any OCI-host service
+
+Generalises the proven `downstream-server` deploy-bus pilot
+(`nickmeinhold/downstream` `deploy/oci`) into **one templated set of systemd
+units + shared scripts** so any GHCR-built service gets push+poll CD by adding
+an env file and enabling three units. The relay itself lives one level up in
+[`../`](../README.md); this directory is the *subscriber* side.
+
+> Full design + rationale: [The Imagineering Deploy Bus](https://outline.imagineering.cc/doc/the-imagineering-deploy-bus-qz9QscpP6Q)
+
+## How it works (per service `%i`)
+
+```
+CI build ──image.published──▶ cd-bus relay ──SSE──▶ cd-bus-subscriber@%i ─┐
+(announce step)              (Cloudflare Worker)                          ├─▶ /opt/cd-bus/deploy.sh %i
+                                                  cd-poll@%i.timer (5min)─┘   (flock-serialised, idempotent
+                                                  poll backstop                docker compose pull && up -d)
+```
+
+- **`cd-bus-subscriber@%i`** holds an outbound SSE connection and deploys on each event. Fast path (~seconds).
+- **`cd-poll@%i.timer`** polls every 5 min — the backstop that catches anything the push misses.
+- **`cd-bus-recover@%i.timer`** revives the subscriber if a sustained relay outage drove it to `failed` (so the fast leg can never die permanently silent).
+- **`cd-bus-subscriber-alert@%i` / `cd-poll-alert@%i`** fire on real failure (Telegram, via `/opt/scripts/lib/telegram.sh`).
+
+All legs run the **same** `deploy.sh` under a **per-service flock**: legs of one service serialise; different services deploy in parallel.
+
+## Files
+
+| File | Installs to | Role |
+|---|---|---|
+| `subscribe.sh` | `/opt/cd-bus/subscribe.sh` | SSE subscriber (one copy, all services) |
+| `deploy.sh` | `/opt/cd-bus/deploy.sh` | the one deploy action every leg runs |
+| `subscriber-alert.sh` / `poll-alert.sh` | `/opt/cd-bus/` | OnFailure Telegram handlers |
+| `systemd/*@.service`, `*@.timer`, `*.d/` | `/etc/systemd/system/` | instance-unit templates |
+| `common.env.example` | → `/etc/cd-bus/common.env` | shared `BUS_URL` + `SUBSCRIBE_TOKEN` |
+| `install-shared.sh` | — | one-time host installer for the shared bits |
+
+## One-time host setup
+
+```bash
+scp -r cd-bus/fleet nick@HOST:/tmp/cd-bus-fleet
+ssh HOST 'cd /tmp/cd-bus-fleet && sudo ./install-shared.sh'
+# Create the shared config (token must match the relay's bound SUBSCRIBE_TOKEN):
+ssh HOST 'sudo install -d -o root -g nick -m 0750 /etc/cd-bus && \
+  printf "SUBSCRIBE_TOKEN=%s\n" "<token>" | sudo tee /etc/cd-bus/common.env >/dev/null && \
+  sudo chown root:nick /etc/cd-bus/common.env && sudo chmod 0640 /etc/cd-bus/common.env'
+```
+
+## Onboard a service (`<svc>` = its cd-bus channel name)
+
+1. **Per-service env** (only if it deviates from the convention — `APP_DIR=/home/nick/apps/<svc>`, compose service name `= <svc>`):
+   ```bash
+   # /etc/cd-bus/<svc>.env  (root:nick 0640) — omit entirely if conventions hold
+   APP_DIR=/home/nick/apps/<svc>
+   COMPOSE_SERVICE=<svc>        # if the compose service name differs from <svc>
+   ```
+2. **CI announce step** in that service's build workflow, after the image is pushed (digest required — see the snippet below).
+3. **Enable the units:**
+   ```bash
+   systemctl enable --now cd-bus-subscriber@<svc> \
+                          cd-bus-recover@<svc>.timer \
+                          cd-poll@<svc>.timer
+   ```
+4. **Verify:** `journalctl -u cd-bus-subscriber@<svc> -n 5` shows `subscribing to https://cd-bus.imagineering.cc/events/<svc>` and holds; a test merge logs `deploy ok`.
+
+### CI announce snippet
+
+Add to the build job (after build+push), generalised from the downstream pilot.
+`BUS_PUBLISH_TOKEN` is a repo secret = the relay's bound `PUBLISH_TOKEN`.
+
+```yaml
+      - name: Announce image.published to the deploy bus
+        if: github.ref == 'refs/heads/main'
+        env:
+          BUS_PUBLISH_TOKEN: ${{ secrets.BUS_PUBLISH_TOKEN }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          [ -n "$DIGEST" ] || { echo "::error::no image digest; not announcing"; exit 1; }
+          curl -fsS -X POST https://cd-bus.imagineering.cc/publish \
+            -H "Authorization: Bearer $BUS_PUBLISH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg service <svc> \
+              --arg image ghcr.io/OWNER/<svc> --arg digest "$DIGEST" \
+              '{event:"image.published",service:$service,image:$image,digest:$digest}')"
+```
+
+## Config reference (env, all optional)
+
+| Var | Default | Where | Meaning |
+|---|---|---|---|
+| `BUS_URL` | `https://cd-bus.imagineering.cc` | common.env | relay base |
+| `SUBSCRIBE_TOKEN` | (empty → public-pilot) | common.env | `/events` bearer; one token gates all channels |
+| `APP_DIR` | `/home/nick/apps/<svc>` | <svc>.env | compose dir |
+| `COMPOSE_SERVICE` | `<svc>` | <svc>.env | compose service name if it differs |
+| `HEALTHY_MIN_SECS` | `60` | <svc>.env | hold ≥ this before a relay-closed stream is "healthy" |
+
+## Candidate first services
+
+`dreamfinder`, `img-contact`, `notify` (all GHCR-built). The `downstream-server`
+pilot keeps its own `deploy/oci` copy for now; migrating it onto this template
+is a later consolidation once the template has proven on a second service.
+
+## Relationship to the pilot
+
+This template is a faithful generalisation of the downstream pilot, with one
+hardening applied (claude-tasks #20): `subscribe.sh` passes the bearer via a
+`0600` header file (`curl -H @file`) instead of a `-H "Bearer …"` argument, so
+the token never appears in the process table — it matters once a host runs more
+than one service user.

--- a/cd-bus/fleet/README.md
+++ b/cd-bus/fleet/README.md
@@ -37,6 +37,8 @@ All legs run the **same** `deploy.sh` under a **per-service flock**: legs of one
 
 ## One-time host setup
 
+**Prerequisites** (the units assume these): a `nick` group/user (units run as `User=nick`), and the shared Telegram helper at `/opt/scripts/lib/telegram.sh` (installed by imagineering-infra's `deploy_scripts` — without it the OnFailure *alerts* can't send, though deploys still work). `install-shared.sh` warns if either is missing.
+
 ```bash
 scp -r cd-bus/fleet nick@HOST:/tmp/cd-bus-fleet
 ssh HOST 'cd /tmp/cd-bus-fleet && sudo ./install-shared.sh'

--- a/cd-bus/fleet/common.env.example
+++ b/cd-bus/fleet/common.env.example
@@ -1,0 +1,16 @@
+# Shared deploy-bus subscriber config — install at /etc/cd-bus/common.env
+# (root:nick 0640). Loaded by every cd-bus-subscriber@/cd-poll@ unit BEFORE the
+# per-service /etc/cd-bus/<svc>.env, so per-service files override these.
+#
+# Copy to /etc/cd-bus/common.env on the host and fill in the token. Do NOT
+# commit the real file — only this .example belongs in git.
+
+# Relay base URL. Default in the scripts is already the custom domain, so this
+# is only needed to point a host at a different relay.
+# BUS_URL=https://cd-bus.imagineering.cc
+
+# The relay's /events bearer. ONE token gates every /events/<svc> channel, so
+# it is shared across all services on the host. Must match the relay's bound
+# SUBSCRIBE_TOKEN (wrangler secret put SUBSCRIBE_TOKEN). Leave unset to run in
+# public-pilot mode (no bearer sent).
+SUBSCRIBE_TOKEN=replace-me

--- a/cd-bus/fleet/deploy.sh
+++ b/cd-bus/fleet/deploy.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Deploy-bus deploy action — FLEET TEMPLATE (claude-tasks #714).
+# Installed at /opt/cd-bus/deploy.sh. The ONE deploy action every CD leg runs
+# (SSE push via subscribe.sh, and the 5-min poll backstop cd-poll@.timer), so
+# legs never overlap (shared flock) and the operation is idempotent.
+#
+# Generalised from nickmeinhold/downstream deploy/oci's cd-poll.sh.
+#
+# Failure visibility: docker compose errors exit 1, which the poll unit treats
+# as success (SuccessExitStatus=0 1) so a transient error just retries next
+# tick. To surface a PERSISTENT outage, consecutive failures are counted in
+# $FAIL_STATE; the 3rd consecutive failure (~15 min broken at the 5-min poll
+# cadence) exits 2 — a real unit failure, not in SuccessExitStatus — firing
+# OnFailure (Telegram). While the outage persists it re-alerts every 36th
+# failure (~3 h at 5-min cadence); any success resets the count.
+#
+# NOTE on the SSE leg: subscribe.sh calls this on an event and treats ANY
+# non-zero as deploy failure (it doesn't set SuccessExitStatus), so exit 1 vs 2
+# both mean "retry" there — the counter exists for the poll leg's alerting.
+set -euo pipefail
+
+SVC="${1:?usage: deploy.sh <service>}"
+APP_DIR="${APP_DIR:-/home/nick/apps/$SVC}"
+# The compose service name may differ from the bus/instance name; default to
+# the same. Override via /etc/cd-bus/$SVC.env if the compose service differs.
+COMPOSE_SERVICE="${COMPOSE_SERVICE:-$SVC}"
+FAIL_STATE="$APP_DIR/.cd-poll-failcount"
+
+cd "$APP_DIR"
+# Lock so a slow pull cannot overlap the next timer tick or an SSE event.
+# Per-service lock file: legs of the SAME service serialise; different services
+# deploy in parallel.
+exec 9>"/tmp/cd-bus-deploy-$SVC.lock"
+flock -n 9 || { echo "previous run still holding the lock for $SVC; skipping"; exit 0; }
+
+if docker compose pull "$COMPOSE_SERVICE" && docker compose up -d "$COMPOSE_SERVICE"; then
+  rm -f "$FAIL_STATE"
+  exit 0
+fi
+
+# A corrupt/empty state file would make the arithmetic blow up (exit 1 = the
+# SILENT retry path — alerting suppressed exactly when needed), so validate
+# before use and treat garbage as a fresh streak.
+prev=$(cat "$FAIL_STATE" 2>/dev/null || echo 0)
+[[ "$prev" =~ ^[0-9]+$ ]] || prev=0
+count=$((10#$prev + 1))  # 10# so a stray leading zero can't trip octal parsing
+echo "$count" >"$FAIL_STATE"
+echo "docker compose pull/up failed for $SVC (consecutive failure #${count})" >&2
+# Threshold (count==3) and every 36 thereafter: exit 2 -> unit failure ->
+# OnFailure alert. Everything else: exit 1 -> silent retry.
+if [ "$count" -ge 3 ] && [ $(((count - 3) % 36)) -eq 0 ]; then
+  exit 2
+fi
+exit 1

--- a/cd-bus/fleet/deploy.sh
+++ b/cd-bus/fleet/deploy.sh
@@ -26,6 +26,12 @@ APP_DIR="${APP_DIR:-/home/nick/apps/$SVC}"
 COMPOSE_SERVICE="${COMPOSE_SERVICE:-$SVC}"
 FAIL_STATE="$APP_DIR/.cd-poll-failcount"
 
+# A missing APP_DIR is a config error (typo'd /etc/cd-bus/<svc>.env, dir not
+# created yet), never transient — and `cd` failing under `set -e` would exit 1,
+# which the poll unit's SuccessExitStatus=0 1 SWALLOWS as success: no deploy, no
+# counter, no alert (the silent dead-deployer class, #168). Exit 2 instead so it
+# alerts immediately. (cage-match #83, Maxwell.)
+[ -d "$APP_DIR" ] || { echo "APP_DIR '$APP_DIR' for $SVC does not exist — config error" >&2; exit 2; }
 cd "$APP_DIR"
 # Lock so a slow pull cannot overlap the next timer tick or an SSE event.
 # Per-service lock file: legs of the SAME service serialise; different services

--- a/cd-bus/fleet/install-shared.sh
+++ b/cd-bus/fleet/install-shared.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# One-time (and re-runnable) host install of the shared deploy-bus fleet bits.
+# Copies the shared scripts to /opt/cd-bus and the unit TEMPLATES to
+# /etc/systemd/system, then daemon-reloads. Idempotent. Per-service enablement
+# (and /etc/cd-bus/<svc>.env) is separate — see README.md.
+#
+# Run FROM this directory on the host (these repo files are hand-managed
+# mirrors of the host, like the rest of imagineering-infra's deploy artifacts):
+#   scp -r cd-bus/fleet nick@host:/tmp/cd-bus-fleet && \
+#     ssh host 'cd /tmp/cd-bus-fleet && sudo ./install-shared.sh'
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPT=/opt/cd-bus
+UNITS=/etc/systemd/system
+
+[ "$(id -u)" -eq 0 ] || { echo "must run as root (installs to $UNITS)"; exit 1; }
+
+echo "installing shared scripts -> $OPT"
+install -d -o root -g root -m 0755 "$OPT"
+for s in subscribe.sh deploy.sh subscriber-alert.sh poll-alert.sh; do
+  install -o root -g root -m 0755 "$SRC_DIR/$s" "$OPT/$s"
+  echo "  $OPT/$s"
+done
+
+echo "ensuring /etc/cd-bus exists for per-service env (root:nick 0750)"
+install -d -o root -g nick -m 0750 /etc/cd-bus
+
+echo "installing unit templates -> $UNITS"
+# Plain files at the top of systemd/, plus the .d drop-in dirs.
+find "$SRC_DIR/systemd" -maxdepth 1 -type f \( -name '*.service' -o -name '*.timer' \) | while read -r u; do
+  install -o root -g root -m 0644 "$u" "$UNITS/$(basename "$u")"
+  echo "  $UNITS/$(basename "$u")"
+done
+# Drop-in directories (e.g. cd-bus-subscriber@.service.d/onfailure.conf).
+find "$SRC_DIR/systemd" -mindepth 1 -type d -name '*.d' | while read -r d; do
+  dest="$UNITS/$(basename "$d")"
+  install -d -o root -g root -m 0755 "$dest"
+  for f in "$d"/*; do
+    install -o root -g root -m 0644 "$f" "$dest/$(basename "$f")"
+    echo "  $dest/$(basename "$f")"
+  done
+done
+
+echo "daemon-reload"
+systemctl daemon-reload
+echo "done. Next: /etc/cd-bus/common.env (+ per-service <svc>.env), then"
+echo "  systemctl enable --now cd-bus-subscriber@<svc> cd-bus-recover@<svc>.timer cd-poll@<svc>.timer"

--- a/cd-bus/fleet/install-shared.sh
+++ b/cd-bus/fleet/install-shared.sh
@@ -9,12 +9,18 @@
 #   scp -r cd-bus/fleet nick@host:/tmp/cd-bus-fleet && \
 #     ssh host 'cd /tmp/cd-bus-fleet && sudo ./install-shared.sh'
 set -euo pipefail
+shopt -s nullglob # so an (unexpected) empty .d dir globs to nothing, not a literal '*'
 
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OPT=/opt/cd-bus
 UNITS=/etc/systemd/system
 
 [ "$(id -u)" -eq 0 ] || { echo "must run as root (installs to $UNITS)"; exit 1; }
+# Host prerequisites the units assume (cage-match #83): the alert scripts source
+# the shared Telegram helper, and the unit files run as group nick. Warn rather
+# than fail — install the scripts/units regardless, but make a missing prereq loud.
+getent group nick >/dev/null || echo "WARN: group 'nick' not found — the units run as User=nick; create it or edit the units."
+[ -f /opt/scripts/lib/telegram.sh ] || echo "WARN: /opt/scripts/lib/telegram.sh missing — failure ALERTS will not send until imagineering-infra's deploy_scripts installs it."
 
 echo "installing shared scripts -> $OPT"
 install -d -o root -g root -m 0755 "$OPT"

--- a/cd-bus/fleet/poll-alert.sh
+++ b/cd-bus/fleet/poll-alert.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# OnFailure handler for cd-poll@<svc>.service — FLEET TEMPLATE.
+# Installed at /opt/cd-bus/poll-alert.sh; invoked as `poll-alert.sh %i` by
+# cd-poll-alert@.service.
+#
+# Fired when the poll-leg unit *really* fails — exit 2 from deploy.sh after >=3
+# consecutive docker compose failures (~15 min broken at the 5-min cadence), or
+# unit-level breakage (script missing, perms). Two channels:
+#  1. journald `TELEGRAM[crit]:` line (forwarder contract + audit trail).
+#  2. direct POST to Telegram via the shared /opt/scripts/lib/telegram.sh.
+#
+# ALERT_SUFFIX (optional env) is appended; verification runs use it.
+set -uo pipefail # deliberately no -e: try every channel even if one fails
+
+SVC="${1:?usage: poll-alert.sh <service>}"
+
+# shellcheck source=/dev/null
+. /opt/scripts/lib/telegram.sh
+
+MSG="cd-poll@${SVC} failed on $(hostname) — the CD pull leg has been broken for ~15 min (docker compose pull/up failing). Deploys for ${SVC} are NOT landing on either leg until this clears.${ALERT_SUFFIX:-}"
+
+echo "TELEGRAM[crit]: ${MSG}" | systemd-cat -t "cd-poll-alert@${SVC}" -p crit
+send_telegram_alert "CRITICAL: $(telegram_html_escape "${MSG}")"

--- a/cd-bus/fleet/subscribe.sh
+++ b/cd-bus/fleet/subscribe.sh
@@ -70,10 +70,15 @@ seen_at_start=$(cat "$STATE" 2>/dev/null || true)
 [ -n "$seen_at_start" ] && hdr=(-H "Last-Event-ID: $seen_at_start")
 
 # Subscribe auth (claude-tasks #20): pass the bearer via a 0600 header FILE
-# (curl -H @file), NEVER a -H "Bearer ..." ARG — an arg is world-readable in
-# the process table (ps -ef, /proc/<pid>/cmdline), which on a multi-tenant host
-# leaks the token to other service users. The file is removed on exit. No-op
-# while SUBSCRIBE_TOKEN is empty (relay /events still public, header omitted).
+# (curl -H @file), NEVER a -H "Bearer ..." ARG. The guarantee this gives, stated
+# precisely (cage-match #83, Carnot): the token VALUE never appears in the
+# process table (ps -ef, /proc/<pid>/cmdline) — only the file PATH does, and the
+# file is mode 0600 owned by the run user, so a DIFFERENT-UID service on a
+# multi-tenant host cannot read it. It does NOT defend against a same-UID
+# process (which can read the path then the file) — but that threat is already
+# moot, since such a process can read /etc/cd-bus/common.env (root:nick 0640)
+# where the same token lives. The file is removed on exit. No-op while
+# SUBSCRIBE_TOKEN is empty (relay /events still public, header omitted).
 hdrfile=""
 # shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
 cleanup() { [ -n "$hdrfile" ] && rm -f "$hdrfile"; }

--- a/cd-bus/fleet/subscribe.sh
+++ b/cd-bus/fleet/subscribe.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Deploy-bus SSE subscriber — FLEET TEMPLATE (claude-tasks #714).
+# Installed at /opt/cd-bus/subscribe.sh; driven by cd-bus-subscriber@.service.
+#
+# Generalised from nickmeinhold/downstream deploy/oci's cd-bus-subscribe.sh
+# (the proven pilot). One copy serves every bus-managed service: the service
+# name is $1 (the systemd instance %i), and all paths/config derive from it,
+# overridable via /etc/cd-bus/{common,$SVC}.env.
+#
+# Holds an outbound-only SSE connection to the cd-bus relay and invokes the
+# shared deploy action on each image.published event. The deploy action takes
+# the flock all CD legs share (SSE push here, the 5-min poll backstop), so legs
+# never overlap and `docker compose up -d` is idempotent.
+#
+# Replay: the relay retains the last event per service and replays it on
+# (re)connect unless our Last-Event-ID proves we saw it. An UNSEEN id deploys
+# (catch-up after host downtime); a SEEN id is skipped via $STATE.
+#
+# Failure visibility: a stream that ends after a HEALTHY hold is a normal
+# Cloudflare-Worker connection recycle (Workers cap streaming lifetime), NOT a
+# failure — exit 0, systemd (Restart=always) reconnects silently. Only two
+# things exit non-zero (-> start-limit -> failed -> OnFailure alert): a deploy
+# that fails, or a connection that dies almost immediately (relay unreachable).
+set -uo pipefail
+
+SVC="${1:?usage: subscribe.sh <service> (the systemd instance %i)}"
+# Per-service config, all overridable via the EnvironmentFiles:
+#   BUS_URL          relay base (shared; default = the custom domain)
+#   SUBSCRIBE_TOKEN  relay /events bearer (shared; empty => public-pilot no-op)
+#   APP_DIR          the service's compose dir on the host
+#   HEALTHY_MIN_SECS hold >= this before a relay-closed stream counts healthy
+BUS_URL="${BUS_URL:-https://cd-bus.imagineering.cc}"
+SUBSCRIBE_TOKEN="${SUBSCRIBE_TOKEN:-}"
+APP_DIR="${APP_DIR:-/home/nick/apps/$SVC}"
+STATE="$APP_DIR/.cd-bus-last-event-id"
+DEPLOY="${DEPLOY:-/opt/cd-bus/deploy.sh}"
+HEALTHY_MIN_SECS="${HEALTHY_MIN_SECS:-60}"
+
+# Dispatch one complete SSE event. Returns non-zero only on deploy failure.
+handle_event() {
+  local ev_id="$1" ev_data="$2" digest seen
+  digest=$(printf '%s' "$ev_data" | jq -r '.digest // empty' 2>/dev/null)
+  [ -z "$digest" ] && return 0 # not an image.published payload; ignore
+  seen=$(cat "$STATE" 2>/dev/null || true)
+  if [ -n "$ev_id" ] && [ "$ev_id" = "$seen" ]; then
+    echo "event id=$ev_id already deployed; skipping (replay)"
+    return 0
+  fi
+  echo "image.published id=${ev_id:-?} digest=$digest -> deploying $SVC"
+  # KNOWN BENIGN RACE: if another CD leg holds the flock now, deploy.sh exits 0
+  # ("skipping") and we mark the id seen without having deployed THIS event
+  # ourselves. The concurrent holder runs the same idempotent pull/up; worst
+  # case is corrected by the next poll tick. Exit-0-on-lock-skip is success by
+  # design — do not "fix" this by parsing output.
+  if "$DEPLOY" "$SVC"; then
+    [ -n "$ev_id" ] && echo "$ev_id" >"$STATE"
+    echo "deploy ok (id=${ev_id:-?})"
+    return 0
+  fi
+  echo "deploy FAILED (id=${ev_id:-?}); exiting for restart+replay retry" >&2
+  return 1
+}
+
+echo "subscribing to $BUS_URL/events/$SVC"
+
+# Last-Event-ID on (re)connect so the relay can skip replaying an event we
+# already deployed (standard SSE resumption).
+hdr=()
+seen_at_start=$(cat "$STATE" 2>/dev/null || true)
+[ -n "$seen_at_start" ] && hdr=(-H "Last-Event-ID: $seen_at_start")
+
+# Subscribe auth (claude-tasks #20): pass the bearer via a 0600 header FILE
+# (curl -H @file), NEVER a -H "Bearer ..." ARG — an arg is world-readable in
+# the process table (ps -ef, /proc/<pid>/cmdline), which on a multi-tenant host
+# leaks the token to other service users. The file is removed on exit. No-op
+# while SUBSCRIBE_TOKEN is empty (relay /events still public, header omitted).
+hdrfile=""
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { [ -n "$hdrfile" ] && rm -f "$hdrfile"; }
+trap cleanup EXIT
+if [ -n "$SUBSCRIBE_TOKEN" ]; then
+  hdrfile=$(umask 077; mktemp "${TMPDIR:-/tmp}/cd-bus-hdr-$SVC.XXXXXX") || exit 1
+  printf 'Authorization: Bearer %s\n' "$SUBSCRIBE_TOKEN" >"$hdrfile"
+  hdr+=(-H "@$hdrfile")
+fi
+
+# SSE parsing per spec: an event is a block of fields terminated by a blank
+# line; `data:` may span multiple lines. Accumulate, dispatch on the boundary,
+# reset. Comment lines (": ping" heartbeats) match no field and are ignored.
+ev_id=""
+ev_data=""
+CONNECT_EPOCH=$(date +%s)
+curl -sN --no-buffer ${hdr[@]+"${hdr[@]}"} "$BUS_URL/events/$SVC" |
+while IFS= read -r line; do
+  case "$line" in
+    id:*)
+      ev_id="${line#id:}"
+      ev_id="${ev_id# }"
+      ;;
+    data:*)
+      d="${line#data:}"
+      d="${d# }"
+      ev_data="${ev_data:+$ev_data
+}$d"
+      ;;
+    "")
+      # Blank line = event boundary. exit 3 (not 1) so the deploy-failure case
+      # is distinguishable from a plain stream-end after the pipe.
+      if [ -n "$ev_data" ]; then
+        handle_event "$ev_id" "$ev_data" || exit 3
+      fi
+      ev_id=""
+      ev_data=""
+      ;;
+  esac
+done
+# Capture the while-subshell's status FIRST — the next command clobbers
+# PIPESTATUS. [1] is the while; [0] would be curl.
+WHILE_RC=${PIPESTATUS[1]:-0}
+DURATION=$(( $(date +%s) - CONNECT_EPOCH ))
+
+# Deploy failure (exit 3) is a genuine failure regardless of hold time: exit
+# non-zero so the alert fires and the relay replays the retained event.
+if [ "$WHILE_RC" -eq 3 ]; then
+  echo "deploy failed; exiting non-zero for restart+replay+alert" >&2
+  exit 1
+fi
+
+# Otherwise the stream ended (EOF). A healthy hold = the relay recycled the
+# connection — exit 0, quiet reconnect. A near-instant end = relay
+# unreachable/flapping — exit 1 so a sustained outage trips the alert.
+if [ "$DURATION" -ge "$HEALTHY_MIN_SECS" ]; then
+  echo "stream ended after ${DURATION}s (healthy hold; normal relay recycle) — quiet reconnect"
+  exit 0
+fi
+echo "stream ended after only ${DURATION}s (relay unreachable/flapping) — failing for restart+alert" >&2
+exit 1

--- a/cd-bus/fleet/subscriber-alert.sh
+++ b/cd-bus/fleet/subscriber-alert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OnFailure handler for cd-bus-subscriber@<svc>.service — FLEET TEMPLATE.
+# Installed at /opt/cd-bus/subscriber-alert.sh; invoked as
+# `subscriber-alert.sh %i` by cd-bus-subscriber-alert@.service.
+#
+# Fired when the SSE subscriber unit *really* fails (start-limit exceeded — it
+# cannot hold a connection to the relay). The SSE leg being down is NOT a
+# deploy outage (the poll backstop converges within 5 min), but it is the
+# dead-deployer class that hid for 13 days (claude-tasks #168) — so it must be
+# VISIBLE. Two channels, same as the pilot:
+#  1. journald line with the `TELEGRAM[crit]:` prefix (forwarder contract +
+#     greppable audit trail).
+#  2. direct POST to Telegram via the shared /opt/scripts/lib/telegram.sh.
+#
+# ALERT_SUFFIX (optional env) is appended; verification runs use it.
+set -uo pipefail # deliberately no -e: try every channel even if one fails
+
+SVC="${1:?usage: subscriber-alert.sh <service>}"
+
+# shellcheck source=/dev/null
+. /opt/scripts/lib/telegram.sh
+
+MSG="cd-bus-subscriber@${SVC} failed on $(hostname) — SSE push leg is down (deploys fall back to the 5-min poll; latency degraded, not broken)${ALERT_SUFFIX:-}"
+
+echo "TELEGRAM[crit]: ${MSG}" | systemd-cat -t "cd-bus-subscriber-alert@${SVC}" -p crit
+send_telegram_alert "CRITICAL: $(telegram_html_escape "${MSG}")"

--- a/cd-bus/fleet/systemd/cd-bus-recover@.service
+++ b/cd-bus/fleet/systemd/cd-bus-recover@.service
@@ -1,0 +1,34 @@
+# Auto-recovery for a deploy-bus SSE subscriber — FLEET TEMPLATE (claude-tasks #736).
+#
+# WHY. The recycle-as-success behaviour makes the subscriber exit 0 on a healthy
+# Worker connection recycle, so systemd's start-limit is the ONLY path to
+# `failed`. A sustained relay outage trips that limit after ~5 min of
+# fast-failing reconnects; the unit enters `failed` and — because the limit is
+# hit — systemd will NOT auto-restart it. It stays dead until reset-failed.
+# Meanwhile the poll backstop keeps deploys flowing, so nobody would notice the
+# fast leg is silently gone.
+#
+# WHAT. A oneshot, fired ~every 10 min by the companion @.timer, that revives the
+# subscriber ONLY if it is `failed`. On a healthy unit the is-failed guard
+# short-circuits to a no-op. Does not silence alerting — BOUNDS its cadence:
+# sustained outage re-alerts roughly every ~15 min instead of going permanently
+# silent or spamming on every reconnect.
+#
+# STATELESS: reads live `systemctl is-failed` each tick — no state file that
+# could rot the watchdog into a permanent no-op.
+#
+# PRIVILEGE: reset-failed/start on a system unit require root, so (unlike the
+# User=nick alert units) this runs as root.
+# Install at /etc/systemd/system/cd-bus-recover@.service
+[Unit]
+Description=Auto-recover a failed cd-bus-subscriber@%i (bounded re-alert, no permanent death)
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+
+[Service]
+Type=oneshot
+# Guard then act: is-failed exits 0 only when the unit is `failed`, so reset+start
+# runs solely in that case. The trailing `|| true` keeps THIS unit out of its own
+# `failed` state (no OnFailure, no recursion) — a failed attempt just retries next tick.
+ExecStart=/bin/bash -c 'systemctl is-failed --quiet cd-bus-subscriber@%i.service && { echo "cd-bus-subscriber@%i is failed — clearing start-limit and restarting"; systemctl reset-failed cd-bus-subscriber@%i.service && systemctl start cd-bus-subscriber@%i.service; } || true'
+StandardOutput=journal
+StandardError=journal

--- a/cd-bus/fleet/systemd/cd-bus-recover@.timer
+++ b/cd-bus/fleet/systemd/cd-bus-recover@.timer
@@ -1,0 +1,25 @@
+# Drives cd-bus-recover@%i.service ~every 10 min — FLEET TEMPLATE (claude-tasks #736).
+# Enable per service: `systemctl enable --now cd-bus-recover@dreamfinder.timer`.
+#
+# Cadence: the subscriber takes ~5 min of fast-failing reconnects to trip its
+# start-limit and reach `failed`. A ~10 min recovery poll revives a dead SSE leg
+# within ~10 min — well inside the window the 5-min poll backstop covers — and a
+# still-broken relay re-alerts on a bounded ~15 min cadence rather than going
+# permanently silent.
+#
+# Not Persistent=: a missed tick during downtime has no value — after a reboot
+# the subscriber starts fresh (not `failed`), so a caught-up tick would only no-op.
+# Install at /etc/systemd/system/cd-bus-recover@.timer
+[Unit]
+Description=Periodic auto-recovery check for cd-bus-subscriber@%i
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+
+[Timer]
+# First check 5 min after boot (let the subscriber come up and, if the relay is
+# down, actually reach `failed`), then every 10 min.
+OnBootSec=5min
+OnUnitActiveSec=10min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/cd-bus/fleet/systemd/cd-bus-subscriber-alert@.service
+++ b/cd-bus/fleet/systemd/cd-bus-subscriber-alert@.service
@@ -1,0 +1,16 @@
+# Telegram alert for a failed cd-bus-subscriber@<svc> — FLEET TEMPLATE.
+# Triggered via OnFailure= (see the subscriber's onfailure.conf drop-in) when
+# the subscriber enters `failed`. The SSE leg being down is not a deploy
+# outage (poll backstop still converges) but it must be VISIBLE — the
+# dead-deployer class that hid for 13 days (claude-tasks #168).
+# Install at /etc/systemd/system/cd-bus-subscriber-alert@.service
+[Unit]
+Description=Telegram alert for cd-bus-subscriber@%i failure
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+
+[Service]
+Type=oneshot
+# Runs as nick: the shared /opt/scripts/lib/telegram.sh reads the bot token
+# from /etc/imagineering-secrets/telegram.env (root:nick 0640), readable by nick.
+User=nick
+ExecStart=/opt/cd-bus/subscriber-alert.sh %i

--- a/cd-bus/fleet/systemd/cd-bus-subscriber@.service
+++ b/cd-bus/fleet/systemd/cd-bus-subscriber@.service
@@ -1,0 +1,36 @@
+# Deploy-bus SSE subscriber — FLEET TEMPLATE (claude-tasks #714).
+# `%i` is the service name, e.g. `systemctl enable --now cd-bus-subscriber@dreamfinder`.
+# Install at /etc/systemd/system/cd-bus-subscriber@.service
+#
+# Failure semantics, tuned to the leg's importance: losing SSE only degrades
+# deploy latency to the 5-min poll floor, so a sub-minute relay blip must NOT
+# page. RestartSec=30 + StartLimitBurst=10 / 600s means the unit only reaches
+# `failed` (LOUD — the OnFailure drop-in alerts) after ~5 min of continuously
+# failing to make progress, i.e. once degradation has lasted ~a poll interval.
+# An occasional stream drop just reconnects 30s later; the relay's retained-
+# event replay covers anything missed. The companion cd-bus-recover@.timer
+# revives a `failed` unit so it can never die permanently silent.
+[Unit]
+Description=Deploy-bus SSE subscriber for %i
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+StartLimitIntervalSec=600
+StartLimitBurst=10
+
+[Service]
+User=nick
+# Shared config first (BUS_URL, the relay SUBSCRIBE_TOKEN that gates every
+# /events channel), then per-service overrides (APP_DIR, COMPOSE_SERVICE, ...).
+# Both optional (leading `-`): absent => the script's defaults + public-pilot.
+EnvironmentFile=-/etc/cd-bus/common.env
+EnvironmentFile=-/etc/cd-bus/%i.env
+ExecStart=/opt/cd-bus/subscribe.sh %i
+Restart=always
+RestartSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/cd-bus/fleet/systemd/cd-bus-subscriber@.service.d/onfailure.conf
+++ b/cd-bus/fleet/systemd/cd-bus-subscriber@.service.d/onfailure.conf
@@ -1,0 +1,6 @@
+# Drop-in for cd-bus-subscriber@.service: alert when the subscriber gives up
+# (start-limit hit -> unit failed). A drop-in keeps the base unit untouched.
+# %i propagates to the instance, so each service alerts for itself.
+# Install at /etc/systemd/system/cd-bus-subscriber@.service.d/onfailure.conf
+[Unit]
+OnFailure=cd-bus-subscriber-alert@%i.service

--- a/cd-bus/fleet/systemd/cd-poll-alert@.service
+++ b/cd-bus/fleet/systemd/cd-poll-alert@.service
@@ -1,0 +1,14 @@
+# Telegram alert for a failed cd-poll@<svc> — FLEET TEMPLATE.
+# Triggered via OnFailure= (see cd-poll@.service.d/onfailure.conf) when the
+# pull leg really fails (deploy.sh exit 2 after >=3 consecutive failures, or
+# unit-level breakage). Unlike the SSE leg, a failed pull leg DOES mean deploys
+# are not landing — both legs run the same action.
+# Install at /etc/systemd/system/cd-poll-alert@.service
+[Unit]
+Description=Telegram alert for cd-poll@%i failure
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+
+[Service]
+Type=oneshot
+User=nick
+ExecStart=/opt/cd-bus/poll-alert.sh %i

--- a/cd-bus/fleet/systemd/cd-poll@.service
+++ b/cd-bus/fleet/systemd/cd-poll@.service
@@ -1,0 +1,23 @@
+# Deploy-bus 5-min poll backstop — FLEET TEMPLATE (claude-tasks #714).
+# The pull leg that catches anything the SSE push misses. Runs the SAME shared
+# deploy action as the SSE leg (idempotent, flock-serialised).
+# Install at /etc/systemd/system/cd-poll@.service
+[Unit]
+Description=Deploy-bus CD pull backstop for %i
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=nick
+EnvironmentFile=-/etc/cd-bus/common.env
+EnvironmentFile=-/etc/cd-bus/%i.env
+ExecStart=/opt/cd-bus/deploy.sh %i
+# Transient pull errors must not propagate as unit failure — the next tick
+# retries. deploy.sh exits 2 (NOT in this list) only after >=3 consecutive
+# failures, so OnFailure means the pull leg has been broken ~15 min.
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/cd-bus/fleet/systemd/cd-poll@.service.d/onfailure.conf
+++ b/cd-bus/fleet/systemd/cd-poll@.service.d/onfailure.conf
@@ -1,0 +1,7 @@
+# Drop-in for cd-poll@.service: alert when the pull leg really fails. A drop-in
+# keeps the base unit untouched. The base unit's SuccessExitStatus=0 1 means a
+# single docker compose error is NOT failure — deploy.sh only exits 2 after 3
+# consecutive failures, so this alert means the pull leg has been broken ~15 min.
+# Install at /etc/systemd/system/cd-poll@.service.d/onfailure.conf
+[Unit]
+OnFailure=cd-poll-alert@%i.service

--- a/cd-bus/fleet/systemd/cd-poll@.timer
+++ b/cd-bus/fleet/systemd/cd-poll@.timer
@@ -1,0 +1,17 @@
+# Triggers the CD pull backstop every 5 min — FLEET TEMPLATE.
+# Enable per service: `systemctl enable --now cd-poll@dreamfinder.timer`.
+# Install at /etc/systemd/system/cd-poll@.timer
+[Unit]
+Description=Trigger deploy-bus CD pull for %i every 5 min
+Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+
+[Timer]
+# First tick 2 min after boot (let Docker settle), then every 5 min.
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=10s
+# Catch up a missed deploy after host downtime (bounded so it can't stampede).
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Generalises the proven `downstream-server` deploy-bus pilot into **one templated set of systemd instance-units + shared scripts** under `cd-bus/fleet/`, so any GHCR-built service gets push (SSE) + poll CD by adding an env file and enabling three units (claude-tasks #714). Unblocks the fleet rollout that the relay hardening (#82/#196) cleared.

**No host change in this PR** — template files only. Onboarding a first service (dreamfinder / notify / img-contact) is a separate, gated step.

## The template (all keyed by systemd instance `%i` = service name)
- `subscribe.sh` → `/opt/cd-bus/` — SSE subscriber, one copy for all services
- `deploy.sh` → `/opt/cd-bus/` — the one deploy action every leg runs (per-service flock, idempotent `compose pull/up`, the 3-consecutive-failure→exit-2 alert counter)
- `cd-bus-subscriber@.service` (+ onfailure drop-in) + `cd-bus-subscriber-alert@.service`
- `cd-bus-recover@.{service,timer}` — revives a `failed` subscriber so the SSE leg can't die permanently silent
- `cd-poll@.{service,timer}` (+ onfailure) + `cd-poll-alert@.service` — the 5-min poll backstop
- `install-shared.sh`, `common.env.example`, and a README onboarding hub with the CI announce snippet

## Config model
Layered `EnvironmentFile`s: `/etc/cd-bus/common.env` (shared `BUS_URL` + the single `SUBSCRIBE_TOKEN` that gates every `/events` channel) then `/etc/cd-bus/%i.env` (per-service `APP_DIR`/`COMPOSE_SERVICE`). Script defaults follow the host convention, so a conforming service needs only `systemctl enable --now`.

## Hardening folded in (claude-tasks #20)
`subscribe.sh` passes the relay bearer via a `0600` header file (`curl -H @file`; host curl 8.5.0 verified), never a `-H "Bearer …"` arg — keeps the token out of the process table on a multi-tenant host.

## Review focus (please scrutinise)
- **systemd `%i` propagation** across the templated units, the `.d/onfailure.conf` drop-ins, and the `cd-bus-recover@` ExecStart that references `cd-bus-subscriber@%i`.
- **`deploy.sh` fail-counter semantics** preserved from the pilot (exit 1 = silent retry, exit 2 = alert) and the per-service flock.
- **`install-shared.sh` runs as root** — installs to `/opt/cd-bus` + `/etc/systemd/system`.
- The `#20` temp-file/`trap` approach in `subscribe.sh`.

## Validation
All scripts `bash -n` + `shellcheck` clean at strictest severity. CI gains a second ShellCheck step for `./cd-bus` (scandir only covered `./scripts` — the lint check was green without covering these new scripts; state-authority fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)