### PR TITLE
feat(watchers): email-health watcher for silent Brevo failures

### DIFF
--- a/notify/secrets.yaml
+++ b/notify/secrets.yaml
@@ -1,6 +1,7 @@
 telegram_bot_token: ENC[AES256_GCM,data:ebPXf4rXV+0nT+bcSmh4sfdi58plQ30mom4w347XgCliWx6nm5V2uZ1HtOGo8g==,iv:Urfb45sOVmxKpHM+C0cBXdbvH6kxO+QPsVBGb0p3g8Y=,tag:7oMOWGB33nZg5WQNxPo6Vw==,type:str]
 telegram_chat_id: ENC[AES256_GCM,data:dzMEkKotGgDkKg==,iv:bNdVAOWWR7E2s2nCY+QMHHrpTyaYbrWeFjtOaHsy2a4=,tag:9u8W3Hs+9Crlm4AP5ggM3g==,type:str]
 notify_api_key: ENC[AES256_GCM,data:Re+LhwYJzBLMbLfSLGnSpi9G9k4UQNrxLPLPbeX3yjshMykds1TP0nMwm1jmGZAkKjoI94SEeZEO5G/Yvm81zA==,iv:TIKUmP6G9hN16vWmWFQPCEzYiXc3g5XIZYFdX6GpXiQ=,tag:h2vQKxmYrKMyeHhc+itCbQ==,type:str]
+brevo_api_key: ENC[AES256_GCM,data:Re9+8yCZLYzGw6QJWPqOQhtxNBYMOStJAX5lVqJ/XJRYCGYfcnTCziPTel3xJHjPotTat+NbesOumYx3iScBEtXJcQlWKgyLUTmYrxWfB1Hdy90P4o8bwkA=,iv:fgeEDCmLh6aPofLR+FiuFbEOliLwIBfSVTCvIAzmbbk=,tag:r/7ZkdghHs66rAq3UtleFg==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -12,7 +13,7 @@ sops:
             NTFHMW1zWHkvcVJkcVkxeGpMZ2ZUZEkKOQ5fa01l80U2AJ20vMeAXfi0viqxP/jz
             KKIewy7xSFL/aef4SNlRc+EkytyWogmtfqnMhOBIu0+bC0vBGMqqYw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-30T05:20:58Z"
-    mac: ENC[AES256_GCM,data:RoMA0ZnxZwftd8S0NIealFQE53MqXB0wmAgNrNGvDVvOK9BrkxBWiMQ6w/WB+PQBP5a3HmhvRJZRJ8rtE/zck5MzAJdvNoO10VuNkWTmKWYhMYL+pwLI+w/2PQnzo4/vI58FA1ZS0IGmV7Hfu8twlX8g8Z63odSHautsC1NQ6jI=,iv:8esC1PuRUQIGGTLmhIPsyVOBKcDfmMiV0862u1rzGBg=,tag:anFTqYu1JUmnTVHab84ifA==,type:str]
+    lastmodified: "2026-06-20T10:33:51Z"
+    mac: ENC[AES256_GCM,data:OnA4dBmksNu5/xknQP1zgA6E5hXDm7KzL4X/5EaTaH4Nj+6QYmBjUt/ntZy7v6BKhGohI0JsRyBSj0gBvAm5aijBfDlH7XMJKMh+NPE8ABZdEb3p1Bz3lNYrCEf8Xk9wXK1GBtHNIipPiKX6IYPM8zc1r1C8Jyt1kUHxjV9LgFM=,iv:nBLw87vKhN/qc/riJ/r+7pAPH4DRrtZIbQay7r2XnCU=,tag:jqzrdkqWXB7+LmCtvh4mig==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/notify/secrets.yaml.example
+++ b/notify/secrets.yaml.example
@@ -1,3 +1,8 @@
 telegram_bot_token: REPLACE_WITH_BOT_TOKEN
 telegram_chat_id: REPLACE_WITH_CHAT_ID
 notify_api_key: REPLACE_WITH_RANDOM_HEX_32_BYTES
+# Consumed by the email-health watcher (scripts/watchers/email-health-watch.sh),
+# not by the notify service itself. Lives here because it is watcher/alerting
+# infrastructure. Installed onto Sydney by hand as ~/.config/imagineering/brevo-credentials
+# (mode 0600, exports BREVO_API_KEY) — see scripts/watchers/README.md.
+brevo_api_key: REPLACE_WITH_BREVO_XKEYSIB_KEY

--- a/scripts/watchers/README.md
+++ b/scripts/watchers/README.md
@@ -71,7 +71,8 @@ scripts/watchers/
 │   └── watcher-base.sh    # shared helpers + state machine (sourced by all watchers)
 ├── template.sh            # skeleton for new watchers
 ├── README.md              # this file
-├── disk-usage-watch.sh    # built example
+├── disk-usage-watch.sh    # built example (recurring threshold-alert)
+├── email-health-watch.sh  # built example (recurring; Brevo sender-auth + volume + errors)
 └── …                       # other watchers
 ```
 
@@ -250,6 +251,65 @@ listed here so the template has demand-side context):
 Each of these has the right shape (external state, transitions, want-to-be-notified,
 genuinely-stops-mattering-after-resolution). Each is also <50 lines of
 phase logic on top of the template. If you build one, link it back here.
+
+## Built: email-health-watch
+
+`email-health-watch.sh` catches the class of silent transactional-email
+failure that hit imagineering.cc on 2026-06-20: the Brevo sending domain was
+unauthenticated, so Brevo accepted every send (250 OK at SMTP) then dropped it
+at processing — every app thought email worked, no alert fired, password
+resets / magic links / contact-form leads silently vanished for days.
+
+It is a **recurring threshold-alert** (modelled on `disk-usage-watch.sh`,
+*not* the self-disabling two-phase template): `phase_a_check` runs three checks
+every cycle and always returns 1, so the state machine never advances and the
+watcher never removes its own cron entry. Each check debounces to **at most one
+alert per UTC day** via a per-check sentinel under `~/.config/imagineering/`,
+and clears that sentinel on recovery.
+
+Three checks against the Brevo REST API (`https://api.brevo.com/v3`):
+
+1. **Domain auth** — `GET /senders/domains`: each required domain
+   (`imagineering.cc`, `xdeca.com`) must be present with `authenticated:true`
+   **and** `verified:true`. This is the check that would have caught the
+   incident. Tunable: `REQUIRED_DOMAINS`.
+2. **Daily volume** — `GET /smtp/statistics/aggregatedReport?days=1` `.requests`
+   vs the shared free-plan cap. Alerts at `>= WARN_PCT%` of `CAP` (default 70%
+   of 300 = 210) — early warning before a flood exhausts the cap and starves
+   auth email. Tunable: `CAP`, `WARN_PCT`.
+3. **Error spike** — same report `.error` field. Alerts when `> ERROR_THRESHOLD`
+   (default 25/day). Tunable: `ERROR_THRESHOLD`.
+
+JSON is parsed with `python3` (robust against missing keys) rather than
+grep/jq chains. If `BREVO_API_KEY` is absent or the API is unreachable, the
+watcher logs and skips that cycle — it never crashes cron.
+
+### Install on Sydney
+
+```bash
+# 1. Lib + script (lib likely already present from other watchers).
+scp scripts/watchers/lib/watcher-base.sh 149.118.69.221:/tmp/   # if not already there
+ssh 149.118.69.221 'sudo install -m 0755 -o ubuntu -g ubuntu /tmp/watcher-base.sh /home/ubuntu/lib/'
+scp scripts/watchers/email-health-watch.sh 149.118.69.221:/tmp/
+ssh 149.118.69.221 'sudo install -m 0755 -o ubuntu -g ubuntu /tmp/email-health-watch.sh /home/ubuntu/'
+
+# 2. Install the Brevo credential file (mode 0600, mirrors notify-credentials).
+#    The key lives in notify/secrets.yaml under brevo_api_key. Build the
+#    envfile locally and scp it — do NOT echo the key over an interactive ssh
+#    (it lands in shell history / logs).
+export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
+umask 077
+printf 'BREVO_API_KEY=%s\n' "$(sops -d notify/secrets.yaml | yq -r '.brevo_api_key')" > /tmp/brevo-credentials
+scp /tmp/brevo-credentials 149.118.69.221:/tmp/
+ssh 149.118.69.221 'install -m 0600 /tmp/brevo-credentials ~/.config/imagineering/brevo-credentials && rm -f /tmp/brevo-credentials'
+rm -f /tmp/brevo-credentials
+
+# 3. Install the cron entry (every 4 hours, off the hour). Tag MUST match CRON_TAG.
+ssh 149.118.69.221 'crontab -l | { cat; echo "23 */4 * * * /home/ubuntu/email-health-watch.sh  # email-health-watch"; } | crontab -'
+
+# 4. Confirm first cycle (force a run, watch the log).
+ssh 149.118.69.221 '/home/ubuntu/email-health-watch.sh; tail ~/email-health-watch.log'
+```
 
 ## See also
 

--- a/scripts/watchers/README.md
+++ b/scripts/watchers/README.md
@@ -286,6 +286,10 @@ watcher logs and skips that cycle — it never crashes cron.
 
 ### Install on Sydney
 
+This watcher depends ONLY on `watcher-base.sh` (it inlines its one needed
+helper, `html_escape`, rather than sourcing `lib/diagnose.sh`), so the install
+footprint is just the lib + the script.
+
 ```bash
 # 1. Lib + script (lib likely already present from other watchers).
 scp scripts/watchers/lib/watcher-base.sh 149.118.69.221:/tmp/   # if not already there
@@ -296,16 +300,23 @@ ssh 149.118.69.221 'sudo install -m 0755 -o ubuntu -g ubuntu /tmp/email-health-w
 # 2. Install the Brevo credential file (mode 0600, mirrors notify-credentials).
 #    The key lives in notify/secrets.yaml under brevo_api_key. Build the
 #    envfile locally and scp it — do NOT echo the key over an interactive ssh
-#    (it lands in shell history / logs).
+#    (it lands in shell history / logs). Abort if the key is empty/null so we
+#    never install a credential file that silently makes the watcher skip.
 export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
 umask 077
-printf 'BREVO_API_KEY=%s\n' "$(sops -d notify/secrets.yaml | yq -r '.brevo_api_key')" > /tmp/brevo-credentials
+BREVO_KEY=$(sops -d notify/secrets.yaml | yq -r '.brevo_api_key')
+[ -n "$BREVO_KEY" ] && [ "$BREVO_KEY" != "null" ] || { echo "ERROR: brevo_api_key empty/null — aborting"; exit 1; }
+printf 'BREVO_API_KEY=%s\n' "$BREVO_KEY" > /tmp/brevo-credentials
 scp /tmp/brevo-credentials 149.118.69.221:/tmp/
-ssh 149.118.69.221 'install -m 0600 /tmp/brevo-credentials ~/.config/imagineering/brevo-credentials && rm -f /tmp/brevo-credentials'
-rm -f /tmp/brevo-credentials
+# mkdir the config dir first — watcher-base.sh creates it at runtime, but the
+# credfile is installed BEFORE the first run, so it must exist now.
+ssh 149.118.69.221 'mkdir -p ~/.config/imagineering && install -m 0600 /tmp/brevo-credentials ~/.config/imagineering/brevo-credentials && rm -f /tmp/brevo-credentials'
+rm -f /tmp/brevo-credentials; unset BREVO_KEY
 
-# 3. Install the cron entry (every 4 hours, off the hour). Tag MUST match CRON_TAG.
-ssh 149.118.69.221 'crontab -l | { cat; echo "23 */4 * * * /home/ubuntu/email-health-watch.sh  # email-health-watch"; } | crontab -'
+# 3. Install the cron entry (every 4 hours, off the hour). Tag MUST match
+#    CRON_TAG. Idempotent: strips any existing email-health-watch line first so
+#    re-running this step never creates duplicate entries / duplicate alerts.
+ssh 149.118.69.221 'crontab -l 2>/dev/null | grep -vF "# email-health-watch" | { cat; echo "23 */4 * * * /home/ubuntu/email-health-watch.sh  # email-health-watch"; } | crontab -'
 
 # 4. Confirm first cycle (force a run, watch the log).
 ssh 149.118.69.221 '/home/ubuntu/email-health-watch.sh; tail ~/email-health-watch.log'

--- a/scripts/watchers/email-health-watch.sh
+++ b/scripts/watchers/email-health-watch.sh
@@ -18,7 +18,8 @@
 #
 # THREE CHECKS (alert on any failing):
 #   1. DOMAIN AUTH  — GET /v3/senders/domains: each required domain must be
-#                     present with authenticated:true AND verified:false→fail.
+#                     present with authenticated:true AND verified:true; any
+#                     domain missing / not-authenticated / not-verified fails.
 #                     THIS is the check that would have caught the incident.
 #   2. DAILY VOLUME — GET /v3/smtp/statistics/aggregatedReport?days=1 .requests
 #                     vs the daily cap. Alert at >= WARN_PCT% of CAP — early
@@ -52,11 +53,17 @@ __lib="$(dirname "$0")/lib/watcher-base.sh"
 source "$__lib"
 unset __lib
 
-__diag="$(dirname "$0")/lib/diagnose.sh"
-[[ -r "$__diag" ]] || __diag="$HOME/lib/diagnose.sh"
-# shellcheck disable=SC1090
-source "$__diag"
-unset __diag
+# NOTE: we deliberately do NOT source lib/diagnose.sh. This watcher needs only
+# one helper from it (html_escape), so inlining it below keeps the install
+# footprint to watcher-base.sh + this file — sourcing diagnose.sh unconditionally
+# would otherwise crash at startup (set -e) on any host that doesn't have it.
+html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    printf '%s' "$s"
+}
 
 # --- Configuration (env-tunable) -------------------------------------------
 BREVO_API="${BREVO_API:-https://api.brevo.com/v3}"

--- a/scripts/watchers/email-health-watch.sh
+++ b/scripts/watchers/email-health-watch.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Email-health watcher — catches silent Brevo transactional-email failures.
+#
+# WHY THIS EXISTS (2026-06-20 incident):
+#   imagineering.cc transactional email (Outline password resets, Kan magic
+#   links/invites, contact-form lead notifications) was silently dead for
+#   days. Root cause: the Brevo sending domain `imagineering.cc` was never
+#   authenticated, so Brevo accepted every send at SMTP (250 queued) then
+#   rejected it at processing ("sender noreply@imagineering.cc is not
+#   valid"). The 250-OK made every app think email worked — NO alert fired.
+#   This watcher catches that class of silent failure going forward.
+#
+# RECURRING, NOT SELF-DISABLING. Unlike the two-phase template watchers
+# (which wait for a transition then remove their own cron entry), this is a
+# permanent threshold monitor — modelled on disk-usage-watch.sh. phase_a_check
+# runs all three checks every cycle and ALWAYS returns 1, so run_watcher never
+# transitions A→B and never self-disables. phase_b_check is a no-op safety net.
+#
+# THREE CHECKS (alert on any failing):
+#   1. DOMAIN AUTH  — GET /v3/senders/domains: each required domain must be
+#                     present with authenticated:true AND verified:false→fail.
+#                     THIS is the check that would have caught the incident.
+#   2. DAILY VOLUME — GET /v3/smtp/statistics/aggregatedReport?days=1 .requests
+#                     vs the daily cap. Alert at >= WARN_PCT% of CAP — early
+#                     warning before a flood exhausts the shared cap and starves
+#                     auth email (see the 2026-06-08 contact-form flood).
+#   3. ERROR SPIKE  — same report .error field. Alert if > ERROR_THRESHOLD —
+#                     catches bulk sender-rejection / delivery failure.
+#
+# DEBOUNCE: a recurring watcher must not re-fire every cycle while a condition
+# persists. Each check writes a per-day sentinel under $CONFIG_DIR keyed on
+# YYYY-MM-DD; if today's sentinel exists, that check stays quiet. So a
+# persistent failure alerts at most once per UTC day per check, not every run.
+#
+# CREDENTIALS: needs BREVO_API_KEY. Sourced from
+# ~/.config/imagineering/brevo-credentials (mode 0600, exports BREVO_API_KEY),
+# mirroring the notify-credentials pattern that watcher-base.sh already uses.
+# If absent, the watcher logs and exits cleanly (can't check, won't crash cron).
+#
+# Cron: 23 */4 * * * /home/ubuntu/email-health-watch.sh  # email-health-watch
+
+set -euo pipefail
+
+# shellcheck disable=SC2034  # consumed by watcher-base.sh after sourcing
+WATCHER_NAME="email-health-watch"
+# shellcheck disable=SC2034
+CRON_TAG="email-health-watch"
+
+__lib="$(dirname "$0")/lib/watcher-base.sh"
+[[ -r "$__lib" ]] || __lib="$HOME/lib/watcher-base.sh"
+# shellcheck disable=SC1090  # dynamic path; resolved at runtime
+source "$__lib"
+unset __lib
+
+__diag="$(dirname "$0")/lib/diagnose.sh"
+[[ -r "$__diag" ]] || __diag="$HOME/lib/diagnose.sh"
+# shellcheck disable=SC1090
+source "$__diag"
+unset __diag
+
+# --- Configuration (env-tunable) -------------------------------------------
+BREVO_API="${BREVO_API:-https://api.brevo.com/v3}"
+# Required sending domains — each must be authenticated + verified in Brevo.
+# Space-separated so it can be overridden from the environment if needed.
+REQUIRED_DOMAINS="${REQUIRED_DOMAINS:-imagineering.cc xdeca.com}"
+CAP="${CAP:-300}"                       # Brevo free-plan daily send cap
+WARN_PCT="${WARN_PCT:-70}"              # alert when daily requests >= this % of CAP
+ERROR_THRESHOLD="${ERROR_THRESHOLD:-25}" # alert when daily .error exceeds this
+
+# Brevo credentials. Mirror the notify-credentials sourcing in watcher-base.sh:
+# a 0600 env file under $CONFIG_DIR that exports BREVO_API_KEY.
+BREVO_CRED_FILE="$CONFIG_DIR/brevo-credentials"
+# shellcheck source=/dev/null
+[[ -r "$BREVO_CRED_FILE" ]] && { set -a; . "$BREVO_CRED_FILE"; set +a; }
+
+# --- Helpers ----------------------------------------------------------------
+
+# brevo_get <path> — GET the Brevo API, echo the raw JSON body on success.
+# Returns non-zero on transport failure or non-2xx HTTP status so callers can
+# distinguish "their fault / transient" (skip this cycle) from real data.
+brevo_get() {
+    local path="$1" body http
+    # Append HTTP status as a trailing line so we can split body from code
+    # without needing jq on the status. --fail is intentionally NOT used so
+    # we can read the status ourselves and log it.
+    body=$(curl -sS --max-time 15 -w $'\n%{http_code}' \
+        "${BREVO_API}${path}" \
+        -H "api-key: ${BREVO_API_KEY}" \
+        -H "accept: application/json" 2>/dev/null) || return 1
+    http="${body##*$'\n'}"
+    body="${body%$'\n'*}"
+    if [[ "$http" != 2* ]]; then
+        log "brevo_get $path: HTTP $http"
+        return 1
+    fi
+    printf '%s' "$body"
+}
+
+# alerted_today <check-key> — true if this check already alerted today (UTC).
+alerted_today() {
+    local key="$1" today
+    today=$(date -u +%Y-%m-%d)
+    [[ -f "$CONFIG_DIR/$WATCHER_NAME.$key.alerted" ]] \
+        && [[ "$(cat "$CONFIG_DIR/$WATCHER_NAME.$key.alerted" 2>/dev/null)" == "$today" ]]
+}
+
+# mark_alerted <check-key> — record that this check alerted today.
+mark_alerted() {
+    date -u +%Y-%m-%d > "$CONFIG_DIR/$WATCHER_NAME.$1.alerted"
+}
+
+# clear_alerted <check-key> — reset the debounce so the next failure re-fires.
+# Called on recovery so a healthy day doesn't suppress the next real alert.
+clear_alerted() {
+    rm -f "$CONFIG_DIR/$WATCHER_NAME.$1.alerted"
+}
+
+# --- Checks -----------------------------------------------------------------
+# Each check fires tg() at most once/day (debounced) and clears its sentinel on
+# recovery. None of them transition the state machine — phase_a_check returns 1.
+
+# CHECK 1: domain authentication. The incident-catching check.
+check_domain_auth() {
+    local json bad
+    json=$(brevo_get "/senders/domains") || { log "check_domain_auth: API unavailable, skipping"; return; }
+
+    # Python parse: for each required domain, report failures. Emits one human
+    # line per problem; empty output means all required domains are healthy.
+    bad=$(REQUIRED_DOMAINS="$REQUIRED_DOMAINS" python3 -c '
+import json, os, sys
+data = json.loads(sys.stdin.read())
+domains = {d.get("domain_name"): d for d in data.get("domains", [])}
+problems = []
+for name in os.environ["REQUIRED_DOMAINS"].split():
+    d = domains.get(name)
+    if d is None:
+        problems.append(f"{name}: MISSING from Brevo account")
+    elif not d.get("authenticated", False):
+        problems.append(f"{name}: authenticated=false")
+    elif not d.get("verified", False):
+        problems.append(f"{name}: verified=false")
+print("\n".join(problems))
+' <<< "$json") || { log "check_domain_auth: parse failed"; return; }
+
+    if [[ -n "$bad" ]]; then
+        log "check_domain_auth: PROBLEMS: ${bad//$'\n'/ | }"
+        if ! alerted_today domain_auth; then
+            local pretty
+            pretty=$(html_escape "$bad")
+            tg "$(printf '🚨 <b>Brevo sending-domain auth FAILING</b>\n\nTransactional email (Outline resets, Kan magic links/invites, contact-form leads) will be silently dropped — Brevo accepts sends (250 OK) then rejects at processing.\n\n<pre>%s</pre>\nFix in Brevo → Senders, Domains &amp; IPs. <i>(2026-06-20 incident class.)</i>' "$pretty")"
+            mark_alerted domain_auth
+        fi
+    else
+        log "check_domain_auth: all required domains authenticated+verified"
+        clear_alerted domain_auth
+    fi
+}
+
+# CHECK 2 & 3 share one aggregatedReport call (volume + error).
+check_volume_and_errors() {
+    local json requests error warn_at
+    json=$(brevo_get "/smtp/statistics/aggregatedReport?days=1") \
+        || { log "check_volume_and_errors: API unavailable, skipping"; return; }
+
+    # Pull the two integer fields with python (robust against missing keys).
+    requests=$(python3 -c 'import json,sys; print(int(json.loads(sys.stdin.read()).get("requests",0)))' <<< "$json") \
+        || { log "check_volume_and_errors: parse failed (requests)"; return; }
+    error=$(python3 -c 'import json,sys; print(int(json.loads(sys.stdin.read()).get("error",0)))' <<< "$json") \
+        || { log "check_volume_and_errors: parse failed (error)"; return; }
+
+    warn_at=$(( CAP * WARN_PCT / 100 ))
+    log "check_volume_and_errors: requests=$requests (warn>=$warn_at of cap $CAP) error=$error (threshold=$ERROR_THRESHOLD)"
+
+    # CHECK 2: volume vs cap.
+    if [[ "$requests" -ge "$warn_at" ]]; then
+        if ! alerted_today volume; then
+            tg "$(printf '🚨 <b>Brevo daily send volume high: %s / %s</b> (&ge;%s%% of cap)\n\nThe daily send cap is shared across imagineering + xdeca. Exhausting it starves password-reset / magic-link email. Check for a flood (scanner bot, runaway loop) before the cap is hit.' \
+            "$requests" "$CAP" "$WARN_PCT")"
+            mark_alerted volume
+        fi
+    else
+        clear_alerted volume
+    fi
+
+    # CHECK 3: error spike.
+    if [[ "$error" -gt "$ERROR_THRESHOLD" ]]; then
+        if ! alerted_today errors; then
+            tg "$(printf '🚨 <b>Brevo delivery errors elevated: %s today</b> (threshold %s)\n\nBulk send-failures — possible sender rejection, hard bounces, or a misconfigured sender. Check Brevo → Statistics for the breakdown.' \
+            "$error" "$ERROR_THRESHOLD")"
+            mark_alerted errors
+        fi
+    else
+        clear_alerted errors
+    fi
+}
+
+# --- State-machine glue -----------------------------------------------------
+# Recurring watcher: do all the work in phase A and never advance. Returning 1
+# keeps run_watcher in phase A every cycle (no A→B, no self-disable).
+phase_a_check() {
+    if [[ -z "${BREVO_API_KEY:-}" ]]; then
+        log "phase_a: BREVO_API_KEY not set (missing $BREVO_CRED_FILE?); cannot check"
+        return 1
+    fi
+    check_domain_auth
+    check_volume_and_errors
+    return 1
+}
+
+# Never reached (phase_a_check always returns 1), but the lib contract requires
+# it to exist. Return 1 so that even if state were forced to B, it would not
+# self-disable.
+phase_b_check() {
+    return 1
+}
+
+run_watcher


### PR DESCRIPTION
## What

A new **recurring** watcher — `scripts/watchers/email-health-watch.sh` — that catches silent Brevo transactional-email failures. Closes task #22.

## The incident it guards against (2026-06-20)

imagineering.cc transactional email (Outline password resets, Kan magic links/invites, contact-form lead notifications) was silently dead for **days**. Root cause: the Brevo sending domain `imagineering.cc` was never authenticated, so Brevo accepted every send at SMTP (`250 queued`) then rejected it at processing (`sender noreply@imagineering.cc is not valid`). The 250-OK made every app think email worked — **no alert fired**. This is the exact class of failure the watcher now detects.

## What it checks (each cycle, alert on any failing)

1. **Domain auth** — `GET /v3/senders/domains`: for each of `imagineering.cc`, `xdeca.com`, alert if missing / `authenticated:false` / `verified:false`. **This is the check that would have caught the incident.**
2. **Daily volume vs cap** — `GET /v3/smtp/statistics/aggregatedReport?days=1` `.requests`; alert at `>= WARN_PCT%` of `CAP` (default 70% of 300 = 210). Early warning before a flood exhausts the shared cap and starves auth email (cf. the 2026-06-08 contact-form flood).
3. **Error spike** — same report `.error`; alert if `> ERROR_THRESHOLD` (default 25/day). Catches bulk sender-rejection / delivery failure.

All thresholds are env-tunable (`REQUIRED_DOMAINS`, `CAP`, `WARN_PCT`, `ERROR_THRESHOLD`).

## Design notes

- **Recurring, not self-disabling.** Modelled on `disk-usage-watch.sh`, *not* `template.sh` (the two-phase self-disabling state machine — wrong shape here). `phase_a_check` does all the work and always returns 1, so `run_watcher` never advances A→B and never removes its own cron entry.
- **Debounce.** Each check writes a per-day sentinel under `~/.config/imagineering/`; a persistent failure alerts at most **once per UTC day per check**, not every cycle. Sentinels clear on recovery so the next real failure re-fires.
- **JSON via `python3`** (robust to missing keys), not fragile grep/jq chains.
- **Fail-safe.** Missing `BREVO_API_KEY` or an unreachable/non-2xx Brevo API → log and skip the cycle; never crashes cron.

## Cron cadence

Every 4 hours, off the hour:
```
23 */4 * * * /home/ubuntu/email-health-watch.sh  # email-health-watch
```

## Sydney install steps (Nick's gate — see below)

`BREVO_API_KEY` is now in `notify/secrets.yaml` (SOPS-encrypted) under `brevo_api_key`. It must be hand-installed onto Sydney as `~/.config/imagineering/brevo-credentials` (mode 0600, `BREVO_API_KEY=...`), mirroring the existing `notify-credentials` pattern. Full copy-paste steps are in `scripts/watchers/README.md` → **Built: email-health-watch → Install on Sydney** (lib + script install, credential install via `sops -d | yq` → scp, cron line).

## Testing

- `shellcheck` clean; `bash -n` clean.
- DRY_RUN smoke-tested against the **live** Brevo API:
  - healthy state → no alert (both domains authenticated, requests=7 < 210, error=5 < 25)
  - error spike / volume warning / missing domain → alert fires with clear message
  - **debounce verified**: two consecutive runs of a failing check → exactly one alert
  - empty `BREVO_API_KEY` → graceful skip, exit 0, no crash

## Merge / deploy gate

This PR touches **load-bearing secrets** (`notify/secrets.yaml`) and adds a **prod cron entry**. Per repo convention, **Nick merges + deploys this himself** — the watcher only goes live once the cron line + `brevo-credentials` file are installed on Sydney by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)