### PR TITLE
fix(contact): move contact form to OCI Email Delivery (isolate Brevo blast radius)

### DIFF
--- a/imagineering-contact-us/secrets.yaml
+++ b/imagineering-contact-us/secrets.yaml
@@ -1,21 +1,22 @@
-smtp_host: ENC[AES256_GCM,data:76O3SYLoAe/fziDKnjv3jzFX2aY=,iv:2Jv5qjoyLuaNoaHaBsMZUVBhrWcjdCKlF4pogctcQc0=,tag:5nLMbqxZYQA0Aibfe6RGkw==,type:str]
-smtp_port: ENC[AES256_GCM,data:L/0y,iv:06hKCehnXn9fFZ2wH332bIdWGUGMhgoD6vnvet4SE7M=,tag:Kr6B7e2bDbVQ+O3Ief0hfw==,type:str]
-smtp_username: ENC[AES256_GCM,data:Ze3Zt/HA24bMWl6HmrDdyrnmgAIGeIDZ,iv:X94eWFDOaT8UgWGCfjgMV6yK6jHbmJuWijaCoWAyI1o=,tag:6wSlNLa5m93PaTnn86kC+Q==,type:str]
-smtp_password: ENC[AES256_GCM,data:wgURK0DIYgD05EGeey+8p8ol+TM/tTWmRTZaqP6iNkJ+CkE8rO82juaje27Tp74sv1TJLbXcJRDEN+OFd5awGHSMw8M1J+9gnK3UYx1AE7IQR9sH/vicwn4E,iv:ybxfIK6hqBhSc7jcJE/0++yKrbkoSgdq3GIuw8bpwCg=,tag:Dld97Vagfd2aPVmhcbNSfw==,type:str]
-smtp_from_email: ENC[AES256_GCM,data:9RMvZBEsblfG+kBTxxn6btPSNqbOKU4=,iv:gDdLLY+GyJ1Mp/pEE82xrFylC3Vue2jM1cgoi86ourA=,tag:bdyhr6j0ogqZ6fd+2ut2SA==,type:str]
-contact_to: ENC[AES256_GCM,data:wdpdRjiJQXk7JmUclJb2401QTVthsPhqKOOh9xJR8XPOGp46KQr0xlCK8a0ZPDM=,iv:EYTvkDF+NCvrLwliU1qbVLT1yj++ydQ6EDv6guQNAN8=,tag:i+JGrXHQag00EDQGFANlfA==,type:str]
+smtp_host: ENC[AES256_GCM,data:scYIw4l3bMNW6yr+Rs+4NiT2wp8AHhGku1ElI3ueT7iZxts2M4oz0U1l,iv:nGFPL6xFDT4PVeY8dQD9dIXXQxH8ije2vkL9iOEZmx4=,tag:kC+QPNVuBflcXIBuFDrHiQ==,type:str]
+smtp_port: ENC[AES256_GCM,data:hk26,iv:yQcU+TsUSo7YAsHtPpcHqzlY1jBQ1KGiI3iGVY1WOBk=,tag:FowBtlTi2rREdqTU9kuwIQ==,type:str]
+smtp_username: ENC[AES256_GCM,data:Ys2i3lrm5+R37ivNFAARgnCyIlVrYbuS5dUm5kgOm/4J/EG2sV5W8MWw1+s+FAcPIyHktoyh71QrxM73AZC+sFoizRaxPTxKXNd3DTRlSDFbyrnaavI1hX1FyFKHmPDSYFVCxV0X5O+Yrj4bb7/304L3d6F98gTsP3GpVygXd2nmmvHUOcU9fPj5cayx4BqLz3wR23fkOqtmX7po+mYtRqW+oA==,iv:DJdYDCihVMw+FXhSgaVpJv77OVQzPR2PCfwWAYQ4SDM=,tag:JrAX3walwRT1oPxmaTnGVw==,type:str]
+smtp_password: ENC[AES256_GCM,data:gGLLNxfsj0UNQQbRhVZRjLqE6mg=,iv:UUXDBWClfPyuqM64Ki4Ko1MVCDi1/eoMl1BhEYWTIkk=,tag:9dwnIYZXtvtU9MmoWJ3ouw==,type:str]
+smtp_from_email: ENC[AES256_GCM,data:mjlGrMpbAfJy6nOdFr/hQvQdx5Cj3Iw=,iv:/F4BM4W7D6F4r0T97DUK+Ox12ZQSg5ykwA9D+q8apGI=,tag:SrYcwZLdiw/fRRBkjABQjQ==,type:str]
+contact_to: ENC[AES256_GCM,data:FVAmmVkk8CtMu8DUqbDDxwIrSsr0NXhfmrLw4K83ks3xQS3ztubm5NqTwvyT+m4=,iv:KtnANQUxeuhyoc7OYmVAhKeOU8KHKo0JzvLjDp8Wles=,tag:TedcWByJh8hKa7VXtKhsag==,type:str]
+turnstile_secret: ENC[AES256_GCM,data:LK5hCdCeVwCu7pG5LCES5LmOpubTZG+n0qEkorK6mLxapMg=,iv:B3dbuCQSxJlHQvKgB+yCqQEV/rixsxBcApMO6DUdLQY=,tag:MKpGxiASfCIVB8q2d71DGQ==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTDBFWU9FUURpVzcwUy9h
-            MCtOUkxNWG0vNEkzMnZQRE9FNTV5b1BmN0NJCjdZK0s3alhhTEN0ZzdnVDh1ays1
-            MzQyaWRmdU5OOVpJV3U2SUJhNDFMR0kKLS0tIGV5ZjY3bTJEdGdTdldoK0Vxazhn
-            Z0R1azdNT3Y4TkVld3ozR3NmTXpwcGMKedxDHacAyZlcJh0an/v4NtngWPbKMe0Q
-            VFfArfPhcuHGDBCzWrRVxauVPYsKwzADYQ067wRn9KEc77+f4Ko27Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSdTl3KzVvNlZITHhRTllE
+            L2UrUnRncTUxWUNReXpiV29hWkR3QXgybXdJClNqdkp4R21CVXpDdFMvKzdHUkZn
+            VWg3dG00c2JpZERHdzNrY0pPVjVwWU0KLS0tIHVkd01DcTZ1K0F1dU9YOGdsSWZ5
+            UzlrLzliNVF2aEdORnBGU0NzUFUyS3cKc2LKxXY1EKfmEodmFXu1eLu+HMJB/EoQ
+            oIbBJo7bjjsBX88ELkDqzcS584JG+V08Of3wgbO3lWqPVM61vyXGkQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-29T21:15:18Z"
-    mac: ENC[AES256_GCM,data:gIVtAw/pqVeDBK3Dg3yeIt8yLiDro9Y97Jw2vCeAvhJ3wvGn6QlhZ6xCljYahbk09ltSRqm+nF4wFxRxAUT+BUAUZdyTI+Qt9Wx3UVswTltYWf5/eWaHL/TCG9wzyRTDaIcjTEwDFiBBSBcTjpVIRUsgtpnOFT0HAykDCVEskQE=,iv:25n/7o7CmMZ330spjfXB2dEANfeoEtOT3maprMtoqDg=,tag:ug1BsLNVo7aEUhc+69Qn3Q==,type:str]
+    lastmodified: "2026-06-20T10:37:56Z"
+    mac: ENC[AES256_GCM,data:GuI9M3JjebLI/karwA0aQOsHuo2N8ssxzL3aWrSBP7XVQl1Z/cTVoV9XhSwcrr6+tnXvnn10d4TNOpq5fZCXreWcrAlal4XdLoLFGJWBwHQeJMjpwLwT11wpGvhRG0ZIDdWJfg7xKOuf37uqK/T8x5XRmI6YFmhfZprO/jX1bhI=,iv:VOaTiOjQ7tu87SH01dBhOW/wnxzwfR6ucOt8kzjgitc=,tag:dz1znrjU3fUXgBNsJ+b6JQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## What
Repoints `imagineering-contact-us` SMTP from the **shared Brevo account** to **OCI Email Delivery** (ap-sydney-1). Config-only — `server.py` untouched.

## Why
Closes the core of the blast-radius problem (claude-tasks #1 / issue #614): a flood of the public contact form could exhaust the shared Brevo 300/day cap and starve **Outline + Kan** auth email (the 2026-06-08 incident class). The attacker-facing surface is now on a **separate provider** — its abuse can't touch the auth-critical apps.

## Done & verified (already deployed)
- OCI Email Delivery: domain `imagineering.cc` authenticated, DKIM `imagineering` selector ACTIVE, approved sender `noreply@imagineering.cc`.
- DKIM CNAME added in Cloudflare. (SPF deliberately NOT extended — OCI authenticates via DKIM alignment; avoids the SPF 10-lookup limit that would break Brevo.)
- Dedicated OCI SMTP credential (not shared with anything).
- e2e verified: direct send + **in-container send** + inbox delivery, DKIM-signed.
- Deployed to `img-contact` on 149.118.69.221; container env confirmed.

## Also folds in
- Commits the **Turnstile secret** that had drifted to a server-only `.env` (so a future redeploy can't silently disable bot protection). ⚠️ Overlaps peer branch `fix/commit-turnstile-secret` — coordinate on merge (this branch's secrets.yaml is a superset: OCI SMTP **+** turnstile).

## Gate
Load-bearing encrypted secrets → **Nick to merge** (per repo convention). Already live in prod; this PR persists it so redeploys don't revert to Brevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)