### PR TITLE
feat(dreamfinder): plumb EVENT_REMINDER_ROOM_ID for River event reminder

### DIFF
--- a/dreamfinder/docker-compose.yml
+++ b/dreamfinder/docker-compose.yml
@@ -56,6 +56,12 @@ services:
       - CALENDAR_URL=${CALENDAR_URL:-}
       - EVENT_TIMEZONE=${EVENT_TIMEZONE:-}
       - DEPLOY_ANNOUNCE_GROUP_ID=${DEPLOY_ANNOUNCE_GROUP_ID:-}
+      # Matrix portal room for the Imagineering Telegram group. When set, River
+      # posts the weekly "session starts in 5 minutes" reminder there every
+      # Saturday 14:55 Australia/Melbourne (venue alternates online/in-person).
+      # Empty until River's Telegram account (+61461488770) joins the group and
+      # the mautrix-telegram bridge creates the portal room. See claude-tasks #23.
+      - EVENT_REMINDER_ROOM_ID=${EVENT_REMINDER_ROOM_ID:-}
       - HEALTH_PORT=8081
     volumes:
       - bot_data:/app/data


### PR DESCRIPTION
Adds `EVENT_REMINDER_ROOM_ID` to the dreamfinder container env, enabling River's weekly Imagineering **"session starts in 5 minutes"** reminder (Saturday 14:55 Australia/Melbourne, venue alternating online/in-person).

Code PR: imagineering-cc/dreamfinder#108.

Empty by default (`${EVENT_REMINDER_ROOM_ID:-}`) so the feature merges **dark** — it only activates once River's Telegram account (+61461488770) joins the Imagineering group, the mautrix-telegram bridge creates the portal room, and that room id is set in the deploy env. (claude-tasks #23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)