### PR TITLE
feat(dreamfinder): enable River event reminder → #imagineering hub

### DIFF
--- a/dreamfinder/docker-compose.yml
+++ b/dreamfinder/docker-compose.yml
@@ -56,12 +56,13 @@ services:
       - CALENDAR_URL=${CALENDAR_URL:-}
       - EVENT_TIMEZONE=${EVENT_TIMEZONE:-}
       - DEPLOY_ANNOUNCE_GROUP_ID=${DEPLOY_ANNOUNCE_GROUP_ID:-}
-      # Matrix portal room for the Imagineering Telegram group. When set, River
-      # posts the weekly "session starts in 5 minutes" reminder there every
-      # Saturday 14:55 Australia/Melbourne (venue alternates online/in-person).
-      # Empty until River's Telegram account (+61461488770) joins the group and
-      # the mautrix-telegram bridge creates the portal room. See claude-tasks #23.
-      - EVENT_REMINDER_ROOM_ID=${EVENT_REMINDER_ROOM_ID:-}
+      # Room River posts the weekly "session starts in 5 minutes" reminder to,
+      # every Saturday 14:55 Australia/Melbourne (venue alternates online vs
+      # in-person). Default is the #imagineering Matrix hub: River posts there
+      # and the matrix-chat-superbridge fans it out to every platform group
+      # (Telegram, Signal, WhatsApp, Discord) — River needs no per-platform
+      # membership. See claude-tasks #23.
+      - EVENT_REMINDER_ROOM_ID=${EVENT_REMINDER_ROOM_ID:-!SNO2v77SDkrFKxUGFw:imagineering.cc}
       - HEALTH_PORT=8081
     volumes:
       - bot_data:/app/data


### PR DESCRIPTION
Flips the River weekly event reminder live by defaulting `EVENT_REMINDER_ROOM_ID` to the `#imagineering` Matrix hub (`!SNO2v77SDkrFKxUGFw`).

**Why the hub, not a Telegram portal:** verified that the matrix-chat-superbridge mirrors every Imagineering platform group (Telegram/Signal/WhatsApp/Discord) — and that it relays `@dreamfinder-bot`'s *own* messages. So River posts once to the hub and it fans out everywhere, including Discord, with **no per-platform membership** (River was briefly added to the TG group during investigation, then removed — unnecessary + risked double-ingestion).

Code already merged: imagineering-cc/dreamfinder#108. Non-secret room id, set as a compose default exactly like the existing `*_MANAGEMENT_ROOM` defaults. Next step after merge: `deploy-to.sh pm-bot`. (claude-tasks #23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)