### PR TITLE
feat(watchers): name the broken DNS record in Brevo email-health alerts (#1062)

### DIFF
--- a/scripts/watchers/email-health-watch.sh
+++ b/scripts/watchers/email-health-watch.sh
@@ -122,6 +122,42 @@ clear_alerted() {
     rm -f "$CONFIG_DIR/$WATCHER_NAME.$1.alerted"
 }
 
+# domain_dns_detail <domain> — ENRICHMENT (not detection). Only called on the
+# unhealthy path to NAME which DNS record is broken. GET /senders/domains/{d}
+# returns a `dns_records` object whose entries each carry a `status` boolean
+# (true = verified, false/null = not). The 2026-06-20 incident was a missing
+# DMARC `rua` record — the cheap LIST endpoint can't see that granularity, this
+# can. Echoes one "  - <record>: not verified (status=<v>)" line per broken
+# record, or nothing if all records verify / detail is unavailable.
+#
+# DEFENSIVE: any API failure or unexpected shape returns empty (the caller then
+# falls back to the existing generic alert) — enrichment must never crash the
+# watcher or block the alert it decorates. Record keys are read generically
+# (Brevo mixes camelCase `dkim1Record` and snake_case `dmarc_record`), and a
+# `null` status is treated as not-verified but reported distinctly from `false`.
+domain_dns_detail() {
+    local domain="$1" json detail
+    json=$(brevo_get "/senders/domains/$domain") || return 0
+    detail=$(python3 -c '
+import json, sys
+try:
+    recs = json.loads(sys.stdin.read()).get("dns_records") or {}
+except Exception:
+    sys.exit(0)
+if not isinstance(recs, dict):
+    sys.exit(0)
+lines = []
+for name in sorted(recs):
+    entry = recs[name]
+    status = entry.get("status") if isinstance(entry, dict) else None
+    if status is not True:
+        shown = "null" if status is None else str(status).lower()
+        lines.append(f"  - {name}: not verified (status={shown})")
+print("\n".join(lines))
+' <<< "$json" 2>/dev/null) || return 0
+    printf '%s' "$detail"
+}
+
 # --- Checks -----------------------------------------------------------------
 # Each check fires tg() at most once/day (debounced) and clears its sentinel on
 # recovery. None of them transition the state machine — phase_a_check returns 1.
@@ -152,9 +188,26 @@ print("\n".join(problems))
     if [[ -n "$bad" ]]; then
         log "check_domain_auth: PROBLEMS: ${bad//$'\n'/ | }"
         if ! alerted_today domain_auth; then
-            local pretty
+            # ENRICHMENT: for each flagged domain, pull the per-domain DNS-record
+            # detail so the alert can name the broken record (DKIM/DMARC/brevo
+            # code) rather than just "domain unauthenticated". Only the unhealthy
+            # path pays this extra call — healthy cycles stay one cheap LIST call.
+            local detail_block="" dom dom_detail
+            while IFS= read -r line; do
+                [[ -n "$line" ]] || continue
+                dom="${line%%:*}"          # "<domain>: <reason>" → "<domain>"
+                dom_detail=$(domain_dns_detail "$dom")
+                if [[ -n "$dom_detail" ]]; then
+                    detail_block+="${dom} DNS records:"$'\n'"${dom_detail}"$'\n'
+                fi
+            done <<< "$bad"
+
+            local pretty extra=""
             pretty=$(html_escape "$bad")
-            tg "$(printf '🚨 <b>Brevo sending-domain auth FAILING</b>\n\nTransactional email (Outline resets, Kan magic links/invites, contact-form leads) will be silently dropped — Brevo accepts sends (250 OK) then rejects at processing.\n\n<pre>%s</pre>\nFix in Brevo → Senders, Domains &amp; IPs. <i>(2026-06-20 incident class.)</i>' "$pretty")"
+            if [[ -n "$detail_block" ]]; then
+                extra=$(printf '\n<b>Broken DNS records:</b>\n<pre>%s</pre>' "$(html_escape "${detail_block%$'\n'}")")
+            fi
+            tg "$(printf '🚨 <b>Brevo sending-domain auth FAILING</b>\n\nTransactional email (Outline resets, Kan magic links/invites, contact-form leads) will be silently dropped — Brevo accepts sends (250 OK) then rejects at processing.\n\n<pre>%s</pre>%s\nFix in Brevo → Senders, Domains &amp; IPs. <i>(2026-06-20 incident class.)</i>' "$pretty" "$extra")"
             mark_alerted domain_auth
         fi
     else


### PR DESCRIPTION
## What

Enriches the `email-health-watch.sh` domain-auth alert so it **names which DNS record is broken** instead of just "domain unauthenticated".

The watcher's detection uses the cheap LIST endpoint (`GET /v3/senders/domains`), which only exposes `authenticated`/`verified` booleans — enough to detect a silent transactional-email failure but not to pinpoint the cause. On the **unhealthy path only**, it now calls the per-domain detail endpoint (`GET /v3/senders/domains/{domain}`) and reads each `dns_records.*.status`, appending lines like `dmarc_record: not verified (status=false)` to the Telegram alert.

## Why (#1062)

The real 2026-06-20 incident was a missing DMARC `rua` record. The alert that would fire today says only "domain unauthenticated" — an operator still has to go digging in the Brevo dashboard to find the broken record. This closes that gap. Enrichment, not detection: the LIST check still owns the alert trigger.

## Design notes

- **Cost-safe**: the per-domain call runs only inside the `unhealthy && not-yet-alerted-today` branch. Healthy cycles stay at one cheap LIST call; a persistent failure pays the extra call at most once/UTC-day (existing debounce).
- **Defensive**: Brevo mixes key casing (`dkim1Record` camelCase vs `dmarc_record` snake_case), so records are iterated generically rather than hardcoded. A `null` status is reported distinctly from `false`. Any API error / 404 / malformed shape returns empty, and the caller falls back to the existing generic alert — enrichment never crashes the watcher or blocks the alert it decorates.
- **Surprise from the live API**: the brief assumed three records (`dkim_record,dmarc_record,brevo_code`); the live response actually has five with `dkim_record.status = null` while the real DKIM records `dkim1Record`/`dkim2Record` are `true`. Hardcoding the three would have produced a false "dkim_record NOT verified" alarm — hence the generic-iteration + null-distinct approach.

## Test evidence

- `shellcheck scripts/watchers/email-health-watch.sh` → clean
- `DRY_RUN=1` run against the live API with a forced missing domain → 404 handled, graceful fallback to generic alert, no crash
- Fixture unit tests of the enrichment parser:
  - mixed (false + null + true) → names exactly the two broken records, distinguishes null from false
  - all healthy → empty (no false alarm)
  - malformed JSON → empty
  - API error → empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)