### PR TITLE
feat(watchers): Melbourne canary for Sydney's notify alerting chain

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,63 @@
+# `.claude/` — repo-local Claude Code config
+
+## `settings.json` — Bash permission allowlist
+
+`settings.json` holds a `permissions.allow` list of read-only ship-cycle Bash
+commands (git status/diff/log/show/branch/rev-parse/remote/fetch, gh pr
+view/list/diff/checks, shellcheck, yamllint, `bash -n`). Added in PR #87 to cut
+permission prompts during routine review/ship work.
+
+These use Claude Code's command-**prefix** matcher: `Bash(git diff:*)` (the `:*`
+suffix is equivalent to a trailing ` *`) matches any command starting with
+`git diff `.
+
+### Verified: prefix rules do NOT pre-approve chained mutations (hole closed)
+
+A reasonable fear about prefix allowlists: does `Bash(git diff:*)` also approve a
+**compound** command like `git diff && rm -rf /` — i.e. does Claude Code
+prefix-match the *whole* command string?
+
+**No.** Claude Code parses shell operators and re-checks **each subcommand
+independently** against the allow rules. A compound command is auto-approved only
+if *every* subcommand matches an allow rule; otherwise it falls through to a
+normal permission prompt. So `git diff && rm -rf /` still prompts on the
+`rm -rf /` part — the allowlist does not widen the blast radius beyond the exact
+read-only commands listed.
+
+This is enforced by Claude Code itself (not the model), independent of anything
+in `CLAUDE.md` or the prompt.
+
+**Evidence** (verified 2026-06-22, against the current published docs):
+
+- Permissions reference — "Compound commands":
+  <https://code.claude.com/docs/en/permissions> —
+  > "Claude Code is aware of shell operators, so a rule like `Bash(safe-cmd *)`
+  > won't give it permission to run the command `safe-cmd && other-cmd`. The
+  > recognized command separators are `&&`, `||`, `;`, `|`, `|&`, `&`, and
+  > newlines. A rule must match each subcommand independently."
+- Security reference — defense-in-depth backing the above:
+  <https://code.claude.com/docs/en/security> —
+  > "Command injection detection: Suspicious bash commands require manual
+  > approval even if previously allowlisted." …
+  > "Fail-closed matching: Unmatched commands default to requiring manual
+  > approval."
+
+### Residual caveats (not present in the current allowlist, but watch for them)
+
+The per-subcommand guarantee covers `&&`/`||`/`;`/`|`/`&`/newline chaining. Two
+documented bypass classes are *not* covered by a simple prefix rule — none apply
+to the current read-only ruleset, but don't add rules that introduce them:
+
+- **Environment/exec runners pass through to the inner command.** A rule like
+  `Bash(devbox run *)` / `docker exec *` / `npx *` matches *whatever follows*,
+  including `devbox run rm -rf .`. (Plain wrappers `timeout`/`time`/`nice`/
+  `nohup`/`stdbuf`/bare `xargs` are stripped and are safe.) If you ever allow a
+  runner, pin the inner command: `Bash(devbox run npm test)`.
+- **Argument-constraining prefix rules are fragile** (option reordering,
+  protocol/redirect, `URL=… && curl $URL`). For network egress, prefer
+  `deny` on `curl`/`wget` + `WebFetch(domain:…)`, not a `Bash(curl http://… *)`
+  allow rule.
+
+Scope of this note: the claim above was verified against the docs cited on
+2026-06-22. `settings.json` is strict JSON (it carries a `$schema`) and does not
+support comments, which is why this note lives here rather than inline.

--- a/scripts/watchers/README.md
+++ b/scripts/watchers/README.md
@@ -322,6 +322,97 @@ ssh 149.118.69.221 'crontab -l 2>/dev/null | grep -vF "# email-health-watch" | {
 ssh 149.118.69.221 '/home/ubuntu/email-health-watch.sh; tail ~/email-health-watch.log'
 ```
 
+## Built: notify-canary-melbourne
+
+`notify-canary-melbourne.sh` is the **external witness for the alerting path
+itself**. Every cron + watcher on Sydney funnels alerts through ONE chain:
+notify container (127.0.0.1:8090) → Telegram → Nick. That chain cannot announce
+its own death — if Docker, the notify container, or Sydney's egress to
+api.telegram.org is down, the alert is POSTed to the corpse and lost silently.
+This canary runs on **Melbourne** (nick-mel) — a sibling of
+`oci-instance-watch-melbourne.sh` — and watches Sydney's notify chain from
+outside.
+
+**The independence rule (the whole point):** the canary must NOT route its own
+alert through the Sydney notify service it is checking. So, unlike every other
+watcher, it does **not** use the lib's `tg()` helper (which POSTs to
+notify.imagineering.cc). It sources `scripts/lib/telegram.sh` and calls
+`send_telegram_alert()`, which hits `api.telegram.org` **directly** with a bot
+token held on Melbourne. Spreading the bot token is normally an anti-pattern
+(that's why notify exists) — but the one client that may not depend on notify
+is the client that watches notify. Documented exception.
+
+**Three-layer probe over one SSH hop** (Mel→Syd), because a bare TCP/`/health`
+check is a false positive — `/health` returns static `{"ok":true}` without ever
+touching Telegram, so a revoked token or blocked egress passes it:
+
+1. **L1** — `docker inspect` notify: container `running` AND Docker-health
+   `healthy` (tolerates `none` if no healthcheck defined).
+2. **L2** — `GET http://127.0.0.1:8090/health` returns `200`.
+3. **L3** — Telegram `getMe` succeeds **from Sydney's network**, using the
+   container's own bot token (read from its env, never shipped over the wire).
+   This is the layer that makes it a *delivery* check, not a liveness check —
+   it proves egress + token validity WITHOUT sending Nick a message (a test
+   `/send` would spam Telegram every cycle).
+
+**Shape:** recurring threshold-alert (like `email-health-watch.sh`, *not* the
+self-disabling template) — a canary that disabled itself after one recovery
+would stop guarding. `phase_a_check` always returns 1; the state machine never
+advances to DONE. Alerts debounce to **one 🚨 per failure-episode** via a
+sentinel file, fire a single ✅ on recovery, then re-arm. A single transient
+`UNKNOWN` (SSH blip, no token in container env) does **not** fire — only a
+second consecutive `UNKNOWN` escalates (a `FAIL` fires immediately). `DRY_RUN=1`
+logs the alert instead of sending.
+
+**Residual gap (known tradeoff):** if Melbourne AND Sydney die simultaneously,
+no alert fires — but that's covered by the existing mutual peer monitoring
+(Sydney's `oci-instance-watch.sh` watches Melbourne; Melbourne's
+`oci-instance-watch-melbourne.sh` watches Sydney), so a dead Melbourne is
+itself alarmed from Sydney. The canary also can't distinguish "notify token
+revoked" from "Telegram API outage" — both surface as `FAIL:telegram-*`; that's
+acceptable since both mean Sydney can't deliver.
+
+### Install on Melbourne (nick-mel, 130.162.192.233)
+
+```bash
+# 1. Lib + the direct-Telegram helper + the canary. Melbourne already runs
+#    oci-instance-watch-melbourne.sh, so lib/watcher-base.sh + ~/bin tooling
+#    are present; the canary additionally needs lib/telegram.sh.
+scp scripts/watchers/lib/watcher-base.sh nick-mel:/tmp/   # if not already there
+scp scripts/lib/telegram.sh              nick-mel:/tmp/
+scp scripts/watchers/notify-canary-melbourne.sh nick-mel:/tmp/
+ssh nick-mel 'mkdir -p ~/lib \
+  && install -m 0755 /tmp/watcher-base.sh ~/lib/ \
+  && install -m 0755 /tmp/telegram.sh     ~/lib/ \
+  && install -m 0755 /tmp/notify-canary-melbourne.sh ~/ \
+  && rm -f /tmp/watcher-base.sh /tmp/telegram.sh /tmp/notify-canary-melbourne.sh'
+
+# 2. The INDEPENDENT alert path needs a Telegram bot token on Melbourne, at
+#    /etc/imagineering-secrets/telegram.env (root:nick 0640) — the same file
+#    scripts/lib/telegram.sh auto-sources. Build it locally from notify's
+#    secrets and install (never echo the token over an interactive ssh).
+export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
+umask 077
+BOT=$(sops -d notify/secrets.yaml | yq -r '.telegram_bot_token')
+CHAT=$(sops -d notify/secrets.yaml | yq -r '.telegram_chat_id')
+[ -n "$BOT" ] && [ "$BOT" != "null" ] || { echo "ERROR: telegram_bot_token empty/null — aborting"; exit 1; }
+printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n' "$BOT" "$CHAT" > /tmp/telegram.env
+scp /tmp/telegram.env nick-mel:/tmp/
+ssh nick-mel 'sudo install -d -m 0755 /etc/imagineering-secrets \
+  && sudo install -m 0640 -o root -g "$(id -gn)" /tmp/telegram.env /etc/imagineering-secrets/telegram.env \
+  && rm -f /tmp/telegram.env'
+rm -f /tmp/telegram.env; unset BOT CHAT
+
+# 3. Confirm Melbourne can SSH to Sydney as ubuntu (BatchMode, key-based):
+ssh nick-mel 'ssh -o BatchMode=yes -o ConnectTimeout=10 ubuntu@149.118.69.221 "echo reachable"'
+
+# 4. DRY_RUN smoke on the box, then install the cron entry (Melbourne crontab,
+#    user ubuntu — offset to :47, clear of the oci-watcher's :17). Tag MUST
+#    match CRON_TAG. Idempotent: strips any existing line first.
+ssh nick-mel 'DRY_RUN=1 ~/notify-canary-melbourne.sh; tail ~/notify-canary-melbourne.log'
+ssh nick-mel 'crontab -l 2>/dev/null | grep -vF "# notify-canary-melbourne" | { cat; echo "47 */2 * * * /home/ubuntu/notify-canary-melbourne.sh  # notify-canary-melbourne"; } | crontab -'
+```
+
 ## See also
 
 - `template.sh` — the file

--- a/scripts/watchers/README.md
+++ b/scripts/watchers/README.md
@@ -388,20 +388,23 @@ ssh nick-mel 'mkdir -p ~/lib \
   && rm -f /tmp/watcher-base.sh /tmp/telegram.sh /tmp/notify-canary-melbourne.sh'
 
 # 2. The INDEPENDENT alert path needs a Telegram bot token on Melbourne, at
-#    /etc/imagineering-secrets/telegram.env (root:nick 0640) — the same file
-#    scripts/lib/telegram.sh auto-sources. Build it locally from notify's
-#    secrets and install (never echo the token over an interactive ssh).
+#    /etc/imagineering-secrets/telegram.env (root:ubuntu 0640 — ubuntu is the
+#    cron user that sources it) — the same file scripts/lib/telegram.sh
+#    auto-sources. Build it from notify's secrets and STREAM it over ssh stdin
+#    under umask 077: scp would land the token world-readable (0644) in the
+#    remote /tmp; piping under umask 077 keeps the temp file 0600, and the
+#    remote `trap ... EXIT` removes it even if a later step fails.
 export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
 umask 077
 BOT=$(sops -d notify/secrets.yaml | yq -r '.telegram_bot_token')
 CHAT=$(sops -d notify/secrets.yaml | yq -r '.telegram_chat_id')
-[ -n "$BOT" ] && [ "$BOT" != "null" ] || { echo "ERROR: telegram_bot_token empty/null — aborting"; exit 1; }
-printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n' "$BOT" "$CHAT" > /tmp/telegram.env
-scp /tmp/telegram.env nick-mel:/tmp/
-ssh nick-mel 'sudo install -d -m 0755 /etc/imagineering-secrets \
-  && sudo install -m 0640 -o root -g "$(id -gn)" /tmp/telegram.env /etc/imagineering-secrets/telegram.env \
-  && rm -f /tmp/telegram.env'
-rm -f /tmp/telegram.env; unset BOT CHAT
+[ -n "$BOT" ]  && [ "$BOT" != "null" ]  || { echo "ERROR: telegram_bot_token empty/null — aborting"; exit 1; }
+[ -n "$CHAT" ] && [ "$CHAT" != "null" ] || { echo "ERROR: telegram_chat_id empty/null — aborting"; exit 1; }
+printf 'TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n' "$BOT" "$CHAT" \
+  | ssh nick-mel 'umask 077; trap "rm -f /tmp/telegram.env" EXIT; cat > /tmp/telegram.env \
+      && sudo install -d -m 0755 /etc/imagineering-secrets \
+      && sudo install -m 0640 -o root -g ubuntu /tmp/telegram.env /etc/imagineering-secrets/telegram.env'
+unset BOT CHAT
 
 # 3. Confirm Melbourne can SSH to Sydney as ubuntu (BatchMode, key-based):
 ssh nick-mel 'ssh -o BatchMode=yes -o ConnectTimeout=10 ubuntu@149.118.69.221 "echo reachable"'

--- a/scripts/watchers/notify-canary-melbourne.sh
+++ b/scripts/watchers/notify-canary-melbourne.sh
@@ -143,13 +143,25 @@ health=$(docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}
 case "$health" in healthy|none) : ;; *) echo "FAIL:container-unhealthy($health)"; exit 0 ;; esac
 # L2: /health answers 200 on the loopback bind.
 code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:${P}/health" 2>/dev/null) || code="000"
-[ "$code" = "200" ] || { echo "FAIL:health-http($code)"; exit 0; }
+# A 000 (connect failed) is a transient blip → UNKNOWN (debounced); a real
+# non-200 (server returned an error) is deterministic → FAIL.
+[ "$code" = "200" ] || { if [ "$code" = "000" ]; then echo "UNKNOWN:health-unreachable"; else echo "FAIL:health-http($code)"; fi; exit 0; }
 # L3: Telegram getMe FROM Sydney, using the container'\''s own bot token.
 # Read the token out of the running container env (never printed/logged here).
 tok=$(docker inspect -f "{{range .Config.Env}}{{println .}}{{end}}" "$C" 2>/dev/null | sed -n "s/^TELEGRAM_BOT_TOKEN=//p")
 [ -n "$tok" ] || { echo "UNKNOWN:no-token-in-container-env"; exit 0; }
-gm=$(curl -s --max-time 8 "https://api.telegram.org/bot${tok}/getMe" 2>/dev/null) || { echo "FAIL:telegram-egress"; exit 0; }
-case "$gm" in *'\''"ok":true'\''*) echo "OK" ;; *) echo "FAIL:telegram-getme-rejected" ;; esac
+gm=$(curl -s --max-time 8 "https://api.telegram.org/bot${tok}/getMe" 2>/dev/null) || { echo "UNKNOWN:telegram-egress"; exit 0; }
+# ok:true → delivery-capable. Otherwise split transient (429 rate-limit / 5xx
+# Telegram outage → debounced UNKNOWN) from deterministic (401 revoked token,
+# other 4xx → immediate FAIL, the exact thing this canary exists to catch).
+case "$gm" in
+    *'\''"ok":true'\''*) echo "OK" ;;
+    *) ec=${gm#*"error_code":}; ec=${ec%%[!0-9]*}
+       case "$ec" in
+           429|5??) echo "UNKNOWN:telegram-transient($ec)" ;;
+           *)       echo "FAIL:telegram-getme-rejected($ec)" ;;
+       esac ;;
+esac
 '
     local out
     if ! out=$(ssh \

--- a/scripts/watchers/notify-canary-melbourne.sh
+++ b/scripts/watchers/notify-canary-melbourne.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Notify-container CANARY — Melbourne→Sydney, INDEPENDENT alert path.
+#
+# ─── The invariant this enforces ───────────────────────────────────────────
+#   "Sydney's alerting chain can actually deliver."
+#   Every cron + watcher on Sydney funnels its alerts through ONE chain:
+#       notify container (127.0.0.1:8090) → Telegram Bot API → Nick.
+#   That chain cannot announce its OWN death. If Docker is down, the notify
+#   container has crashed, or Sydney's egress to api.telegram.org is broken,
+#   the alert is POSTed to the corpse and lost — silently. Nick learns Sydney
+#   went dark only when he happens to notice. This canary is the outside
+#   witness that closes that hole.
+#
+# ─── System-shape assumptions ──────────────────────────────────────────────
+#   1. Melbourne (nick-mel, 130.162.192.233) is always-on, and its cron is
+#      healthy. (It already runs oci-instance-watch-melbourne.sh on the same
+#      box; if Melbourne itself dies, Sydney's oci-instance-watch.sh catches
+#      Melbourne — mutual peer monitoring. So neither box is its own witness.)
+#   2. Melbourne can SSH to Sydney as `ubuntu` (the same key the deploy/peer
+#      tooling already uses — Mel→Syd reachability is a standing assumption of
+#      the peer-watcher fleet).
+#   3. Melbourne holds a Telegram bot token DIRECTLY (via
+#      /etc/imagineering-secrets/telegram.env, loaded by lib/telegram.sh).
+#      This is the crux: the canary must NOT route its alert through the very
+#      Sydney notify service it is checking. It talks to api.telegram.org
+#      itself. Spreading the bot token is normally an anti-pattern (that's
+#      WHY notify exists) — but the one client that may not depend on notify
+#      is the client that watches notify. This is the documented exception.
+#
+# ─── The probe (why three layers, not one TCP check) ───────────────────────
+#   A bare "is :8090 open?" or even a GET /health proves only that the HTTP
+#   server process is up — /health returns a static {"ok":true} WITHOUT ever
+#   touching Telegram. A green /health with a revoked bot token or blocked
+#   egress is a FALSE POSITIVE that defeats the entire canary (we'd report
+#   "delivery fine" while every real alert silently vanishes). So the probe,
+#   run over a single SSH hop to Sydney, layers:
+#
+#     L1  notify container is RUNNING & Docker-healthy
+#         (`docker inspect` .State.Health.Status == healthy)  → process alive
+#     L2  notify answers GET /health on 127.0.0.1:8090 → 200   → HTTP serving
+#     L3  Telegram getMe succeeds FROM Sydney's network        → egress + token
+#         (proves the delivery chain end-to-end WITHOUT sending Nick a message
+#          — getMe is read-only; a test /send would spam Telegram every cycle)
+#
+#   All three must pass for "delivery-capable". L3 is the one that turns this
+#   from a liveness check into a DELIVERY check — it is the boundary the whole
+#   canary stands for. If SSH itself fails we can't distinguish "Sydney box
+#   down" from "Mel→Syd network blip"; we treat repeated SSH failure as a
+#   Phase-A trip too (Sydney unreachable from its witness is itself alarming),
+#   but debounce so a single flap doesn't fire.
+#
+# ─── Shape: recurring threshold-alert (NOT self-disabling) ─────────────────
+#   A canary that disabled itself after one recovery would stop guarding. So,
+#   like email-health-watch.sh, phase_a_check ALWAYS returns 1 — the state
+#   machine never advances to DONE, the cron entry is never removed. Alerts
+#   debounce to at most one per failure-episode via a sentinel file, and a
+#   recovery ✅ fires once when the probe goes green again, then re-arms.
+#
+# Cron (Melbourne crontab, as user `ubuntu`):
+#   47 */2 * * * /home/ubuntu/notify-canary-melbourne.sh  # notify-canary-melbourne
+#   (Every 2 hours, off the hour. Offset to :47 — well clear of the Melbourne
+#    oci-watcher's :17 — so the two Mel→Syd probes don't fire simultaneously.)
+
+set -euo pipefail
+
+# shellcheck disable=SC2034  # consumed by watcher-base.sh after sourcing
+WATCHER_NAME="notify-canary-melbourne"
+# shellcheck disable=SC2034
+CRON_TAG="notify-canary-melbourne"
+
+# ── Source the base lib for log()/run_watcher()/state plumbing ─────────────
+# NOTE: we deliberately do NOT use the lib's tg() helper — tg() POSTs through
+# notify.imagineering.cc, i.e. through the very Sydney service we're checking.
+# Our alert path is send_telegram_alert() from lib/telegram.sh, which hits
+# api.telegram.org directly with a bot token held on Melbourne.
+__lib="$(dirname "$0")/lib/watcher-base.sh"
+[[ -r "$__lib" ]] || __lib="$HOME/lib/watcher-base.sh"
+# shellcheck disable=SC1090
+source "$__lib"
+unset __lib
+
+# ── Source the DIRECT Telegram helper (independent alert path) ─────────────
+__tg="$(dirname "$0")/lib/telegram.sh"
+[[ -r "$__tg" ]] || __tg="$HOME/lib/telegram.sh"
+# shellcheck disable=SC1090
+source "$__tg"
+unset __tg
+
+# ── Config (override via env if needed) ────────────────────────────────────
+SYDNEY_SSH="${SYDNEY_SSH:-149.118.69.221}"      # Sydney public IP
+SYDNEY_SSH_USER="${SYDNEY_SSH_USER:-ubuntu}"    # standing peer-fleet user
+NOTIFY_CONTAINER="${NOTIFY_CONTAINER:-notify}"  # docker container name
+NOTIFY_PORT="${NOTIFY_PORT:-8090}"              # 127.0.0.1-bound on Sydney
+SSH_TIMEOUT="${SSH_TIMEOUT:-20}"                # seconds for the whole probe
+
+# Sentinel: present == we are currently in a fired/alerted state. Used to
+# debounce (one 🚨 per failure-episode) and to know when to fire the ✅.
+ALERT_SENTINEL="$CONFIG_DIR/$WATCHER_NAME.alerted"
+
+# ── alert <html-message> : INDEPENDENT path, never via notify ──────────────
+# DRY_RUN=1 logs instead of sending (smoke-testing without Telegram noise).
+# We re-implement the DRY_RUN gate here rather than calling tg(), because
+# tg() is the notify-routed path we must avoid even in production.
+alert() {
+    local msg="$1"
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        log "alert [DRY_RUN]: ${msg//$'\n'/ }"
+        return 0
+    fi
+    # send_telegram_alert is a silent no-op if the bot token is unset (e.g.
+    # creds not yet installed on Melbourne); it logs to stderr in that case.
+    send_telegram_alert "$msg"
+    log "alert: dispatched via direct Telegram API (independent of Sydney notify)"
+}
+
+# ── probe : runs the 3-layer check over ONE ssh hop. ───────────────────────
+# Echoes "OK" on full delivery-capable, or "FAIL:<reason>" otherwise.
+# Echoes "UNKNOWN:<reason>" when we genuinely can't tell (don't fire on these
+# alone — they're transient until they persist; debounce handles persistence).
+probe() {
+    # The remote script runs ON Sydney. It must use only tools we know are
+    # present there (docker, curl, the bot token via the same secrets file).
+    # We read the token from Sydney's own notify env so we don't ship it over
+    # the wire — getMe is run with Sydney's container token, proving THAT
+    # token + Sydney's egress, which is exactly the chain real alerts use.
+    local remote
+    # The remote script is a single-quoted heredoc with $NOTIFY_CONTAINER /
+    # $NOTIFY_PORT spliced in via the close-single/open-double quote dance
+    # ('"'"'"$VAR"'"'"'). Shellcheck can't see across that concatenation
+    # boundary and flags SC2016 ("won't expand") — but they DO expand at
+    # string-build time. The '\'' sequences are literal apostrophes in remote
+    # comments/strings. Both are intended; suppress the false positive.
+    # shellcheck disable=SC2016
+    remote='
+set -euo pipefail
+C="'"$NOTIFY_CONTAINER"'"
+P="'"$NOTIFY_PORT"'"
+# L1: container running + Docker-healthy.
+state=$(docker inspect -f "{{.State.Status}}" "$C" 2>/dev/null) || { echo "FAIL:container-absent"; exit 0; }
+[ "$state" = "running" ] || { echo "FAIL:container-not-running($state)"; exit 0; }
+health=$(docker inspect -f "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}" "$C" 2>/dev/null || echo "none")
+# "none" == no healthcheck defined; tolerate it (older compose) but L2 still gates.
+case "$health" in healthy|none) : ;; *) echo "FAIL:container-unhealthy($health)"; exit 0 ;; esac
+# L2: /health answers 200 on the loopback bind.
+code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:${P}/health" 2>/dev/null) || code="000"
+[ "$code" = "200" ] || { echo "FAIL:health-http($code)"; exit 0; }
+# L3: Telegram getMe FROM Sydney, using the container'\''s own bot token.
+# Read the token out of the running container env (never printed/logged here).
+tok=$(docker inspect -f "{{range .Config.Env}}{{println .}}{{end}}" "$C" 2>/dev/null | sed -n "s/^TELEGRAM_BOT_TOKEN=//p")
+[ -n "$tok" ] || { echo "UNKNOWN:no-token-in-container-env"; exit 0; }
+gm=$(curl -s --max-time 8 "https://api.telegram.org/bot${tok}/getMe" 2>/dev/null) || { echo "FAIL:telegram-egress"; exit 0; }
+case "$gm" in *'\''"ok":true'\''*) echo "OK" ;; *) echo "FAIL:telegram-getme-rejected" ;; esac
+'
+    local out
+    if ! out=$(ssh \
+            -o BatchMode=yes \
+            -o ConnectTimeout="$SSH_TIMEOUT" \
+            -o ServerAliveInterval=5 -o ServerAliveCountMax=2 \
+            "${SYDNEY_SSH_USER}@${SYDNEY_SSH}" \
+            "bash -s" <<< "$remote" 2>/dev/null); then
+        # SSH itself failed: Sydney unreachable from its witness. Alarming, but
+        # could be a Mel→Syd network blip — surface as UNKNOWN; debounce +
+        # episode-persistence (sentinel) decides whether to escalate.
+        echo "UNKNOWN:ssh-unreachable"
+        return 0
+    fi
+    # Guard against an empty echo (e.g. remote bash died before printing).
+    [[ -n "$out" ]] && echo "$out" || echo "UNKNOWN:empty-probe-output"
+}
+
+# Escalation policy: a single UNKNOWN (transient blip) does NOT fire; a second
+# consecutive UNKNOWN is treated as a real failure (the blip persisted). FAIL
+# fires immediately. We track consecutive-unknown count in a tiny state file.
+UNKNOWN_STREAK_FILE="$CONFIG_DIR/$WATCHER_NAME.unknown-streak"
+
+phase_a_check() {
+    local result reason
+    result=$(probe)
+    log "probe: $result"
+
+    case "$result" in
+        OK)
+            rm -f "$UNKNOWN_STREAK_FILE"
+            # Recovery: if we had previously alerted, fire ✅ once and re-arm.
+            if [[ -f "$ALERT_SENTINEL" ]]; then
+                alert '✅ <b>Sydney notify delivery RESTORED</b> (Melbourne canary)
+
+The notify alerting chain (container → Telegram) is delivery-capable again. Sydney crons can alert Nick once more.'
+                rm -f "$ALERT_SENTINEL"
+            fi
+            return 1   # recurring watcher: never advance to DONE
+            ;;
+        FAIL:*)
+            reason="${result#FAIL:}"
+            rm -f "$UNKNOWN_STREAK_FILE"
+            _fire_failure "$reason"
+            return 1
+            ;;
+        UNKNOWN:*)
+            reason="${result#UNKNOWN:}"
+            local streak
+            streak=$(cat "$UNKNOWN_STREAK_FILE" 2>/dev/null || echo 0)
+            streak=$(( streak + 1 ))
+            echo "$streak" > "$UNKNOWN_STREAK_FILE"
+            if (( streak >= 2 )); then
+                _fire_failure "persistent-$reason (x$streak)"
+            else
+                log "UNKNOWN streak=$streak; one more before escalating ($reason)"
+            fi
+            return 1
+            ;;
+        *)
+            log "probe returned unrecognized result: $result"
+            return 1
+            ;;
+    esac
+}
+
+# _fire_failure <reason> : fire 🚨 ONCE per failure-episode (debounced by the
+# sentinel), via the INDEPENDENT Telegram path. Escapes the dynamic reason.
+_fire_failure() {
+    local reason esc
+    reason="$1"
+    if [[ -f "$ALERT_SENTINEL" ]]; then
+        log "failure persists ($reason); already alerted this episode — debounced"
+        return 0
+    fi
+    esc=$(telegram_html_escape "$reason")
+    alert "$(printf '🚨 <b>Sydney notify chain CANNOT DELIVER</b> (Melbourne canary)
+
+Probe result: <code>%s</code>
+
+This is the path EVERY Sydney cron/watcher alert flows through (notify container → Telegram). It is down, so Sydney alerts are being silently lost. This message reached you via Melbourne'\''s INDEPENDENT Telegram path. Check Sydney: <code>ssh %s@%s</code> then <code>docker ps | grep %s</code>.' \
+        "$esc" "$SYDNEY_SSH_USER" "$SYDNEY_SSH" "$NOTIFY_CONTAINER")"
+    touch "$ALERT_SENTINEL"
+}
+
+# Recurring watcher: phase B is never reached (A never returns 0). Present to
+# satisfy the run_watcher() contract.
+phase_b_check() {
+    return 1
+}
+
+run_watcher


### PR DESCRIPTION
Closes claude-tasks #731 (local task #16).

## Problem

Every cron + watcher on Sydney funnels its alerts through **one chain**:
notify container (`127.0.0.1:8090`) → Telegram Bot API → Nick. That chain
**cannot announce its own death**. If Docker is down, the notify container has
crashed, or Sydney's egress to `api.telegram.org` is broken, the alert is
POSTed to the corpse and silently lost. Nick learns Sydney went dark only when
he happens to notice.

## Solution: an external witness on Melbourne

`scripts/watchers/notify-canary-melbourne.sh` runs on **nick-mel** — a sibling
of `oci-instance-watch-melbourne.sh` — and watches Sydney's notify chain from
outside, every 2h at `:47`.

### The independent-alert-path design (the crux)

The canary must **not** route its own alert through the Sydney notify service it
is checking — that would be POSTing the alert to the very corpse it's
announcing. So, unlike every other watcher, it does **not** use the base lib's
`tg()` helper (which POSTs to `notify.imagineering.cc`). It sources
`scripts/lib/telegram.sh` and calls `send_telegram_alert()`, which hits
`api.telegram.org` **directly** with a bot token held on Melbourne. Spreading
the bot token is normally an anti-pattern (that's *why* notify exists) — but the
one client that may not depend on notify is the client that watches notify.
Documented exception, in both the script header and the README.

### Three-layer probe (delivery, not just liveness)

A bare TCP-open or `GET /health` check is a **false positive**: `/health`
returns static `{"ok":true}` without ever touching Telegram, so a revoked token
or blocked egress sails through it. The probe runs three layers over **one SSH
hop** Mel→Syd:

| Layer | Check | Proves |
|---|---|---|
| L1 | `docker inspect` notify: `running` + Docker-health `healthy` | container alive |
| L2 | `GET 127.0.0.1:8090/health` == `200` | HTTP serving |
| L3 | Telegram `getMe` **from Sydney's network**, container's own token | egress + token valid, **no message sent** |

L3 is what makes this a *delivery* check. `getMe` is read-only — a test `/send`
would spam Telegram every cycle.

### Shape

Recurring threshold-alert (like `email-health-watch.sh`, **not** the
self-disabling template) — a canary that disabled itself after one recovery
would stop guarding. Debounced to **one 🚨 per failure-episode** via a sentinel;
fires a single ✅ on recovery, then re-arms. A single transient `UNKNOWN` (SSH
blip / no token in container env) does **not** fire; only a second consecutive
`UNKNOWN` escalates. A `FAIL` fires immediately. `DRY_RUN=1` logs instead of
sending.

## Self-review against the failure mode

- **If Sydney notify is down, does my alert still reach Nick?** Yes — the alert
  goes Mel→`api.telegram.org` direct, never Mel→Syd-notify→Telegram. Verified in
  the smoke test (sends land via `send_telegram_alert`, never via `tg()`).
- **Does a false-positive defeat the purpose?** L3 (`getMe` from Sydney) closes
  the "TCP-open but delivery-broken" gap (revoked token / blocked egress).

### Residual gaps (named tradeoffs)

- **Mel + Syd die simultaneously → no alert.** Covered by existing mutual peer
  monitoring (Sydney's `oci-instance-watch.sh` alarms a dead Melbourne).
- **Can't distinguish "token revoked" from "Telegram API outage"** — both
  surface as `FAIL:telegram-*`. Acceptable: both mean Sydney can't deliver.
- L3 uses the container's *own* token, so it proves the exact token real alerts
  use — but if notify's token and Melbourne's `telegram.env` token ever diverge,
  the probe validates Sydney's while alerting via Melbourne's. Both are sourced
  from the same `notify/secrets.yaml`, so they match by construction.

## Test evidence

- **shellcheck clean** at default severity (matches CI's `action-shellcheck` over
  `./scripts`). Two SC2016 info findings on the remote-exec quote-dance are
  documented false positives, suppressed with a scoped `# shellcheck disable`.
- **DRY_RUN smoke run** exercised the full state machine with a stubbed probe:
  FAIL→🚨(once)→FAIL(debounced)→UNKNOWN(streak 1, no fire)→UNKNOWN(streak 2,
  fires)→OK(✅ recovery)→OK(silent). Exactly 3 sends, all via the independent
  path. A real-libs DRY_RUN run against an unreachable Sydney exited 0
  (cron-safe) and mapped to `UNKNOWN:ssh-unreachable` streak=1 (no false fire).

## Gate

Branch protection on `main` needs **1 approving review** — not admin-merging.
PR left open for review.

**Deferred (Nick's hands):** install on Melbourne is documented in the README
(`## Built: notify-canary-melbourne` → install section). It needs (a) the
`telegram.env` bot token installed on nick-mel for the independent path, and (b)
the crontab line `47 */2 * * * /home/ubuntu/notify-canary-melbourne.sh  #
notify-canary-melbourne`. No live crontab was edited by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)