### PR TITLE
fix(edf): pin known_hosts mount for lyra-live ssh hop (cage-match #81 finding 2)

### DIFF
--- a/embodied-dreamfinder/docker-compose.lyra.yml
+++ b/embodied-dreamfinder/docker-compose.lyra.yml
@@ -12,16 +12,34 @@
 # `lyra-live`. Manual equivalent:
 #   docker compose -f docker-compose.yml -f docker-compose.lyra.yml up -d
 #
-# Still outstanding (cage-match #81, finding 2 — tracked separately, cross-repo):
-# the consuming code in embodied-dreamfinder uses StrictHostKeyChecking=no +
-# UserKnownHostsFile=/dev/null for this ssh hop. Once that's fixed to verify the
-# server identity, add a pinned known_hosts mount here:
-#   - /home/nick/.ssh/lyra-known_hosts:/app/.ssh/known_hosts:ro
-# (not mounted yet — a bind-mount of a non-existent path would create an empty
-# dir, and the JS doesn't consume it until the cross-repo fix lands.)
+# Host-key pinning (cage-match #81, finding 2 — the cross-repo other half):
+# the lyra-live ssh hop in embodied-dreamfinder used StrictHostKeyChecking=no +
+# UserKnownHostsFile=/dev/null, accepting ANY server identity (MITM). The JS
+# fix is prepared in embodied-dreamfinder PR #65 (still OPEN, based on
+# feat/lyra-speak — the lyra-live brain isn't in that repo's main yet): the hop
+# switches to StrictHostKeyChecking=yes and reads its known_hosts from
+# LYRA_KNOWN_HOSTS (default /app/.ssh/known_hosts). This mount provides the file
+# the JS verifies the server against — the infra half of that fix.
+#
+# ACTIVATION GATE — all three must be true before flipping DF_BRAIN=lyra-live in
+# production, or the hop fails closed:
+#   1. embodied-dreamfinder PR #65 merged into the deployed app branch (so the
+#      StrictHostKeyChecking=yes consuming code is actually built).
+#   2. The pinned host key generated ONCE on the deploy host:
+#          ssh-keyscan 207.211.145.30 > /home/nick/.ssh/lyra-known_hosts
+#   3. DF_BRAIN=lyra-live set (which applies THIS override; see deploy-to.sh).
+# If the host file is missing/empty, the mount surfaces an empty/absent
+# known_hosts and StrictHostKeyChecking=yes makes ssh REFUSE the hop (fail
+# closed, by design — a missing pin must never silently trust any server).
+# In the default DF_BRAIN=api path this override is not applied, the mount is
+# absent, and the ssh hop never runs.
 services:
   app:
     volumes:
       # Deploy key for the lyra-live ssh hop (read-only). Present ONLY when this
       # override is applied — i.e. only in lyra-live mode.
       - /home/nick/.ssh/lyra-deploy:/app/.ssh/lyra-deploy:ro
+      # Pinned host key (known_hosts) the JS verifies robins-oci against — the
+      # server-identity half of the auth. Generate on the host with the
+      # ssh-keyscan above before enabling lyra-live (fail-closed if absent).
+      - /home/nick/.ssh/lyra-known_hosts:/app/.ssh/known_hosts:ro


### PR DESCRIPTION
## What

Adds the pinned `known_hosts` bind-mount to `embodied-dreamfinder/docker-compose.lyra.yml` — the **infra half** of cage-match #81's finding 2 (host-key pinning for the lyra-live ssh hop to robins-oci). Closes the cross-repo gap the file's own comment was tracking.

```yaml
- /home/nick/.ssh/lyra-known_hosts:/app/.ssh/known_hosts:ro
```

## Why

The lyra-live brain reaches the real Lyra container on `robins-oci` (`ubuntu@207.211.145.30`) over `ssh … docker exec`. The consuming code used `StrictHostKeyChecking=no` + `UserKnownHostsFile=/dev/null` — it accepted **any** server identity, so a network-positioned attacker could impersonate robins-oci, accept our deploy-key session, and capture the prompt/answer stream (MITM). The deploy key authenticates **us → server**; only a pinned host key verifies **server → us**.

The **app half** (`StrictHostKeyChecking=yes` + reading `known_hosts` from `LYRA_KNOWN_HOSTS`) is prepared in **embodied-dreamfinder PR #65**. This PR supplies the file that code verifies against, mounted only in lyra-live mode.

## Status of the moving parts (accurate, not optimistic)

- **embodied-dreamfinder PR #65** — OPEN, based on `feat/lyra-speak` (the lyra-live brain is **not** in that repo's `main` yet — `voice-pipeline-local.js` in app-main has no ssh hop at all). So this whole path is dark in prod twice over: `DF_BRAIN=api` ships AND the consuming JS isn't built yet.
- This override (`docker-compose.lyra.yml`) is applied **only** when `DF_BRAIN=lyra-live` (via `deploy-to.sh`). In the default `api` path the mount is absent and the hop never runs — so landing this is harmless to current prod.

## Fail-closed

If `/home/nick/.ssh/lyra-known_hosts` is missing/empty, the mount surfaces an empty/absent known_hosts and `StrictHostKeyChecking=yes` makes ssh **refuse** the hop. No path trusts an arbitrary key.

## ACTIVATION GATE (for Nick — all three before flipping `DF_BRAIN=lyra-live`)

1. **Merge embodied-dreamfinder PR #65** into the app's deployed branch (so the `StrictHostKeyChecking=yes` code is actually built). Note #65's base is `feat/lyra-speak`, not `main` — that chain needs to reach the deployed branch.
2. **Generate the pinned host key once on the deploy host:**
   ```sh
   ssh-keyscan 207.211.145.30 > /home/nick/.ssh/lyra-known_hosts
   ```
3. Set `DF_BRAIN=lyra-live` (applies this override).

Until all three hold, the lyra hop fails closed — intended.

## Review tier

Infra-as-code touching a **deploy** override (compose mount). Self-reviewed: yamllint clean with CI's exact config (`{extends: relaxed, rules: {line-length: {max: 150}}}`); change is additive (one volume + rewritten comment), the `api` path is provably untouched (override not applied), and the failure mode is fail-closed. CI's yamllint glob is `*/docker-compose.yml` so it won't lint this `.lyra.yml` file — verified manually instead.

Refs cage-match #81 finding 2; embodied-dreamfinder PR #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)