### PR TITLE
fix(dreamfinder): recognize River's bridged admin identities + fix calendar access

### DIFF
--- a/dreamfinder/docker-compose.yml
+++ b/dreamfinder/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       - LIVEKIT_API_KEY=${LIVEKIT_API_KEY:-}
       - LIVEKIT_API_SECRET=${LIVEKIT_API_SECRET:-}
       - ADMIN_IDS=${ADMIN_IDS:-}
+      # River's own relayed/bridged puppet MXIDs — dropped as self so River
+      # doesn't respond to its own echo the superbridge fans back into the hub.
+      - SELF_PUPPET_IDS=${SELF_PUPPET_IDS:-}
       - MATRIX_ALWAYS_RESPOND_ROOMS=${MATRIX_ALWAYS_RESPOND_ROOMS:-}
       # Bridge appservice bots excluded from DM member counting (portal rooms
       # carry the bridge bot as an extra member). All four MXIDs verified

--- a/dreamfinder/secrets.yaml
+++ b/dreamfinder/secrets.yaml
@@ -20,6 +20,7 @@ calendar_url: ENC[AES256_GCM,data:1xvCtL2eetvc2YpcF3a56aNqXOnXJbFquL6wuTUDFHtx+Y
 event_timezone: ENC[AES256_GCM,data:3TQqx+qbeJU+25l76fKyLc7OHQ==,iv:Goi/WKwFyMl0IGKG/pWGN3jZIHJmkyUd90M19ZK0CHg=,tag:qr1j5/zVLG7fcgnMtqcC3g==,type:str]
 deploy_announce_group_id: ENC[AES256_GCM,data:S6+bhVlDrI08EgqBiNOw4/ZE8gZJ/TVTUmljyIKbHQ5+VdY=,iv:OxZw4ZK5Q3huNnWF8h5PDm4MreWjbKeSSVEpjEJooP0=,tag:vA1Fgh7LvFK6TxCznJbvkw==,type:str]
 claude_code_oauth_token: ENC[AES256_GCM,data:PFKpkfjhxeZU9r1Y/kHrYGiMCmmDWaum5uM+EsimpDLh1s0txmaz+fbz0kRwaTBkSUKLjUxt19Uiva4UHQ2opRwm5nBdQC3tyB/KHHzNNjqP0OcUaK9BqTOlMrT8kvs+NPK6d/P/GBbQHtxY,iv:iR7fNnepq6EfTBwGbWezAfkocYH21Ijqjb6gbLgiXUk=,tag:LlJ3M9NRTTWAFzYs0za+bQ==,type:str]
+self_puppet_ids: ENC[AES256_GCM,data:6/BZzp1j+ALd5abXux96sMe8wpemX8jdJYiMwVROex4PT6456ZaqsVei+pG+IOE8CVYhGJe6yP0LxTppb0jGEeRKQ+OIkbiKFV1bJOxUvLKl9MCVCZ2tOteQkNka2iZvDALFdwrSM8NDFwzx7WJ4Zs+IOr0=,iv:eT6YFTQJsCmjMH88EHb525JV10aots5nP4bWAvYAsBs=,tag:Mj1xHtSwzezGE68UpuPZ1g==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -31,7 +32,7 @@ sops:
             cjYremsrWjczcm42QjZDVFQ4czNmMG8Ky2xTXnTpeOAAWjZKvAZ8SuupXqZ+tMFW
             b92n4tsWONqZWY9iALoeIz/N4UhkgYNT5v+gBfNLyq3t9cFXqdXMgQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-22T06:53:08Z"
-    mac: ENC[AES256_GCM,data:S5XHnhszsbT1PjoEfeog90CA2B0ETci9glcOle4QaOJZoejE5WMQK/NAFEgXqV7XcWqnJ8syVr1eaEY/Kv4B+KpUy9djmWxl6IIHmLHXZ0YLDW74WC23mOyp0gNXp5esnsPInh1USxa1OV3wTU2G8fD/K6us9o8XejvQS25wGvk=,iv:6lNPlhphT4qQMk5rZqS31eiBs8TfFfO0Be5sAlzPAGk=,tag:CvGFAsDhZkwUWy3TSeuBsw==,type:str]
+    lastmodified: "2026-06-23T02:52:04Z"
+    mac: ENC[AES256_GCM,data:UdKQd5SpsCaUw/wZMLkcPVqH9IjC7jmptxV3cYO5WA6DVQ71UCh9Zxs1Na23/xSn49BumP79AYzCVQr+yTi8XnLvPzDCE6HydIk8uUV9XSuABc524Odm2GwDxtSGsRucjPwoL/aG4ZJCaABtdjrFRigg/qkJpo9c5j+rpoca2LQ=,iv:3/IBtfcPuZ+dDxxk8487nwY6kfUkgF2YW69OX7Lj/Fs=,tag:V0O1VzRMyTDt/fxCbW/BdQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/dreamfinder/secrets.yaml
+++ b/dreamfinder/secrets.yaml
@@ -14,9 +14,9 @@ api_key: ENC[AES256_GCM,data:SeeK8INLzkAdBREepCfPksWRkt1FAjwS6qgdq+rMU7w8vaqvst5
 livekit_url: ENC[AES256_GCM,data:Z2ffdfV7NIp78dy8s6nAtgqlcSY5mF4e9Jc4L7I=,iv:wg8+fQvLH7B53pv9rpuxaXi6l4OtalV483vF7g4OhdU=,tag:Hxsi7/sD/6XWafz5x5f0Qw==,type:str]
 livekit_api_key: ENC[AES256_GCM,data:NVduA/w4U9TBmPNBJbbuji9Urg==,iv:AA7Y5L1YgW8tLsDeOPadG8DiYlQLMDUlNqaAvKB/Xig=,tag:AoUOhyrDw1nnXdBEdJRhKQ==,type:str]
 livekit_api_secret: ENC[AES256_GCM,data:R+4ssfUpTVTHiP1e/LcUpgf2ZAJTHnMNX8r29fBpNnWfK7snsXid3kKEiQVuH0W0wiF9MQUHCfaFrN6KvHi9bg==,iv:BcZXEHotQc/3uftpI8Dz3X1cPtt2RoU2XTsoGK3ufiY=,tag:uof7AJGxPejNRuAW0HmJ6Q==,type:str]
-admin_ids: ENC[AES256_GCM,data:1OtYW32mnu8WbuRH7np9yBka3AFcxRxmdxMMhUEBEfEmo3cSyTvQSMEp6BPnz/UA25zPCqn53oUsN05vJLW1w0YtCByYp1Vl03OwzJb3z95FSQ==,iv:aY0Z0c8JtiCcfbQpPufSmNjJBW9liO8CwDAvDRxAbC8=,tag:r35sNmYpEL1aR5hLJHNerg==,type:str]
+admin_ids: ENC[AES256_GCM,data:Kd89uPSXWFgwStFw+He/w8EUfnalHlhpFAY3X4kfs3iS/LKwA/1MOKHxW2Cqa/O4Y2IaklM6DOkCH/WXiofqSEMMqu+G8fz/n/XYjRYG5IKDtJd+d/LkCDiPEC+mK9LSYoVf5mItIP+ti9lhnuaiLdd788TTLNgsIrTLcIvHBwBYamzo154DOnklBR38PUDzWQhqCAdiX3/V33lEC/y9nVFxv433erEI0lBfboDSIurJyvXBZvVH8Mpp6HCInXxo6JYizAuwGL2OzzdEUbV/FIOxxPltiMUR+PDQ6NcDpAioY1QGwIlLdsziHFNo8kzlWQ==,iv:tmalWBRkdsdtAImKgpDxZWNgmTikdEkol/f6uWcmxFU=,tag:Xfz6S75l39oNsmkq57RTRQ==,type:str]
 matrix_always_respond_rooms: ENC[AES256_GCM,data:HgVPhJsjYRqASvba5IEU+TRl8PPoKYldB4vGY4F2J15Hq5M=,iv:JZ+NE6H2RJ0Pp1myPmEh4AFFm1AUNWwJe4NDeR0+4b4=,tag:syyL8UUX6twGmg3rf+RX3w==,type:str]
-calendar_url: ENC[AES256_GCM,data:YqkXHhWb1KTzJOLN5jm742Stf/BoNLY2TzvzmxN2mG5FSWG6X6l1RLiYx/0A4iNMzMAJPY3lEp7Ky+K0,iv:gqnydGzMVhSgcirleUxwFWkh+da0Hua54WtXKVjwlCs=,tag:illLnGigADWR/XlJ58Zi9A==,type:str]
+calendar_url: ENC[AES256_GCM,data:1xvCtL2eetvc2YpcF3a56aNqXOnXJbFquL6wuTUDFHtx+Y/s67QsxzZp24U5r6ZNRCzHD3s=,iv:gDaApFD1U4+zYB1SZw/06SzbpXQRftQH7CplT88XSGE=,tag:R4CXHkln99PRv5kcyprCOw==,type:str]
 event_timezone: ENC[AES256_GCM,data:3TQqx+qbeJU+25l76fKyLc7OHQ==,iv:Goi/WKwFyMl0IGKG/pWGN3jZIHJmkyUd90M19ZK0CHg=,tag:qr1j5/zVLG7fcgnMtqcC3g==,type:str]
 deploy_announce_group_id: ENC[AES256_GCM,data:S6+bhVlDrI08EgqBiNOw4/ZE8gZJ/TVTUmljyIKbHQ5+VdY=,iv:OxZw4ZK5Q3huNnWF8h5PDm4MreWjbKeSSVEpjEJooP0=,tag:vA1Fgh7LvFK6TxCznJbvkw==,type:str]
 claude_code_oauth_token: ENC[AES256_GCM,data:PFKpkfjhxeZU9r1Y/kHrYGiMCmmDWaum5uM+EsimpDLh1s0txmaz+fbz0kRwaTBkSUKLjUxt19Uiva4UHQ2opRwm5nBdQC3tyB/KHHzNNjqP0OcUaK9BqTOlMrT8kvs+NPK6d/P/GBbQHtxY,iv:iR7fNnepq6EfTBwGbWezAfkocYH21Ijqjb6gbLgiXUk=,tag:LlJ3M9NRTTWAFzYs0za+bQ==,type:str]
@@ -31,7 +31,7 @@ sops:
             cjYremsrWjczcm42QjZDVFQ4czNmMG8Ky2xTXnTpeOAAWjZKvAZ8SuupXqZ+tMFW
             b92n4tsWONqZWY9iALoeIz/N4UhkgYNT5v+gBfNLyq3t9cFXqdXMgQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-21T09:01:38Z"
-    mac: ENC[AES256_GCM,data:iOPaNYT+ohCr08QX+URqqU0mc+o1QkVYC4lHon7B7MnnqQICpbzhONhpeyq+c5WuYRkS1VhzGpn598pF1L/iySFZrBAXY6MpuhwL0fvata1yWdyqPeYaj791zWXChsuYE8k8R+Vi9I//a0CF57kDnwsYZCEKOZ9pBvgqP6XSwI0=,iv:D5kfFLQGFVpdZYHcIQ5LtVI+qV25Xeg30L3vdqz6DE8=,tag:dTxZPuYERp8x3gMRmWVaGQ==,type:str]
+    lastmodified: "2026-06-22T06:53:08Z"
+    mac: ENC[AES256_GCM,data:S5XHnhszsbT1PjoEfeog90CA2B0ETci9glcOle4QaOJZoejE5WMQK/NAFEgXqV7XcWqnJ8syVr1eaEY/Kv4B+KpUy9djmWxl6IIHmLHXZ0YLDW74WC23mOyp0gNXp5esnsPInh1USxa1OV3wTU2G8fD/K6us9o8XejvQS25wGvk=,iv:6lNPlhphT4qQMk5rZqS31eiBs8TfFfO0Be5sAlzPAGk=,tag:CvGFAsDhZkwUWy3TSeuBsw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -675,6 +675,7 @@ deploy_pm_bot() {
         printf 'LIVEKIT_API_KEY=%s\n'             "$(dotenv_quote "$(pm_bot_field '.livekit_api_key')")"
         printf 'LIVEKIT_API_SECRET=%s\n'          "$(dotenv_quote "$(pm_bot_field '.livekit_api_secret')")"
         printf 'ADMIN_IDS=%s\n'                   "$(dotenv_quote "$(pm_bot_field '.admin_ids')")"
+        printf 'SELF_PUPPET_IDS=%s\n'             "$(dotenv_quote "$(pm_bot_field '.self_puppet_ids')")"
         printf 'MATRIX_ALWAYS_RESPOND_ROOMS=%s\n' "$(dotenv_quote "$(pm_bot_field '.matrix_always_respond_rooms')")"
         printf 'CALENDAR_URL=%s\n'                "$(dotenv_quote "$(pm_bot_field '.calendar_url')")"
         printf 'EVENT_TIMEZONE=%s\n'              "$(dotenv_quote "$(pm_bot_field '.event_timezone')")"


### PR DESCRIPTION
Persists two prod config fixes made live during today's River debugging session (kickstart 'needs admin' + 'doesn't know meetups').

## 1. Bridged admin recognition (`admin_ids`)
River checks `adminIds.contains(event.sender)`. Over a bridge, `event.sender` is a puppet MXID (`@_relay_signal_*`, `@telegram_*`, `@_relay_whatsapp_*`), never `@nick:imagineering.cc` — so every admin-gated action (kickstart workspace setup, chat-config, etc.) refused Nick. Added Nick's per-platform puppet MXIDs (harvested from hub membership; deterministic/stable). **Verified live**: the relay puppet was processed past the admin gate after redeploy.

Stopgap for the proper identity-resolution layer (#13/#14, hybrid auto-suggest+admin-confirm) — these manual entries become its backward-compat seed.

## 2. Calendar access (`calendar_url`)
Was `/dreamfinder/imagineering-events/` — but there is **no `dreamfinder` radicale principal** and no rights grant, so `radicale_list_events` got a permanent 403 → River saw zero events → 'doesn't know the meetups'. Repointed to `/nick/imagineering-events/`, covered by the existing `pm-agent → nick` shared-calendar rights rule. Calendar created (MKCALENDAR 201), readable as pm-agent (207). **Awaiting**: real meetup events to replace the throwaway probe.

## Also done live (not in this diff)
- River left the duplicate Signal 'Imagineering' portal room so it no longer double-responds (runtime Matrix state; durable single-room/ignore-list config is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)