### PR TITLE
feat(self-healer): amber-ping — notify on amber+ via notify proxy

### DIFF
--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -102,20 +102,29 @@ existing `notify` proxy (`https://notify.imagineering.cc/send`, a public HTTPS
 endpoint), so this is a plain `fetch` with no shell/SSH surface.
 
 - **Still read-only.** A ping is a notification, not a remediation.
-- **Secrets are scrubbed** from the message (`scrubSecrets`) — the model's
-  diagnosis could quote a log line containing a credential. Only verdict fields
-  (summary + findings) are sent; never the raw `signals`/log tails. Dynamic text
-  is HTML-escaped so it can't break or inject the Telegram markup.
+- **Best-effort secret scrubbing** (`scrubSecrets`) — the model's diagnosis
+  could quote a credential-bearing log line. A prefix denylist alone is a sieve,
+  so it's *layered*: known prefixes (anthropic/github/slack/google/openai/
+  stripe/brevo/aws/JWT/PEM) + a `key=value` redactor for sensitive key names +
+  a high-entropy catch-all for any 32+ char opaque token (the floor preserves
+  shorter diagnostic IDs like LiveKit's ~24-char nodeIds). Leak-side
+  conservative: over-redaction in an outbound message is cheap; a leak is not.
+  Only verdict fields (summary + findings) are sent — never the raw
+  `signals`/log tails. Dynamic text is HTML-escaped (all five metacharacters).
+- **Cooldown (default ON, escalation-aware).** A persistently-amber signal is
+  re-pinged at most once per `HEALER_COOLDOWN_MIN` (default 60) — but a *new*
+  problem or a *tier escalation* (different fingerprint) pings immediately, and
+  the same problem re-pings as an hourly reminder once the window lapses. State
+  in `HEALER_STATE_DIR/last-ping.json`; degrades OPEN (a state-file failure
+  pings anyway — missing a real alert is worse than a duplicate). Set
+  `HEALER_COOLDOWN_MIN=0` to disable.
 - **Silent when it should be:** green verdicts and environments without a
   `NOTIFY_API_KEY` are no-ops, so a dev run never errors and a clean bill never
-  spams. Set `HEALER_NO_PING=1` to force-disable.
-- **Config:** `NOTIFY_API_KEY` (required to actually send), `NOTIFY_URL`
-  (default the public proxy).
-
-> ⚠️ **KNOWN LIMITATION — stateless, no cooldown.** amber-ping has no dedup: a
-> persistently-amber signal would ping on *every* run. The healer isn't
-> scheduled yet, so this can't spam today — but a cooldown/dedup MUST be added
-> **before** wiring the cron. Tracked as a follow-up.
+  spams. `HEALER_NO_PING=1` force-disables.
+- **`NOTIFY_URL` is validated** to https (or loopback http) so an env-poisoned
+  URL can't redirect the Bearer key to an attacker over cleartext.
+- **Config:** `NOTIFY_API_KEY` (required to send), `NOTIFY_URL` (default the
+  public proxy), `HEALER_COOLDOWN_MIN`, `HEALER_STATE_DIR`, `HEALER_NO_PING`.
 
 ## Security posture (v1)
 

--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -85,14 +85,37 @@ is told: when unsure, pick the higher tier and lower confidence.
 v1 stops at the verdict on purpose — the classifier must earn trust against
 real prod signals before any hands are wired. In order:
 
-1. **v1 (this):** sensor → diagnose → read-only verdict. ✅
-2. **amber ping:** post the verdict to a channel (Telegram/Discord) on amber+.
+1. **v1:** sensor → diagnose → read-only verdict. ✅
+2. **amber ping:** notify on amber+ via the `notify` proxy. ✅ (still read-only)
 3. **green draft:** on a confident green finding, draft a fix PR (no merge).
 4. **green auto:** behind an explicit flag, run the full green-tier loop
    (fix → cage-match → merge → deploy → re-sense to confirm the symptom is gone).
 
 Each step is gated on the previous one being *observed correct in prod*, not
 just coded. The cage is built before the monster.
+
+### amber-ping
+
+When a verdict is amber or red, the healer sends Nick a Telegram message. It
+does **not** hold a bot token or build a Telegram path — it POSTs to the
+existing `notify` proxy (`https://notify.imagineering.cc/send`, a public HTTPS
+endpoint), so this is a plain `fetch` with no shell/SSH surface.
+
+- **Still read-only.** A ping is a notification, not a remediation.
+- **Secrets are scrubbed** from the message (`scrubSecrets`) — the model's
+  diagnosis could quote a log line containing a credential. Only verdict fields
+  (summary + findings) are sent; never the raw `signals`/log tails. Dynamic text
+  is HTML-escaped so it can't break or inject the Telegram markup.
+- **Silent when it should be:** green verdicts and environments without a
+  `NOTIFY_API_KEY` are no-ops, so a dev run never errors and a clean bill never
+  spams. Set `HEALER_NO_PING=1` to force-disable.
+- **Config:** `NOTIFY_API_KEY` (required to actually send), `NOTIFY_URL`
+  (default the public proxy).
+
+> ⚠️ **KNOWN LIMITATION — stateless, no cooldown.** amber-ping has no dedup: a
+> persistently-amber signal would ping on *every* run. The healer isn't
+> scheduled yet, so this can't spam today — but a cooldown/dedup MUST be added
+> **before** wiring the cron. Tracked as a follow-up.
 
 ## Security posture (v1)
 

--- a/self-healer/src/healer.mjs
+++ b/self-healer/src/healer.mjs
@@ -16,6 +16,7 @@ import { gatherSignals, assertValidContainerName } from './sensor.mjs';
 import { diagnose } from './diagnose.mjs';
 import { isOnBox } from './host.mjs';
 import { tierExitCode } from './tiers.mjs';
+import { pingIfNoteworthy } from './notify.mjs';
 
 /**
  * Load + validate the watch list. Fails CLOSED on a malformed config so a bad
@@ -97,6 +98,17 @@ async function main() {
   // healer can be piped into the (future) action stage or a monitor.
   process.stderr.write(render(verdict, signals));
   process.stdout.write(JSON.stringify({ ...verdict, sampledAt: new Date().toISOString(), signals }, null, 2) + '\n');
+
+  // amber-ping: notify Nick via the `notify` proxy when the verdict is amber
+  // or red. Green and unconfigured (no NOTIFY_API_KEY) environments are silent.
+  // A ping FAILURE must not change the diagnostic exit code (the verdict stands
+  // either way) — surface it on stderr and carry on.
+  try {
+    const { pinged, reason } = await pingIfNoteworthy(verdict);
+    process.stderr.write(pinged ? '[healer] amber-ping sent.\n' : `[healer] no ping (${reason}).\n`);
+  } catch (err) {
+    process.stderr.write(`[healer] amber-ping FAILED (verdict still stands): ${err.message}\n`);
+  }
 
   // Exit code communicates tier to a cron/monitor without parsing JSON.
   // verdict.overallTier is already validated to the closed set in diagnose().

--- a/self-healer/src/notify.mjs
+++ b/self-healer/src/notify.mjs
@@ -4,47 +4,92 @@
 // TOPOLOGY: we do NOT hold a Telegram bot token or build a Telegram path. The
 // `notify` service (imagineering-infra/notify, https://notify.imagineering.cc)
 // already is the notification bus — it holds the bot token centrally and takes
-// a thin `POST /send` with a Bearer API key. amber-ping just POSTs to it.
-// Because notify is PUBLIC https (unlike claude-shim's loopback bind), this is
-// a plain `fetch` — no shell, no SSH, no host primitive, no injection surface.
+// a thin `POST /send` with a Bearer API key. Because notify is PUBLIC https
+// (unlike claude-shim's loopback bind), this is a plain `fetch` — no shell, no
+// SSH, no host primitive, no injection surface.
 
-const NOTIFY_URL = process.env.NOTIFY_URL || 'https://notify.imagineering.cc/send';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Resolve + validate the notify endpoint. The Bearer key is sent in this
+ * request, so we refuse to send it anywhere but https (TLS) or loopback http —
+ * an env-poisoned NOTIFY_URL can't redirect the key to an attacker over plain
+ * http (cage-match PR #101). Mirrors diagnose.mjs's SHIM_URL discipline. */
+function resolveNotifyUrl() {
+  const raw = process.env.NOTIFY_URL || 'https://notify.imagineering.cc/send';
+  let u;
+  try { u = new URL(raw); } catch { throw new Error(`NOTIFY_URL is not a valid URL: ${JSON.stringify(raw)}`); }
+  const loopback = u.hostname === '127.0.0.1' || u.hostname === 'localhost' || u.hostname === '::1';
+  if (u.protocol === 'https:' || (u.protocol === 'http:' && loopback)) return u.toString();
+  throw new Error(`NOTIFY_URL must be https (or http to loopback) so the Bearer key isn't sent in cleartext. Got: ${raw}`);
+}
+
+const TELEGRAM_MAX = 4096; // Telegram's hard message-length limit.
+
+// Known secret PREFIXES — the first line of defence (cheap, precise). NOT the
+// only line: the generic rules below catch the shapes a prefix list can't.
+const KNOWN_SECRET_PATTERNS = [
+  [/\bsk-ant-[a-zA-Z0-9_-]{6,}/g, '<redacted:anthropic-key>'],
+  [/\b(?:github_pat|gh[posru])_[A-Za-z0-9_]{16,}/g, '<redacted:github-token>'],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, '<redacted:slack-token>'],
+  [/\bAIza[A-Za-z0-9_-]{20,}/g, '<redacted:google-key>'],
+  [/\bsk-(?:proj-)?[A-Za-z0-9]{20,}/g, '<redacted:openai-key>'],
+  [/\bsk_(?:live|test)_[A-Za-z0-9]{16,}/g, '<redacted:stripe-key>'],
+  [/\bxkeysib-[A-Za-z0-9]{16,}/g, '<redacted:brevo-key>'],
+  [/\bAKIA[0-9A-Z]{16}\b/g, '<redacted:aws-key-id>'],
+  [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/g, '<redacted:bearer>'],
+  [/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}/g, '<redacted:jwt>'],
+  [/-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----/g, '<redacted:private-key>'],
+];
 
 /**
- * Scrub secret-shaped tokens out of any text before it leaves the box. The
- * verdict's diagnosis/evidence fields are model-generated and MAY quote a log
- * line that contains a credential (cage-match PR #100 concern). We replace
- * known token shapes with a typed placeholder rather than trusting the model
- * not to echo a secret.
+ * Scrub secret-shaped text out of a message before it leaves the box. The
+ * model's diagnosis/evidence MAY quote a credential-bearing log line. A prefix
+ * denylist alone is a sieve (cage-match PR #101: AWS secret keys, unknown
+ * tokens, k=v configs all slip it), so we LAYER three defences, leak-side
+ * conservative (over-redaction in an outbound notification is cheap; a leak is
+ * not):
+ *   1. known secret prefixes (precise);
+ *   2. key=value / key: value for sensitive key NAMES (catches unknown formats);
+ *   3. a high-entropy catch-all for any 32+ char opaque token (catches AWS
+ *      secret keys & unknown credentials). The 32 floor preserves shorter
+ *      diagnostic IDs like LiveKit's ~24-char nodeIds.
  * @param {string} text
  * @returns {string}
  */
 export function scrubSecrets(text) {
   if (typeof text !== 'string') return '';
-  return text
-    .replace(/sk-ant-[a-zA-Z0-9_-]{8,}/g, '<redacted:anthropic-key>')
-    .replace(/\bgh[posru]_[A-Za-z0-9]{16,}/g, '<redacted:github-token>')
-    .replace(/\bxkeysib-[a-f0-9]{16,}/g, '<redacted:brevo-key>')
-    .replace(/\bAKIA[0-9A-Z]{16}\b/g, '<redacted:aws-key>')
-    .replace(/\bBearer\s+[A-Za-z0-9._-]{12,}/g, 'Bearer <redacted>')
-    .replace(/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}/g, '<redacted:jwt>');
+  let out = text;
+  for (const [re, repl] of KNOWN_SECRET_PATTERNS) out = out.replace(re, repl);
+  // 2. sensitive key=value / key: value (preserve the key name, redact value).
+  out = out.replace(
+    /\b(pass(?:word|wd)?|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?key|auth(?:orization)?|token)\b(\s*[=:]\s*)('?"?)[^\s'"]+/gi,
+    (_m, key, sep) => `${key}${sep}<redacted>`,
+  );
+  // 3. high-entropy catch-all: any 32+ char run of credential-alphabet chars.
+  out = out.replace(/\b[A-Za-z0-9+/_-]{32,}={0,2}\b/g, '<redacted:high-entropy>');
+  return out;
 }
 
-/** Escape the five HTML metacharacters so dynamic text can't break (or inject
- * into) the Telegram HTML parse_mode markup. */
+/** Escape the five HTML metacharacters so dynamic text can't break out of (or
+ * inject into) the Telegram HTML parse_mode — including quotes, so the markup
+ * stays safe if an attribute-bearing tag is ever added. */
 function esc(text) {
   return String(text ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 const DOT = { green: '🟢', amber: '🟡', red: '🔴' };
 
 /**
  * Format a verdict into a compact Telegram HTML message. Includes ONLY the
- * verdict fields (summary + findings), never the raw `signals`/log tails — and
- * scrubs secrets from every dynamic string as defence in depth.
+ * verdict fields (summary + findings), never the raw `signals`/log tails, with
+ * every dynamic string scrubbed then escaped, then capped to Telegram's limit.
  * @param {{summary: string, overallTier: string, findings: object[]}} verdict
  * @returns {string}
  */
@@ -63,32 +108,69 @@ export function formatVerdict(verdict) {
   }
   lines.push('');
   lines.push('<i>read-only v1 — no remediation taken</i>');
-  return lines.join('\n');
+
+  let msg = lines.join('\n');
+  if (msg.length > TELEGRAM_MAX) msg = msg.slice(0, TELEGRAM_MAX - 20) + '\n<i>…(truncated)</i>';
+  return msg;
+}
+
+/** A stable fingerprint of the PROBLEM SET (tiers + per-finding
+ * container/tier/signature), order-independent. Same problems ⇒ same key; a new
+ * finding or a tier escalation ⇒ different key ⇒ re-ping immediately. */
+export function verdictFingerprint(verdict) {
+  const parts = (verdict.findings || [])
+    .map((f) => `${f.container}:${f.tier}:${f.signature}`)
+    .sort();
+  return createHash('sha256').update(`${verdict.overallTier}|${parts.join('|')}`).digest('hex').slice(0, 16);
 }
 
 /**
- * Ping Nick about a verdict IF it's worth pinging about (amber or red) and a
- * NOTIFY_API_KEY is configured. Green verdicts and unconfigured environments
- * are silent no-ops — so a dev run without a key doesn't error, and a clean
- * bill of health doesn't spam.
- *
- * NOTE (known limitation, intentional for v1): this is STATELESS — it has no
- * cooldown/dedup. A persistently-amber signal pinged on a cron would notify
- * every run. The healer is not scheduled yet, so this can't spam today; a
- * cooldown MUST be added before wiring the cron (tracked as a follow-up).
- *
+ * Cooldown gate (default ON, escalation-aware). Returns true if we should ping.
+ * Skips a re-ping of the SAME problem set within HEALER_COOLDOWN_MIN minutes
+ * (default 60) so a persistently-amber signal on a cron doesn't notify every
+ * run — but an escalation or a new problem (different fingerprint) always pings,
+ * and the same problem re-pings once the window lapses (an hourly reminder, not
+ * spam). Degrades OPEN: if the state file can't be read/written, we ping anyway
+ * (missing a real alert is worse than a duplicate). @returns {boolean} */
+export function passesCooldown(verdict, nowMs) {
+  const windowMin = Number.parseInt(process.env.HEALER_COOLDOWN_MIN ?? '60', 10);
+  if (!Number.isFinite(windowMin) || windowMin <= 0) return true; // cooldown disabled
+  const dir = process.env.HEALER_STATE_DIR || '/tmp/self-healer';
+  const file = join(dir, 'last-ping.json');
+  const fp = verdictFingerprint(verdict);
+
+  let prior = null;
+  try { prior = JSON.parse(readFileSync(file, 'utf8')); } catch { /* no/!corrupt state ⇒ ping */ }
+  if (prior && prior.fp === fp && typeof prior.atMs === 'number' && nowMs - prior.atMs < windowMin * 60_000) {
+    return false; // same problem set, still inside the window
+  }
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, JSON.stringify({ fp, atMs: nowMs }));
+  } catch { /* best-effort: a write failure must not suppress the alert */ }
+  return true;
+}
+
+/**
+ * Ping Nick about a verdict IF it's amber+, a NOTIFY_API_KEY is configured, and
+ * the cooldown allows it. Green / unconfigured / disabled / cooled-down cases
+ * are silent no-ops so a dev run never errors and nothing spams.
  * @param {{summary: string, overallTier: string, findings: object[]}} verdict
+ * @param {number} [nowMs] injectable clock for tests
  * @returns {Promise<{pinged: boolean, reason?: string}>}
  */
-export async function pingIfNoteworthy(verdict) {
+export async function pingIfNoteworthy(verdict, nowMs = Date.now()) {
   if (verdict.overallTier === 'green') return { pinged: false, reason: 'green — nothing to report' };
   if (process.env.HEALER_NO_PING === '1') return { pinged: false, reason: 'disabled via HEALER_NO_PING' };
 
   const apiKey = process.env.NOTIFY_API_KEY;
   if (!apiKey) return { pinged: false, reason: 'no NOTIFY_API_KEY configured' };
 
+  if (!passesCooldown(verdict, nowMs)) return { pinged: false, reason: 'cooldown — same problem set recently pinged' };
+
+  const url = resolveNotifyUrl();
   const message = formatVerdict(verdict);
-  const res = await fetch(NOTIFY_URL, {
+  const res = await fetch(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
     body: JSON.stringify({ message, parse_mode: 'HTML' }),

--- a/self-healer/src/notify.mjs
+++ b/self-healer/src/notify.mjs
@@ -1,0 +1,102 @@
+// notify.mjs — amber-ping: when a verdict is amber or red, send Nick a
+// Telegram message via the existing `notify` proxy.
+//
+// TOPOLOGY: we do NOT hold a Telegram bot token or build a Telegram path. The
+// `notify` service (imagineering-infra/notify, https://notify.imagineering.cc)
+// already is the notification bus — it holds the bot token centrally and takes
+// a thin `POST /send` with a Bearer API key. amber-ping just POSTs to it.
+// Because notify is PUBLIC https (unlike claude-shim's loopback bind), this is
+// a plain `fetch` — no shell, no SSH, no host primitive, no injection surface.
+
+const NOTIFY_URL = process.env.NOTIFY_URL || 'https://notify.imagineering.cc/send';
+
+/**
+ * Scrub secret-shaped tokens out of any text before it leaves the box. The
+ * verdict's diagnosis/evidence fields are model-generated and MAY quote a log
+ * line that contains a credential (cage-match PR #100 concern). We replace
+ * known token shapes with a typed placeholder rather than trusting the model
+ * not to echo a secret.
+ * @param {string} text
+ * @returns {string}
+ */
+export function scrubSecrets(text) {
+  if (typeof text !== 'string') return '';
+  return text
+    .replace(/sk-ant-[a-zA-Z0-9_-]{8,}/g, '<redacted:anthropic-key>')
+    .replace(/\bgh[posru]_[A-Za-z0-9]{16,}/g, '<redacted:github-token>')
+    .replace(/\bxkeysib-[a-f0-9]{16,}/g, '<redacted:brevo-key>')
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, '<redacted:aws-key>')
+    .replace(/\bBearer\s+[A-Za-z0-9._-]{12,}/g, 'Bearer <redacted>')
+    .replace(/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}/g, '<redacted:jwt>');
+}
+
+/** Escape the five HTML metacharacters so dynamic text can't break (or inject
+ * into) the Telegram HTML parse_mode markup. */
+function esc(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+const DOT = { green: '🟢', amber: '🟡', red: '🔴' };
+
+/**
+ * Format a verdict into a compact Telegram HTML message. Includes ONLY the
+ * verdict fields (summary + findings), never the raw `signals`/log tails — and
+ * scrubs secrets from every dynamic string as defence in depth.
+ * @param {{summary: string, overallTier: string, findings: object[]}} verdict
+ * @returns {string}
+ */
+export function formatVerdict(verdict) {
+  const clean = (s) => esc(scrubSecrets(s));
+  const lines = [
+    `${DOT[verdict.overallTier] || '⚪'} <b>Self-healer: ${esc(verdict.overallTier?.toUpperCase())}</b>`,
+    clean(verdict.summary),
+  ];
+  for (const f of verdict.findings || []) {
+    lines.push('');
+    lines.push(`${DOT[f.tier] || '⚪'} <b>${clean(f.container)}</b> — ${clean(f.signature)}` +
+      `${f.selfRecovered ? ' <i>(self-recovered)</i>' : ''}`);
+    if (f.diagnosis) lines.push(clean(f.diagnosis));
+    if (f.proposedAction && f.proposedAction !== 'none') lines.push(`→ ${clean(f.proposedAction)}`);
+  }
+  lines.push('');
+  lines.push('<i>read-only v1 — no remediation taken</i>');
+  return lines.join('\n');
+}
+
+/**
+ * Ping Nick about a verdict IF it's worth pinging about (amber or red) and a
+ * NOTIFY_API_KEY is configured. Green verdicts and unconfigured environments
+ * are silent no-ops — so a dev run without a key doesn't error, and a clean
+ * bill of health doesn't spam.
+ *
+ * NOTE (known limitation, intentional for v1): this is STATELESS — it has no
+ * cooldown/dedup. A persistently-amber signal pinged on a cron would notify
+ * every run. The healer is not scheduled yet, so this can't spam today; a
+ * cooldown MUST be added before wiring the cron (tracked as a follow-up).
+ *
+ * @param {{summary: string, overallTier: string, findings: object[]}} verdict
+ * @returns {Promise<{pinged: boolean, reason?: string}>}
+ */
+export async function pingIfNoteworthy(verdict) {
+  if (verdict.overallTier === 'green') return { pinged: false, reason: 'green — nothing to report' };
+  if (process.env.HEALER_NO_PING === '1') return { pinged: false, reason: 'disabled via HEALER_NO_PING' };
+
+  const apiKey = process.env.NOTIFY_API_KEY;
+  if (!apiKey) return { pinged: false, reason: 'no NOTIFY_API_KEY configured' };
+
+  const message = formatVerdict(verdict);
+  const res = await fetch(NOTIFY_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ message, parse_mode: 'HTML' }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`notify /send failed (${res.status}): ${body.slice(0, 200)}`);
+  }
+  return { pinged: true };
+}

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -9,13 +9,32 @@ import assert from 'node:assert/strict';
 import { normalizeTier, tierExitCode, maxTier, TIERS } from '../src/tiers.mjs';
 import { extractVerdict, validateVerdict } from '../src/diagnose.mjs';
 import { collapseRepeats, assertValidContainerName } from '../src/sensor.mjs';
-import { scrubSecrets, formatVerdict, pingIfNoteworthy } from '../src/notify.mjs';
+import { scrubSecrets, formatVerdict, pingIfNoteworthy, verdictFingerprint, passesCooldown } from '../src/notify.mjs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pjoin } from 'node:path';
 
-test('scrubSecrets: redacts known token shapes', () => {
+test('scrubSecrets: redacts known token prefixes', () => {
   assert.match(scrubSecrets('token sk-ant-oat01-abc123DEF_xyz here'), /<redacted:anthropic-key>/);
   assert.match(scrubSecrets('ghs_AAAABBBBCCCCDDDD1111'), /<redacted:github-token>/);
-  assert.match(scrubSecrets('Authorization: Bearer abcdef1234567890'), /Bearer <redacted>/);
+  assert.match(scrubSecrets('github_pat_11ABCDEFG_longtailwithunderscores0000'), /<redacted:github-token>/);
+  assert.doesNotMatch(scrubSecrets('Authorization: Bearer abcdef1234567890'), /abcdef1234567890/);
   assert.equal(scrubSecrets('nothing secret here'), 'nothing secret here');
+});
+
+test('scrubSecrets: catches the shapes a prefix list misses (cage-match PR #101)', () => {
+  // AWS *secret* key (40-char base64, no prefix) → high-entropy catch-all.
+  assert.match(scrubSecrets('aws wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1'), /<redacted/);
+  // k=v with a sensitive key name and an unknown token format.
+  assert.match(scrubSecrets('password=hunter2supersecret'), /password=<redacted>/);
+  assert.match(scrubSecrets('client_secret: abc.def.ghi'), /client_secret:\s*<redacted>/);
+  // PEM private key block.
+  assert.match(scrubSecrets('-----BEGIN PRIVATE KEY-----\nMIIabc\n-----END PRIVATE KEY-----'), /<redacted:private-key>/);
+});
+
+test('scrubSecrets: preserves short diagnostic IDs (LiveKit nodeIds ~24 chars)', () => {
+  // The 32-char floor on the high-entropy rule keeps diagnostic value.
+  assert.match(scrubSecrets('rotated to NC_OSYDNEY1A_VTmCnBmjsS8o ok'), /NC_OSYDNEY1A_VTmCnBmjsS8o/);
 });
 
 test('formatVerdict: HTML-escapes dynamic text and scrubs secrets', () => {
@@ -44,6 +63,42 @@ test('pingIfNoteworthy: amber without a key is a no-op (no network)', async () =
     assert.match(r.reason, /NOTIFY_API_KEY/);
   } finally {
     if (saved !== undefined) process.env.NOTIFY_API_KEY = saved;
+  }
+});
+
+test('verdictFingerprint: stable, order-independent, changes on escalation', () => {
+  const a = { overallTier: 'amber', findings: [{ container: 'x', tier: 'amber', signature: 's1' }, { container: 'y', tier: 'green', signature: 's2' }] };
+  const b = { overallTier: 'amber', findings: [{ container: 'y', tier: 'green', signature: 's2' }, { container: 'x', tier: 'amber', signature: 's1' }] };
+  assert.equal(verdictFingerprint(a), verdictFingerprint(b)); // order-independent
+  const escalated = { overallTier: 'red', findings: [{ container: 'x', tier: 'red', signature: 's1' }, { container: 'y', tier: 'green', signature: 's2' }] };
+  assert.notEqual(verdictFingerprint(a), verdictFingerprint(escalated)); // escalation ⇒ new fp
+});
+
+test('passesCooldown: same problem within window skips, escalation + expiry re-ping', () => {
+  const saved = process.env.HEALER_STATE_DIR;
+  process.env.HEALER_STATE_DIR = mkdtempSync(pjoin(tmpdir(), 'healer-cd-'));
+  try {
+    const v = { overallTier: 'amber', findings: [{ container: 'c', tier: 'amber', signature: 's' }] };
+    const t0 = 1_000_000_000_000;
+    assert.equal(passesCooldown(v, t0), true);                 // first time ⇒ ping
+    assert.equal(passesCooldown(v, t0 + 60_000), false);       // 1 min later, same ⇒ skip
+    const worse = { overallTier: 'red', findings: [{ container: 'c', tier: 'red', signature: 's' }] };
+    assert.equal(passesCooldown(worse, t0 + 120_000), true);   // escalated ⇒ ping despite window (re-stamps clock to here)
+    assert.equal(passesCooldown(worse, t0 + 120_000 + 61 * 60_000), true); // >60min after LAST ping ⇒ re-ping (reminder)
+  } finally {
+    if (saved !== undefined) process.env.HEALER_STATE_DIR = saved; else delete process.env.HEALER_STATE_DIR;
+  }
+});
+
+test('passesCooldown: HEALER_COOLDOWN_MIN=0 disables the cooldown', () => {
+  const saved = process.env.HEALER_COOLDOWN_MIN;
+  process.env.HEALER_COOLDOWN_MIN = '0';
+  try {
+    const v = { overallTier: 'amber', findings: [{ container: 'c', tier: 'amber', signature: 's' }] };
+    assert.equal(passesCooldown(v, 5), true);
+    assert.equal(passesCooldown(v, 6), true); // no suppression
+  } finally {
+    if (saved !== undefined) process.env.HEALER_COOLDOWN_MIN = saved; else delete process.env.HEALER_COOLDOWN_MIN;
   }
 });
 

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -9,6 +9,43 @@ import assert from 'node:assert/strict';
 import { normalizeTier, tierExitCode, maxTier, TIERS } from '../src/tiers.mjs';
 import { extractVerdict, validateVerdict } from '../src/diagnose.mjs';
 import { collapseRepeats, assertValidContainerName } from '../src/sensor.mjs';
+import { scrubSecrets, formatVerdict, pingIfNoteworthy } from '../src/notify.mjs';
+
+test('scrubSecrets: redacts known token shapes', () => {
+  assert.match(scrubSecrets('token sk-ant-oat01-abc123DEF_xyz here'), /<redacted:anthropic-key>/);
+  assert.match(scrubSecrets('ghs_AAAABBBBCCCCDDDD1111'), /<redacted:github-token>/);
+  assert.match(scrubSecrets('Authorization: Bearer abcdef1234567890'), /Bearer <redacted>/);
+  assert.equal(scrubSecrets('nothing secret here'), 'nothing secret here');
+});
+
+test('formatVerdict: HTML-escapes dynamic text and scrubs secrets', () => {
+  const msg = formatVerdict({
+    overallTier: 'amber',
+    summary: 'shim leaked sk-ant-oat01-SECRETvalue_here in <logs>',
+    findings: [{ container: 'c<1>', signature: 'sig & stuff', tier: 'amber', proposedAction: 'fix it' }],
+  });
+  assert.doesNotMatch(msg, /sk-ant-oat01-SECRETvalue/); // secret scrubbed
+  assert.match(msg, /&lt;logs&gt;/);                    // angle brackets escaped
+  assert.match(msg, /c&lt;1&gt;/);                       // finding container escaped
+  assert.match(msg, /sig &amp; stuff/);                  // ampersand escaped
+});
+
+test('pingIfNoteworthy: green is a silent no-op (no network)', async () => {
+  const r = await pingIfNoteworthy({ overallTier: 'green', findings: [] });
+  assert.equal(r.pinged, false);
+});
+
+test('pingIfNoteworthy: amber without a key is a no-op (no network)', async () => {
+  const saved = process.env.NOTIFY_API_KEY;
+  delete process.env.NOTIFY_API_KEY;
+  try {
+    const r = await pingIfNoteworthy({ overallTier: 'amber', summary: 'x', findings: [] });
+    assert.equal(r.pinged, false);
+    assert.match(r.reason, /NOTIFY_API_KEY/);
+  } finally {
+    if (saved !== undefined) process.env.NOTIFY_API_KEY = saved;
+  }
+});
 
 test('normalizeTier: trims + lowercases into the closed set', () => {
   assert.equal(normalizeTier('red'), 'red');


### PR DESCRIPTION
## What

Roadmap step 2 of the self-healer. When a verdict is **amber or red**, the healer sends Nick a Telegram message. Still **read-only** — a ping is a notification, not a remediation.

## Topology-first: reuse, don't build

It does NOT hold a bot token or build a Telegram path. It POSTs to the existing **`notify` proxy** (`https://notify.imagineering.cc/send`) which holds the token centrally; the healer carries only a `NOTIFY_API_KEY`. Because notify is **public HTTPS** (unlike claude-shim's loopback bind), amber-ping is a plain `fetch` — **no shell, no SSH, no injection surface** (addresses the class Carnot flagged on PR #100 by avoiding it entirely).

## Safety

- **`scrubSecrets()`** redacts known token shapes (anthropic / github / brevo / aws / JWT / `Bearer …`) from the message — the model's `diagnosis`/`evidence` could quote a credential-bearing log line. Only verdict fields (summary + findings) are sent; **never** the raw `signals`/log tails.
- **HTML-escapes** dynamic text (`& < >`) so it can't break or inject the Telegram HTML parse_mode.
- **Silent when it should be:** green verdicts and missing `NOTIFY_API_KEY` are no-ops (dev runs don't error, clean verdicts don't spam). `HEALER_NO_PING=1` force-disables. A ping failure never changes the diagnostic exit code.

## Tests

+4 (20 total, `node --test`): scrub redaction, formatVerdict HTML-escape+scrub, green no-op, no-key no-op.

## Verified live

Real amber-ping delivered to Telegram: `ok:true`, `message_id 1094`, HTML rendered cleanly, embedded fake secret scrubbed.

## ⚠️ Known limitation (documented in README)

**Stateless — no cooldown/dedup.** A persistently-amber signal would ping every run. The healer isn't scheduled yet, so no spam today; a cooldown MUST land before wiring the cron. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)