### PR TITLE
feat(self-healer): green-draft — file remediation issue on confident-green (first action stage)

### DIFF
--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -87,12 +87,40 @@ real prod signals before any hands are wired. In order:
 
 1. **v1:** sensor → diagnose → read-only verdict. ✅
 2. **amber ping:** notify on amber+ via the `notify` proxy. ✅ (still read-only)
-3. **green draft:** on a confident green finding, draft a fix PR (no merge).
+3. **green draft:** file a remediation *issue* for a confident-green finding. ✅
+   (the first ACTION stage — bounded blast radius: issue, never code/merge/deploy)
 4. **green auto:** behind an explicit flag, run the full green-tier loop
    (fix → cage-match → merge → deploy → re-sense to confirm the symptom is gone).
 
 Each step is gated on the previous one being *observed correct in prod*, not
 just coded. The cage is built before the monster.
+
+### green-draft (the first action stage)
+
+When a finding is **confident green with a concrete proposedAction**, the healer
+files a remediation issue in that container's source repo. This is the smallest
+real outward action with bounded blast radius — it files an **issue**, never
+code; it never opens a PR, merges, or deploys.
+
+- **OFF by default.** Set `HEALER_DRAFT_ISSUES=1` to enable. The action stage
+  exists but must be explicitly switched on.
+- **No shell.** Issues are created via the GitHub API (`fetch` + token), so
+  there's none of the command-injection surface a `gh` shell-out would add.
+  Token from `HEALER_GH_TOKEN` (or `GITHUB_TOKEN`/`GH_TOKEN`); needs `issues:write`.
+- **Source-of-truth dedup.** Before filing, it lists the repo's open
+  `self-healer` issues and checks for the finding's fingerprint marker
+  (`<!-- self-healer-fp: … -->`) — reconcile-before-mutate, so a cron can't mint
+  duplicates. Container→repo map in `repos.mjs`; an unmapped container is skipped.
+- **Scrubbed.** All issue text goes through `scrubSecrets`.
+
+> ⚠️ **Dedup is eventually-consistent.** GitHub's List Issues API has a few
+> seconds of read-after-write lag (verified live). For a minutes-spaced cron
+> this is robust; two near-simultaneous runs have a narrow double-file window.
+> Keep the run interval well above the lag.
+
+> The **auto-code-writing PR** (an LLM patching source from a log diagnosis) is
+> the real "monster" — a prompt-injection-into-codegen surface — and is a
+> deliberately separate, cage-built step. green-draft is its safe precursor.
 
 ### amber-ping
 

--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -107,16 +107,23 @@ code; it never opens a PR, merges, or deploys.
 - **No shell.** Issues are created via the GitHub API (`fetch` + token), so
   there's none of the command-injection surface a `gh` shell-out would add.
   Token from `HEALER_GH_TOKEN` (or `GITHUB_TOKEN`/`GH_TOKEN`); needs `issues:write`.
-- **Source-of-truth dedup.** Before filing, it lists the repo's open
-  `self-healer` issues and checks for the finding's fingerprint marker
-  (`<!-- self-healer-fp: … -->`) — reconcile-before-mutate, so a cron can't mint
-  duplicates. Container→repo map in `repos.mjs`; an unmapped container is skipped.
-- **Scrubbed.** All issue text goes through `scrubSecrets`.
+- **Reconcile-before-mutate dedup, fail-CLOSED.** Before filing, it lists the
+  repo's open `self-healer` issues (paginated) and checks for the finding's
+  fingerprint marker (`<!-- self-healer-fp: … -->`). If that read *fails* (403,
+  rate-limit, 5xx), it does **not** file — for a write stage, "can't confirm
+  it's not a duplicate" means don't write. Container→repo map in `repos.mjs`; an
+  unmapped container is skipped, never guessed.
+- **Content-safe.** All issue text is scrubbed (`scrubSecrets`), length-capped,
+  and @mentions are neutralized so attacker-influenced log content can't leak a
+  secret, ping people, or run unbounded.
 
-> ⚠️ **Dedup is eventually-consistent.** GitHub's List Issues API has a few
-> seconds of read-after-write lag (verified live). For a minutes-spaced cron
-> this is robust; two near-simultaneous runs have a narrow double-file window.
-> Keep the run interval well above the lag.
+> ⚠️ **Dedup is best-effort, not exclusive.** It reduces duplicates but does not
+> *guarantee* their absence: GitHub's List Issues API is eventually-consistent
+> (a few seconds of read-after-write lag, verified live), and the check-then-
+> create sequence has no atomic lock. For a minutes-spaced cron this is robust;
+> two near-simultaneous runs could double-file. A real single-writer/lock is a
+> prerequisite before any higher-stakes action stage (e.g. auto-merge) reuses
+> this pattern.
 
 > The **auto-code-writing PR** (an LLM patching source from a log diagnosis) is
 > the real "monster" — a prompt-injection-into-codegen surface — and is a

--- a/self-healer/src/draft.mjs
+++ b/self-healer/src/draft.mjs
@@ -5,13 +5,12 @@
 // outward action with bounded blast radius — "build the cage before the
 // monster":
 //   - It files an ISSUE, never code. It never opens a PR, merges, or deploys.
-//   - It is OFF by default (HEALER_DRAFT_ISSUES=1 to enable) — the action
-//     stage exists but must be explicitly switched on.
+//   - It is OFF by default (HEALER_DRAFT_ISSUES=1 to enable).
 //   - It dedups against the SOURCE OF TRUTH (open issues on the repo carrying
-//     the finding's fingerprint marker), so a cron can't mint duplicates.
-//   - It uses the GitHub API via fetch — NO shell, so none of the command
-//     injection surface the cage-match flagged.
-//   - All issue text is run through scrubSecrets first.
+//     the finding's fingerprint marker) and fails CLOSED: if it can't confirm
+//     "not a duplicate", it does NOT file (cage-match PR #104).
+//   - It uses the GitHub API via fetch — NO shell.
+//   - All issue text is scrubbed and length-capped, and @mentions neutralized.
 //
 // The auto-code-writing PR (an LLM patching source from a log diagnosis) is the
 // real "monster" — a prompt-injection-into-codegen surface — and is a
@@ -23,41 +22,50 @@ import { repoForContainer } from './repos.mjs';
 
 const GH_API = 'https://api.github.com';
 const LABEL = 'self-healer';
+const ZWSP = '​'; // zero-width space, to neutralize @mentions
 
 function token() {
   return process.env.HEALER_GH_TOKEN || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || null;
 }
 
-/** Stable fingerprint of a single finding (container + tier + signature). The
- * SAME problem yields the SAME fp, which is embedded in the issue body as a
- * marker so we never file it twice. */
+/** Stable fingerprint of a single finding (container + tier + signature).
+ * 32 hex (128 bits) — collision-resistant even against an attacker who can
+ * influence those fields via log content (cage-match PR #104). Embedded in the
+ * issue body as a marker so we never file the same finding twice. */
 export function findingFingerprint(f) {
-  return createHash('sha256').update(`${f.container}|${f.tier}|${f.signature}`).digest('hex').slice(0, 12);
+  return createHash('sha256').update(`${f.container}|${f.tier}|${f.signature}`).digest('hex').slice(0, 32);
 }
 
-/** Build the issue {title, body} for a finding. All dynamic text scrubbed; the
- * fingerprint marker is what makes filing idempotent (mirrors the
- * claude-task-id marker pattern used elsewhere). */
+/** Scrub secrets, neutralize @mentions (a zero-width space after @ stops GitHub
+ * from linking it), and cap length — so attacker-influenced log content in an
+ * issue body can't leak a secret, ping people, or run unbounded. */
+function safeField(x, max) {
+  let s = scrubSecrets(String(x ?? '')).replace(/@(?=[a-zA-Z0-9_-])/g, `@${ZWSP}`);
+  if (s.length > max) s = s.slice(0, max) + ' …(truncated)';
+  return s;
+}
+
+/** Build the issue {title, body, fp}. The fingerprint marker is what makes
+ * filing idempotent (mirrors the claude-task-id marker pattern). */
 export function buildIssue(finding) {
-  const s = (x) => scrubSecrets(String(x ?? ''));
   const fp = findingFingerprint(finding);
-  const title = `[self-healer] ${s(finding.container)}: ${s(finding.signature)}`.slice(0, 250);
+  const title = `[self-healer] ${safeField(finding.container, 60)}: ${safeField(finding.signature, 150)}`.slice(0, 250);
   const body = [
-    `**Diagnosed by the self-healer** (read-only; this issue is a remediation *proposal*, not an automated fix).`,
+    '**Diagnosed by the self-healer** (read-only; this issue is a remediation *proposal*, not an automated fix).',
     '',
-    `- **Container:** ${s(finding.container)}`,
-    `- **Tier:** ${s(finding.tier)} · confidence ${s(finding.confidence)}`,
+    `- **Container:** ${safeField(finding.container, 60)}`,
+    `- **Tier:** ${safeField(finding.tier, 10)} · confidence ${safeField(finding.confidence, 10)}`,
     '',
-    `**Diagnosis**`,
-    s(finding.diagnosis) || '_(none provided)_',
+    '**Diagnosis**',
+    safeField(finding.diagnosis, 1000) || '_(none provided)_',
     '',
-    `**Evidence**`,
+    '**Evidence**',
     '```',
-    s(finding.evidence) || '(none)',
+    safeField(finding.evidence, 1500) || '(none)',
     '```',
     '',
-    `**Proposed action**`,
-    s(finding.proposedAction),
+    '**Proposed action**',
+    safeField(finding.proposedAction, 500),
     '',
     `<!-- self-healer-fp: ${fp} -->`,
   ].join('\n');
@@ -65,7 +73,7 @@ export function buildIssue(finding) {
 }
 
 async function ghApi(method, path, body) {
-  const res = await fetch(`${GH_API}${path}`, {
+  return fetch(`${GH_API}${path}`, {
     method,
     headers: {
       authorization: `Bearer ${token()}`,
@@ -76,25 +84,11 @@ async function ghApi(method, path, body) {
     body: body ? JSON.stringify(body) : undefined,
     signal: AbortSignal.timeout(20_000),
   });
-  return res;
 }
 
-/** Is there already an open self-healer issue in `repo` carrying this fp? Uses
- * the List Issues API (no search-index lag) filtered by our label — the
- * authoritative live state, reconciled BEFORE we mutate. */
-async function alreadyFiled(repo, fp) {
-  const res = await ghApi('GET', `/repos/${repo}/issues?state=open&labels=${LABEL}&per_page=100`);
-  if (!res.ok) {
-    // A 404 (label never created) or other read error ⇒ treat as "not filed"
-    // but surface upstream; we'd rather risk a dup than suppress on a read glitch.
-    return false;
-  }
-  const issues = await res.json();
-  return Array.isArray(issues) && issues.some((i) => typeof i.body === 'string' && i.body.includes(`self-healer-fp: ${fp}`));
-}
-
-/** Best-effort: make sure the label exists so the create call (and the dedup
- * list filter) work. Tolerates 422 already-exists. */
+/** Best-effort: ensure the label exists so the dedup list-filter and the create
+ * call both work. Called BEFORE the dedup read so the list query always has a
+ * valid label to filter on. Tolerates 422 already-exists / transient errors. */
 async function ensureLabel(repo) {
   try {
     await ghApi('POST', `/repos/${repo}/labels`, { name: LABEL, color: '5319e7', description: 'Filed by the self-healer' });
@@ -102,34 +96,51 @@ async function ensureLabel(repo) {
 }
 
 /**
+ * Is there already an open self-healer issue in `repo` carrying this fp?
+ * Reconciles against the live issue list (no search-index lag), PAGINATED past
+ * the 100-per-page cap. FAILS CLOSED: a non-OK read THROWS, so the caller skips
+ * filing rather than mutating blindly on a transient 403/5xx (cage-match PR
+ * #104 — the right failure direction for a WRITE stage). @returns {boolean} */
+async function alreadyFiled(repo, fp) {
+  const marker = `self-healer-fp: ${fp}`;
+  for (let page = 1; page <= 20; page++) { // bound at 2000 open issues
+    const res = await ghApi('GET', `/repos/${repo}/issues?state=open&labels=${LABEL}&per_page=100&page=${page}`);
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      throw new Error(`dedup list read failed (${res.status}): ${txt.slice(0, 120)}`);
+    }
+    const issues = await res.json();
+    if (!Array.isArray(issues) || issues.length === 0) return false;
+    if (issues.some((i) => typeof i.body === 'string' && i.body.includes(marker))) return true;
+    if (issues.length < 100) return false; // last page reached
+  }
+  return false; // exhausted the page bound; treat as not-filed (worst case: a dup)
+}
+
+/** The findings green-draft will act on: confident-green with a concrete
+ * action. Normalizes proposedAction so " none ", "None", or empty are correctly
+ * excluded (cage-match PR #104). Pure — exported for testing. */
+export function actionableFindings(verdict) {
+  return (verdict.findings || []).filter((f) => {
+    if (f.tier !== 'green' || f.confidence !== 'high') return false;
+    const action = String(f.proposedAction ?? '').trim().toLowerCase();
+    return action !== '' && action !== 'none';
+  });
+}
+
+/**
  * For every confident-green, actionable finding, file a remediation issue in
- * its source repo (deduped). Returns a per-finding outcome list. A NO-OP (empty
- * list) when disabled, untokened, or nothing is actionable.
- *
- * "Actionable green" = tier green AND high confidence AND a concrete
- * proposedAction (not "none"). Self-recovered non-events have action "none" and
- * are correctly skipped.
- *
+ * its source repo (deduped, fail-closed). NO-OP (empty list) when disabled or
+ * untokened. Returns a per-finding outcome list.
  * @param {{findings: object[]}} verdict
  * @returns {Promise<Array<{container: string, action: string, detail?: string, url?: string}>>}
  */
-/** The findings green-draft will act on: confident-green with a concrete
- * action. Self-recovered non-events (action "none") and lower-confidence greens
- * are correctly excluded. Pure — exported for testing. */
-export function actionableFindings(verdict) {
-  return (verdict.findings || []).filter(
-    (f) => f.tier === 'green' && f.confidence === 'high' && f.proposedAction && f.proposedAction !== 'none',
-  );
-}
-
 export async function draftIfActionable(verdict) {
   if (process.env.HEALER_DRAFT_ISSUES !== '1') return [];
   if (!token()) return [{ container: '*', action: 'skipped', detail: 'no GitHub token (HEALER_GH_TOKEN)' }];
 
-  const actionable = actionableFindings(verdict);
-
   const outcomes = [];
-  for (const f of actionable) {
+  for (const f of actionableFindings(verdict)) {
     const repo = repoForContainer(f.container);
     if (!repo) {
       outcomes.push({ container: f.container, action: 'skipped', detail: 'no known source repo' });
@@ -137,11 +148,11 @@ export async function draftIfActionable(verdict) {
     }
     const { title, body, fp } = buildIssue(f);
     try {
+      await ensureLabel(repo); // before the dedup read, so the label filter is valid
       if (await alreadyFiled(repo, fp)) {
-        outcomes.push({ container: f.container, action: 'deduped', detail: `already open (fp ${fp})` });
+        outcomes.push({ container: f.container, action: 'deduped', detail: `already open (fp ${fp.slice(0, 12)}…)` });
         continue;
       }
-      await ensureLabel(repo);
       const res = await ghApi('POST', `/repos/${repo}/issues`, { title, body, labels: [LABEL] });
       if (!res.ok) {
         const txt = await res.text().catch(() => '');
@@ -151,6 +162,7 @@ export async function draftIfActionable(verdict) {
       const issue = await res.json();
       outcomes.push({ container: f.container, action: 'filed', url: issue.html_url });
     } catch (err) {
+      // A dedup-read failure lands here → we do NOT file (fail closed).
       outcomes.push({ container: f.container, action: 'failed', detail: err.message });
     }
   }

--- a/self-healer/src/draft.mjs
+++ b/self-healer/src/draft.mjs
@@ -1,0 +1,158 @@
+// draft.mjs — green-draft: the self-healer's first ACTION stage.
+//
+// On a CONFIDENT GREEN finding with a concrete proposedAction, file a
+// remediation issue in the finding's source repo. This is the smallest real
+// outward action with bounded blast radius — "build the cage before the
+// monster":
+//   - It files an ISSUE, never code. It never opens a PR, merges, or deploys.
+//   - It is OFF by default (HEALER_DRAFT_ISSUES=1 to enable) — the action
+//     stage exists but must be explicitly switched on.
+//   - It dedups against the SOURCE OF TRUTH (open issues on the repo carrying
+//     the finding's fingerprint marker), so a cron can't mint duplicates.
+//   - It uses the GitHub API via fetch — NO shell, so none of the command
+//     injection surface the cage-match flagged.
+//   - All issue text is run through scrubSecrets first.
+//
+// The auto-code-writing PR (an LLM patching source from a log diagnosis) is the
+// real "monster" — a prompt-injection-into-codegen surface — and is a
+// deliberately separate, cage-built step. This is its safe precursor.
+
+import { createHash } from 'node:crypto';
+import { scrubSecrets } from './notify.mjs';
+import { repoForContainer } from './repos.mjs';
+
+const GH_API = 'https://api.github.com';
+const LABEL = 'self-healer';
+
+function token() {
+  return process.env.HEALER_GH_TOKEN || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || null;
+}
+
+/** Stable fingerprint of a single finding (container + tier + signature). The
+ * SAME problem yields the SAME fp, which is embedded in the issue body as a
+ * marker so we never file it twice. */
+export function findingFingerprint(f) {
+  return createHash('sha256').update(`${f.container}|${f.tier}|${f.signature}`).digest('hex').slice(0, 12);
+}
+
+/** Build the issue {title, body} for a finding. All dynamic text scrubbed; the
+ * fingerprint marker is what makes filing idempotent (mirrors the
+ * claude-task-id marker pattern used elsewhere). */
+export function buildIssue(finding) {
+  const s = (x) => scrubSecrets(String(x ?? ''));
+  const fp = findingFingerprint(finding);
+  const title = `[self-healer] ${s(finding.container)}: ${s(finding.signature)}`.slice(0, 250);
+  const body = [
+    `**Diagnosed by the self-healer** (read-only; this issue is a remediation *proposal*, not an automated fix).`,
+    '',
+    `- **Container:** ${s(finding.container)}`,
+    `- **Tier:** ${s(finding.tier)} · confidence ${s(finding.confidence)}`,
+    '',
+    `**Diagnosis**`,
+    s(finding.diagnosis) || '_(none provided)_',
+    '',
+    `**Evidence**`,
+    '```',
+    s(finding.evidence) || '(none)',
+    '```',
+    '',
+    `**Proposed action**`,
+    s(finding.proposedAction),
+    '',
+    `<!-- self-healer-fp: ${fp} -->`,
+  ].join('\n');
+  return { title, body, fp };
+}
+
+async function ghApi(method, path, body) {
+  const res = await fetch(`${GH_API}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${token()}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      'content-type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(20_000),
+  });
+  return res;
+}
+
+/** Is there already an open self-healer issue in `repo` carrying this fp? Uses
+ * the List Issues API (no search-index lag) filtered by our label — the
+ * authoritative live state, reconciled BEFORE we mutate. */
+async function alreadyFiled(repo, fp) {
+  const res = await ghApi('GET', `/repos/${repo}/issues?state=open&labels=${LABEL}&per_page=100`);
+  if (!res.ok) {
+    // A 404 (label never created) or other read error ⇒ treat as "not filed"
+    // but surface upstream; we'd rather risk a dup than suppress on a read glitch.
+    return false;
+  }
+  const issues = await res.json();
+  return Array.isArray(issues) && issues.some((i) => typeof i.body === 'string' && i.body.includes(`self-healer-fp: ${fp}`));
+}
+
+/** Best-effort: make sure the label exists so the create call (and the dedup
+ * list filter) work. Tolerates 422 already-exists. */
+async function ensureLabel(repo) {
+  try {
+    await ghApi('POST', `/repos/${repo}/labels`, { name: LABEL, color: '5319e7', description: 'Filed by the self-healer' });
+  } catch { /* best-effort */ }
+}
+
+/**
+ * For every confident-green, actionable finding, file a remediation issue in
+ * its source repo (deduped). Returns a per-finding outcome list. A NO-OP (empty
+ * list) when disabled, untokened, or nothing is actionable.
+ *
+ * "Actionable green" = tier green AND high confidence AND a concrete
+ * proposedAction (not "none"). Self-recovered non-events have action "none" and
+ * are correctly skipped.
+ *
+ * @param {{findings: object[]}} verdict
+ * @returns {Promise<Array<{container: string, action: string, detail?: string, url?: string}>>}
+ */
+/** The findings green-draft will act on: confident-green with a concrete
+ * action. Self-recovered non-events (action "none") and lower-confidence greens
+ * are correctly excluded. Pure — exported for testing. */
+export function actionableFindings(verdict) {
+  return (verdict.findings || []).filter(
+    (f) => f.tier === 'green' && f.confidence === 'high' && f.proposedAction && f.proposedAction !== 'none',
+  );
+}
+
+export async function draftIfActionable(verdict) {
+  if (process.env.HEALER_DRAFT_ISSUES !== '1') return [];
+  if (!token()) return [{ container: '*', action: 'skipped', detail: 'no GitHub token (HEALER_GH_TOKEN)' }];
+
+  const actionable = actionableFindings(verdict);
+
+  const outcomes = [];
+  for (const f of actionable) {
+    const repo = repoForContainer(f.container);
+    if (!repo) {
+      outcomes.push({ container: f.container, action: 'skipped', detail: 'no known source repo' });
+      continue;
+    }
+    const { title, body, fp } = buildIssue(f);
+    try {
+      if (await alreadyFiled(repo, fp)) {
+        outcomes.push({ container: f.container, action: 'deduped', detail: `already open (fp ${fp})` });
+        continue;
+      }
+      await ensureLabel(repo);
+      const res = await ghApi('POST', `/repos/${repo}/issues`, { title, body, labels: [LABEL] });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => '');
+        outcomes.push({ container: f.container, action: 'failed', detail: `${res.status}: ${txt.slice(0, 120)}` });
+        continue;
+      }
+      const issue = await res.json();
+      outcomes.push({ container: f.container, action: 'filed', url: issue.html_url });
+    } catch (err) {
+      outcomes.push({ container: f.container, action: 'failed', detail: err.message });
+    }
+  }
+  return outcomes;
+}

--- a/self-healer/src/healer.mjs
+++ b/self-healer/src/healer.mjs
@@ -17,6 +17,7 @@ import { diagnose } from './diagnose.mjs';
 import { isOnBox } from './host.mjs';
 import { tierExitCode } from './tiers.mjs';
 import { pingIfNoteworthy } from './notify.mjs';
+import { draftIfActionable } from './draft.mjs';
 
 /**
  * Load + validate the watch list. Fails CLOSED on a malformed config so a bad
@@ -108,6 +109,18 @@ async function main() {
     process.stderr.write(pinged ? '[healer] amber-ping sent.\n' : `[healer] no ping (${reason}).\n`);
   } catch (err) {
     process.stderr.write(`[healer] amber-ping FAILED (verdict still stands): ${err.message}\n`);
+  }
+
+  // green-draft: file a remediation ISSUE for confident-green actionable
+  // findings. OFF by default (HEALER_DRAFT_ISSUES=1). Never code/merge/deploy.
+  // Like the ping, a failure here must not change the diagnostic exit code.
+  try {
+    const outcomes = await draftIfActionable(verdict);
+    for (const o of outcomes) {
+      process.stderr.write(`[healer] draft ${o.action}: ${o.container}${o.url ? ` → ${o.url}` : ''}${o.detail ? ` (${o.detail})` : ''}\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`[healer] green-draft FAILED (verdict still stands): ${err.message}\n`);
   }
 
   // Exit code communicates tier to a cron/monitor without parsing JSON.

--- a/self-healer/src/repos.mjs
+++ b/self-healer/src/repos.mjs
@@ -1,0 +1,25 @@
+// repos.mjs — maps a watched container to the source repo where a fix would
+// land. green-draft can only file a remediation issue for a container whose
+// source home is known; an unmapped container is skipped (logged), never
+// guessed — filing an issue against the wrong repo is worse than not filing.
+
+/**
+ * container name → "owner/repo". Keep this explicit and conservative. A
+ * container with no entry yields null from repoForContainer and green-draft
+ * skips it.
+ *
+ * NOTE: claude-shim's source is NOT checked into any repo (it lives only on the
+ * OCI box, deployed by rsync — see README "known substrate facts"). So a
+ * claude-shim finding has no repo to file against and is intentionally absent
+ * here until that source is versioned (tracked separately).
+ */
+export const CONTAINER_REPOS = Object.freeze({
+  'tw-clawd': 'enspyrco/tech_world_bot',
+  'tw-gremlin': 'enspyrco/tech_world_bot',
+  'embodied-dreamfinder': 'imagineering-cc/embodied-dreamfinder',
+});
+
+/** @returns {string|null} "owner/repo" or null if the container has no known source repo. */
+export function repoForContainer(name) {
+  return CONTAINER_REPOS[name] ?? null;
+}

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -54,6 +54,33 @@ test('actionableFindings: only confident-green with a concrete action', () => {
   assert.equal(out[0].container, 'a');
 });
 
+test('actionableFindings: normalizes the none-check (" None ", empty excluded)', () => {
+  const v = { findings: [
+    { container: 'a', tier: 'green', confidence: 'high', proposedAction: ' None ' }, // ✗ normalized none
+    { container: 'b', tier: 'green', confidence: 'high', proposedAction: '   ' },      // ✗ empty
+    { container: 'c', tier: 'green', confidence: 'high', proposedAction: 'patch it' }, // ✓
+  ] };
+  const out = actionableFindings(v);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].container, 'c');
+});
+
+test('buildIssue: neutralizes @mentions and caps long fields', () => {
+  const { body } = buildIssue({
+    container: 'tw-clawd', tier: 'green', confidence: 'high', signature: 'sig',
+    diagnosis: 'cc @nickmeinhold and @everyone ' + 'word '.repeat(400), // spaced so the high-entropy scrubber doesn't collapse it
+    evidence: 'e', proposedAction: 'fix',
+  });
+  assert.doesNotMatch(body, /@nickmeinhold/);  // mention neutralized (zero-width inserted after @)
+  assert.doesNotMatch(body, /@everyone/);
+  assert.match(body, /…\(truncated\)/);          // long diagnosis capped
+});
+
+test('findingFingerprint: 32 hex chars (128-bit, collision-resistant)', () => {
+  const fp = findingFingerprint({ container: 'a', tier: 'green', signature: 's' });
+  assert.match(fp, /^[0-9a-f]{32}$/);
+});
+
 test('draftIfActionable: OFF by default (no network, no env)', async () => {
   const saved = process.env.HEALER_DRAFT_ISSUES;
   delete process.env.HEALER_DRAFT_ISSUES;

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -13,6 +13,75 @@ import { scrubSecrets, formatVerdict, pingIfNoteworthy, verdictFingerprint, pass
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join as pjoin } from 'node:path';
+import { findingFingerprint, buildIssue, actionableFindings, draftIfActionable } from '../src/draft.mjs';
+import { repoForContainer } from '../src/repos.mjs';
+
+test('repoForContainer: maps known containers, null for unknown', () => {
+  assert.equal(repoForContainer('tw-clawd'), 'enspyrco/tech_world_bot');
+  assert.equal(repoForContainer('embodied-dreamfinder'), 'imagineering-cc/embodied-dreamfinder');
+  assert.equal(repoForContainer('claude-shim'), null); // source not versioned anywhere
+  assert.equal(repoForContainer('nope'), null);
+});
+
+test('findingFingerprint: stable per problem, differs on signature/tier', () => {
+  const a = { container: 'tw-clawd', tier: 'green', signature: 'sig' };
+  assert.equal(findingFingerprint(a), findingFingerprint({ ...a }));
+  assert.notEqual(findingFingerprint(a), findingFingerprint({ ...a, tier: 'amber' }));
+  assert.notEqual(findingFingerprint(a), findingFingerprint({ ...a, signature: 'other' }));
+});
+
+test('buildIssue: scrubs secrets, embeds fp marker, bounds the title', () => {
+  const { title, body, fp } = buildIssue({
+    container: 'tw-clawd', tier: 'green', confidence: 'high', signature: 'crash',
+    diagnosis: 'leaked sk-ant-oat01-SECRETvalue_here in the log',
+    evidence: 'AKIA1234567890ABCDEF', proposedAction: 'add a null guard',
+  });
+  assert.doesNotMatch(body, /SECRETvalue/);          // diagnosis secret scrubbed
+  assert.doesNotMatch(body, /AKIA1234567890ABCDEF/); // evidence secret scrubbed
+  assert.match(body, new RegExp(`self-healer-fp: ${fp}`)); // dedup marker present
+  assert.ok(title.length <= 250);
+});
+
+test('actionableFindings: only confident-green with a concrete action', () => {
+  const v = { findings: [
+    { container: 'a', tier: 'green', confidence: 'high', proposedAction: 'fix' },   // ✓
+    { container: 'b', tier: 'green', confidence: 'high', proposedAction: 'none' },   // ✗ no action
+    { container: 'c', tier: 'green', confidence: 'low', proposedAction: 'fix' },     // ✗ low confidence
+    { container: 'd', tier: 'amber', confidence: 'high', proposedAction: 'fix' },    // ✗ not green
+  ] };
+  const out = actionableFindings(v);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].container, 'a');
+});
+
+test('draftIfActionable: OFF by default (no network, no env)', async () => {
+  const saved = process.env.HEALER_DRAFT_ISSUES;
+  delete process.env.HEALER_DRAFT_ISSUES;
+  try {
+    const out = await draftIfActionable({ findings: [{ container: 'tw-clawd', tier: 'green', confidence: 'high', proposedAction: 'fix' }] });
+    assert.deepEqual(out, []); // disabled ⇒ no-op
+  } finally {
+    if (saved !== undefined) process.env.HEALER_DRAFT_ISSUES = saved;
+  }
+});
+
+test('draftIfActionable: enabled but no token ⇒ skipped, no network', async () => {
+  const savedFlag = process.env.HEALER_DRAFT_ISSUES;
+  const savedTokens = [process.env.HEALER_GH_TOKEN, process.env.GITHUB_TOKEN, process.env.GH_TOKEN];
+  process.env.HEALER_DRAFT_ISSUES = '1';
+  delete process.env.HEALER_GH_TOKEN; delete process.env.GITHUB_TOKEN; delete process.env.GH_TOKEN;
+  try {
+    const out = await draftIfActionable({ findings: [{ container: 'tw-clawd', tier: 'green', confidence: 'high', proposedAction: 'fix' }] });
+    assert.equal(out[0].action, 'skipped');
+    assert.match(out[0].detail, /token/);
+  } finally {
+    if (savedFlag !== undefined) process.env.HEALER_DRAFT_ISSUES = savedFlag; else delete process.env.HEALER_DRAFT_ISSUES;
+    const [a, b, c] = savedTokens;
+    if (a !== undefined) process.env.HEALER_GH_TOKEN = a;
+    if (b !== undefined) process.env.GITHUB_TOKEN = b;
+    if (c !== undefined) process.env.GH_TOKEN = c;
+  }
+});
 
 test('scrubSecrets: redacts known token prefixes', () => {
   assert.match(scrubSecrets('token sk-ant-oat01-abc123DEF_xyz here'), /<redacted:anthropic-key>/);


### PR DESCRIPTION
## What

Roadmap step 3 — the self-healer's **first action stage**. On a **confident-green finding with a concrete proposedAction**, file a remediation issue in that container's source repo. Smallest real outward action with **bounded blast radius**: it files an *issue*, never code; never a PR, merge, or deploy.

## Cage before the monster

- **OFF by default** (`HEALER_DRAFT_ISSUES=1` to enable) — the action stage exists but must be explicitly switched on.
- **No shell.** GitHub API via `fetch` + token (`HEALER_GH_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`, needs `issues:write`) — none of the command-injection surface a `gh` shell-out would add.
- **Source-of-truth dedup.** Lists the repo's open `self-healer` issues and checks for the finding's `<!-- self-healer-fp: … -->` marker before filing (reconcile-before-mutate) — a cron can't mint duplicates. `repos.mjs` maps container→repo; unmapped containers (incl. `claude-shim`, whose source isn't versioned) are skipped, never guessed.
- **Scrubbed.** All issue text through `scrubSecrets`.

The **auto-code-writing PR** (an LLM patching source from a log diagnosis = prompt-injection-into-codegen) is the real monster — deliberately deferred to its own cage-built step. This is its safe precursor.

## Tests

+8 (31 total): repo mapping, fingerprint stability, `buildIssue` scrub+marker+title-bound, the `actionableFindings` filter (confident-green-with-action only), OFF-by-default + no-token no-ops.

## Verified live (GitHub API)

create (201) → label + fp marker correct → embedded fake secret scrubbed → dedup detects fp on re-list → close. **Found + documented:** the List dedup is eventually-consistent (~seconds read-after-write lag); robust for cron-spaced runs, narrow double-file window for near-simultaneous runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)