### PR TITLE
fix(self-healer): monotonic timeout chain so shim ceiling isn't capped by curl (deploy #49)

### DIFF
--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -66,6 +66,15 @@ code encodes the worst tier: `0`=green, `1`=amber, `2`=red, `3`=healer error.
 | `SHIM_URL`     | `http://127.0.0.1:8088/chat`   | claude-shim endpoint (host-local)         |
 | `HEALER_MODEL` | `sonnet`                       | model the shim runs for diagnosis         |
 | `HEALER_TARGETS` | `./targets.json`             | watch-list path                           |
+| `SHIM_HTTP_TIMEOUT_MS` | `150000`               | curl `--max-time` for the shim call; outer SIGKILL is this + 10s |
+
+> **Timeout chain.** The ceilings are monotonic from the inside out —
+> `claude generation < shim (SHIM_TIMEOUT_MS, default 120s on the box) < curl
+> --max-time < runOnHost SIGKILL` — so a too-slow diagnosis fails on the shim
+> with a clean "claude timed out" rather than `curl exit 28` discarding an
+> answer the shim already produced. Keep `SHIM_HTTP_TIMEOUT_MS` above the shim's
+> `SHIM_TIMEOUT_MS`. (Observed live: a 93s sonnet verdict for 4 containers — the
+> old hardcoded 90s curl ceiling threw it away.)
 
 ## The traffic-light leash
 

--- a/self-healer/src/diagnose.mjs
+++ b/self-healer/src/diagnose.mjs
@@ -11,6 +11,30 @@ import { normalizeTier, maxTier, TIERS } from './tiers.mjs';
 const DIAGNOSE_MODEL = process.env.HEALER_MODEL || 'sonnet';
 
 /**
+ * Resolve the outbound HTTP timeout chain for the shim call. The ceilings MUST
+ * be monotonic from the inside out so the INNER layer fails first with a clean
+ * error instead of an opaque outer kill:
+ *
+ *   claude generation  <  shim (SHIM_TIMEOUT_MS, default 120s on the box)
+ *                       <  curl --max-time  <  runOnHost hard SIGKILL
+ *
+ * The defaults (150s curl / 160s runOnHost) sit ABOVE the 120s shim ceiling, so
+ * a too-slow diagnosis surfaces as the shim's own "claude timed out after …"
+ * rather than `curl exit 28`. This is the deploy-#49 fix: a legitimate 93s
+ * sonnet verdict was being thrown away by the old hardcoded 90s curl ceiling
+ * (the shim had already answered). curlMaxTimeSec is parsed to an integer so it
+ * stays shell-inert when interpolated into the curl command.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{curlMaxTimeSec: number, runOnHostMs: number}}
+ */
+export function resolveHttpTimeouts(env = process.env) {
+  const raw = Number.parseInt(env.SHIM_HTTP_TIMEOUT_MS ?? '150000', 10);
+  const ms = Number.isFinite(raw) && raw > 0 ? raw : 150_000;
+  return { curlMaxTimeSec: Math.ceil(ms / 1000), runOnHostMs: ms + 10_000 };
+}
+
+/**
  * Resolve + validate the shim endpoint. SHIM_URL is interpolated into a shell
  * command (curl …), so an unvalidated env value would be a command-injection
  * vector (cage-match PR #100: `SHIM_URL='http://x; rm -rf /'`). We require a
@@ -135,8 +159,12 @@ export async function diagnose(signals) {
   // curl ON THE HOST so we hit the shim's localhost bind. Body comes in via
   // stdin (@-) so we never have to quote a multi-KB JSON blob through a shell.
   // SHIM_URL was validated to be a shell-inert loopback http URL at load.
-  const cmd = `curl -s --max-time 90 -H 'content-type: application/json' --data-binary @- '${SHIM_URL}'`;
-  const { stdout, stderr, code } = await runOnHost(cmd, { stdin: body, timeoutMs: 100_000 });
+  // Timeouts are monotonic above the shim's own ceiling so the shim fails first
+  // with a clean error rather than curl killing an answer mid-flight (see
+  // resolveHttpTimeouts). curlMaxTimeSec is an integer ⇒ shell-inert.
+  const { curlMaxTimeSec, runOnHostMs } = resolveHttpTimeouts();
+  const cmd = `curl -s --max-time ${curlMaxTimeSec} -H 'content-type: application/json' --data-binary @- '${SHIM_URL}'`;
+  const { stdout, stderr, code } = await runOnHost(cmd, { stdin: body, timeoutMs: runOnHostMs });
   if (code !== 0) {
     throw new Error(`shim curl failed (exit ${code}): ${stderr.trim() || stdout.trim()}`);
   }

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -315,8 +315,9 @@ test('resolveHttpTimeouts: curl<runOnHost monotonicity + integer hold for ALL in
     assert.ok(Number.isInteger(curlMaxTimeSec) && curlMaxTimeSec > 0, `integer/positive for ${JSON.stringify(v)}`);
     assert.ok(curlMaxTimeSec * 1000 < runOnHostMs, `curl<runOnHost for ${JSON.stringify(v)}`);
   }
-  // the injection string collapses to its leading integer, never a shell token
-  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '90; rm -rf /' }).curlMaxTimeSec, 90);
+  // the injection string collapses to its leading integer (ms), never a shell
+  // token: '150000; rm -rf /' → parseInt 150000 ms → ceil(150000/1000) = 150s.
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '150000; rm -rf /' }).curlMaxTimeSec, 150);
 });
 
 test('collapseRepeats: folds identical runs into ×N, leaves singletons alone', () => {

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -306,6 +306,19 @@ test('resolveHttpTimeouts: curlMaxTimeSec is an integer (shell-inert interpolati
   assert.equal(curlMaxTimeSec, 96); // ceil(95500/1000)
 });
 
+test('resolveHttpTimeouts: curl<runOnHost monotonicity + integer hold for ALL inputs, not just the default', () => {
+  // The curl<runOnHost relation is the safety invariant — pin it for non-default
+  // values AND for shell-injection-shaped strings (which parseInt reduces to a
+  // leading integer), so the property is proven in general, not just at 150s.
+  for (const v of ['200000', '37000', '1', '90; rm -rf /', '1e3', ' 250000 ']) {
+    const { curlMaxTimeSec, runOnHostMs } = resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: v });
+    assert.ok(Number.isInteger(curlMaxTimeSec) && curlMaxTimeSec > 0, `integer/positive for ${JSON.stringify(v)}`);
+    assert.ok(curlMaxTimeSec * 1000 < runOnHostMs, `curl<runOnHost for ${JSON.stringify(v)}`);
+  }
+  // the injection string collapses to its leading integer, never a shell token
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '90; rm -rf /' }).curlMaxTimeSec, 90);
+});
+
 test('collapseRepeats: folds identical runs into ×N, leaves singletons alone', () => {
   assert.equal(collapseRepeats('a\na\na\nb'), 'a  (×3)\nb');
   assert.equal(collapseRepeats('x\ny\nz'), 'x\ny\nz');

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { normalizeTier, tierExitCode, maxTier, TIERS } from '../src/tiers.mjs';
-import { extractVerdict, validateVerdict } from '../src/diagnose.mjs';
+import { extractVerdict, validateVerdict, resolveHttpTimeouts } from '../src/diagnose.mjs';
 import { collapseRepeats, assertValidContainerName } from '../src/sensor.mjs';
 import { scrubSecrets, formatVerdict, pingIfNoteworthy, verdictFingerprint, passesCooldown } from '../src/notify.mjs';
 import { mkdtempSync } from 'node:fs';
@@ -279,6 +279,31 @@ test('validateVerdict: coerces malformed finding fields to safe defaults', () =>
   assert.equal(f.proposedAction, 'none');
   assert.equal(f.selfRecovered, false); // 'yes' (string) is not the boolean true
   assert.equal(f.diagnosis, ''); // non-string coerced
+});
+
+test('resolveHttpTimeouts: defaults sit above the 120s shim ceiling, monotonic (deploy #49)', () => {
+  const { curlMaxTimeSec, runOnHostMs } = resolveHttpTimeouts({});
+  assert.equal(curlMaxTimeSec, 150);
+  assert.equal(runOnHostMs, 160_000);
+  // curl must kill BEFORE the outer hard SIGKILL...
+  assert.ok(curlMaxTimeSec * 1000 < runOnHostMs);
+  // ...and AFTER the shim's own 120s ceiling, so the shim fails first (clean
+  // "claude timed out") rather than curl exit 28 discarding a live answer.
+  assert.ok(curlMaxTimeSec * 1000 > 120_000);
+});
+
+test('resolveHttpTimeouts: honors SHIM_HTTP_TIMEOUT_MS, falls back on garbage/non-positive', () => {
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '200000' }).curlMaxTimeSec, 200);
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '200000' }).runOnHostMs, 210_000);
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: 'xyz' }).curlMaxTimeSec, 150); // unparseable ⇒ default
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '0' }).curlMaxTimeSec, 150);   // non-positive ⇒ default
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '-5' }).curlMaxTimeSec, 150);
+});
+
+test('resolveHttpTimeouts: curlMaxTimeSec is an integer (shell-inert interpolation)', () => {
+  const { curlMaxTimeSec } = resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '95500' });
+  assert.equal(Number.isInteger(curlMaxTimeSec), true);
+  assert.equal(curlMaxTimeSec, 96); // ceil(95500/1000)
 });
 
 test('collapseRepeats: folds identical runs into ×N, leaves singletons alone', () => {


### PR DESCRIPTION
## What

Deploying the self-healer to OCI (#49) surfaced a **stacked-timeout bug** that discards valid diagnoses.

The shim's internal ceiling is env-configurable (`SHIM_TIMEOUT_MS`, raised to **120s** on the box so real sonnet diagnoses fit). But `diagnose.mjs` hardcoded `curl --max-time 90` + a 100s `runOnHost` SIGKILL. Result: a legitimate **93s** 4-container verdict was *answered by the shim* then *thrown away by curl* (`exit 28`) — the outer layer killing an answer the inner layer had already produced.

## Fix

`resolveHttpTimeouts(env)` derives the curl/runOnHost ceilings from `SHIM_HTTP_TIMEOUT_MS` (default **150s** curl / **160s** SIGKILL), monotonic **above** the shim's 120s ceiling:

```
claude generation < shim (SHIM_TIMEOUT_MS=120s) < curl --max-time (150s) < runOnHost SIGKILL (160s)
```

So a too-slow diagnosis fails on the shim with a clean `claude timed out after …` instead of an opaque `curl exit 28`. `curlMaxTimeSec` is parsed to an integer so it stays **shell-inert** when interpolated into the curl command (preserves the PR #100 injection discipline).

## Tests

+3 (`node --test`, 34 → 37 pass): defaults monotonicity vs the 120s ceiling; env override + fail-to-default on garbage/non-positive; integer/shell-inert.

## Verified live

Smoke-ran on OCI against real prod: clean AMBER verdict (DF OpenAI-Realtime ready-loop), tw-clawd/tw-gremlin correctly GREEN (self-recovered node rotation). Discovered while wiring the cron — fix is a deploy prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)