### PR TITLE
fix(self-healer): timestamped logs + cadence-aware collapse so heartbeat ≠ storm

### DIFF
--- a/self-healer/src/sensor.mjs
+++ b/self-healer/src/sensor.mjs
@@ -40,20 +40,50 @@ export function assertValidContainerName(name) {
  * This is not just a size hack: a line repeated 25× carries no MORE diagnostic
  * detail than the line plus its count, but it does waste inference tokens and
  * latency. Collapsing surfaces the repetition AS a signal while shrinking the
- * payload — e.g. "OpenAI Realtime mode ready  (×25)".
+ * payload.
+ *
+ * CADENCE-AWARE (deploy #49 follow-up): logs are fetched with `docker logs -t`,
+ * so each line is prefixed with an RFC3339 timestamp. We fold consecutive lines
+ * that share the same MESSAGE (ignoring the timestamp) and report the time SPAN
+ * of the run — e.g. "OpenAI Realtime mode ready  (×40, 2026-06-23T02:10:17Z→
+ * 2026-06-23T03:50:17Z)". That span is the difference between a benign 10-minute
+ * heartbeat and a tight reconnect storm — a distinction the brain CANNOT make
+ * from a bare "(×40)". (A real run mis-diagnosed exactly this: 40 identical
+ * timestamp-less "ready" lines read as a storm when they were a 10-min beat.)
+ * Lines without a leading timestamp collapse to the plain "(×N)" form.
  */
+
+/** Split a log line into its leading RFC3339 timestamp (fractional seconds
+ * trimmed for compactness) and the remaining message. Returns ts:null for a
+ * line that doesn't start with a docker `-t` timestamp. */
+export function splitLogTimestamp(line) {
+  const m = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})\s([\s\S]*)$/);
+  if (!m) return { ts: null, msg: line };
+  return { ts: `${m[1]}${m[2]}`, msg: m[3] };
+}
+
 export function collapseRepeats(text) {
   const out = [];
-  let prev = null;
+  let prevMsg = null;
+  let firstTs = null;
+  let lastTs = null;
   let run = 0;
   const flush = () => {
-    if (prev === null) return;
-    out.push(run > 1 ? `${prev}  (×${run})` : prev);
+    if (prevMsg === null) return;
+    if (run > 1) {
+      const span = firstTs ? `, ${firstTs}→${lastTs}` : '';
+      out.push(`${prevMsg}  (×${run}${span})`);
+    } else {
+      out.push(firstTs ? `${firstTs} ${prevMsg}` : prevMsg);
+    }
   };
   for (const line of text.split('\n')) {
-    if (line === prev) { run += 1; continue; }
+    const { ts, msg } = splitLogTimestamp(line);
+    if (msg === prevMsg) { run += 1; lastTs = ts; continue; }
     flush();
-    prev = line;
+    prevMsg = msg;
+    firstTs = ts;
+    lastTs = ts;
     run = 1;
   }
   flush();
@@ -89,7 +119,7 @@ async function gatherContainer(name, logLines) {
     `__i=$(docker inspect '${name}' --format '{{.State.Status}}|{{.RestartCount}}|{{.State.Running}}' 2>&1); __rc=$?; ` +
     `printf 'INSPECT_RC=%s\\n' "$__rc"; printf '%s\\n' "$__i"; ` +
     `echo '${SENTINEL}'; ` +
-    `docker logs '${name}' --tail ${logLines} 2>&1`;
+    `docker logs -t '${name}' --tail ${logLines} 2>&1`;
 
   const { stdout, stderr, code } = await runOnHost(cmd);
   // ssh returns 255 when the connection itself fails — a SENSING failure.

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 
 import { normalizeTier, tierExitCode, maxTier, TIERS } from '../src/tiers.mjs';
 import { extractVerdict, validateVerdict, resolveHttpTimeouts } from '../src/diagnose.mjs';
-import { collapseRepeats, assertValidContainerName } from '../src/sensor.mjs';
+import { collapseRepeats, splitLogTimestamp, assertValidContainerName } from '../src/sensor.mjs';
 import { scrubSecrets, formatVerdict, pingIfNoteworthy, verdictFingerprint, passesCooldown } from '../src/notify.mjs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -320,9 +320,37 @@ test('resolveHttpTimeouts: curl<runOnHost monotonicity + integer hold for ALL in
   assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '150000; rm -rf /' }).curlMaxTimeSec, 150);
 });
 
-test('collapseRepeats: folds identical runs into ×N, leaves singletons alone', () => {
+test('collapseRepeats: folds identical runs into ×N, leaves singletons alone (no timestamps)', () => {
   assert.equal(collapseRepeats('a\na\na\nb'), 'a  (×3)\nb');
   assert.equal(collapseRepeats('x\ny\nz'), 'x\ny\nz');
+});
+
+test('splitLogTimestamp: parses docker -t prefix, trims fractional seconds, null when absent', () => {
+  assert.deepEqual(splitLogTimestamp('2026-06-23T02:10:17.304820972Z INFO: ready'),
+    { ts: '2026-06-23T02:10:17Z', msg: 'INFO: ready' });
+  assert.deepEqual(splitLogTimestamp('2026-06-23T02:10:17+10:00 hi'),
+    { ts: '2026-06-23T02:10:17+10:00', msg: 'hi' });
+  assert.deepEqual(splitLogTimestamp('no timestamp here'), { ts: null, msg: 'no timestamp here' });
+});
+
+test('collapseRepeats: cadence-aware — folds by MESSAGE and reports the time SPAN (deploy #49 false-positive fix)', () => {
+  // The exact shape that mis-diagnosed as a "reconnect storm": identical message,
+  // 10 minutes apart. The span makes the benign heartbeat legible to the brain.
+  const beat = [
+    '2026-06-23T02:10:17.304820972Z INFO: OpenAI Realtime mode ready',
+    '2026-06-23T02:20:17.282708278Z INFO: OpenAI Realtime mode ready',
+    '2026-06-23T02:30:17.146134121Z INFO: OpenAI Realtime mode ready',
+  ].join('\n');
+  assert.equal(collapseRepeats(beat),
+    'INFO: OpenAI Realtime mode ready  (×3, 2026-06-23T02:10:17Z→2026-06-23T02:30:17Z)');
+});
+
+test('collapseRepeats: timestamped singleton keeps its timestamp; distinct messages stay separate', () => {
+  assert.equal(collapseRepeats('2026-06-23T02:10:17.5Z only once'),
+    '2026-06-23T02:10:17Z only once');
+  assert.equal(
+    collapseRepeats('2026-06-23T02:10:17Z aaa\n2026-06-23T02:10:18Z bbb'),
+    '2026-06-23T02:10:17Z aaa\n2026-06-23T02:10:18Z bbb');
 });
 
 test('assertValidContainerName: accepts docker-legal names, rejects shell metachars', () => {


### PR DESCRIPTION
## What

The freshly-deployed healer (#49) mis-diagnosed `embodied-dreamfinder`'s benign **10-minute heartbeat** (`INFO: OpenAI Realtime mode ready`) as a high-confidence **"reconnect storm"** — and nearly sent Nick chasing a non-issue. Root cause: the sensor fetched `docker logs` **without timestamps**, so 40 identical lines were indistinguishable from 40 rapid reconnects. The brain reasoned plausibly from impoverished data.

## Fix

- Fetch logs with **`docker logs -t`** (timestamps).
- Make `collapseRepeats` **cadence-aware**: fold consecutive lines by **message** (ignoring the per-line timestamp) and report the run's **time span**:

```
INFO: OpenAI Realtime mode ready  (×40, 2026-06-22T21:40:16Z→2026-06-23T04:10:17Z)
```

That span is exactly the heartbeat-vs-storm signal the classify-by-sequence rule needs. Lines without a timestamp keep the plain `(×N)` form (back-compat — existing tests unchanged).

## Tests

New exported `splitLogTimestamp()`. +3 tests (parse/trim-fractional/null; cadence span on the *real* false-positive shape; timestamped singleton + distinct-message separation). **38 → 41 pass** (`node --test`).

## Verified live

Ran the modified sensor against the real DF container over SSH — the ×40 heartbeat now renders its 6.5h span, making the ~10-min cadence legible. This is a fix discovered *by* the deployed healer's own first false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)