### PR TITLE
ci: add node --test gate for self-healer/

### DIFF
--- a/.github/workflows/self-healer-tests.yml
+++ b/.github/workflows/self-healer-tests.yml
@@ -1,0 +1,29 @@
+name: Self-healer Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['self-healer/**']
+  push:
+    branches: [main]
+    paths: ['self-healer/**']
+
+jobs:
+  self-healer-tests:
+    name: Self-healer Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # The self-healer is a zero-dep Node project whose tests run via
+      # `node --test` (see self-healer/package.json). The other CI checks
+      # (Shell/YAML linting, secret quoting) never exercise it, so a PR that
+      # broke these tests previously merged green — this gate closes that hole.
+      - name: Run self-healer tests
+        working-directory: self-healer
+        run: node --test


### PR DESCRIPTION
## The gap

The repo's required CI checks are **Shell Linting**, **YAML Linting**, and **Secret Quoting Round-trip** — none of them run the `self-healer/` JS tests.

`self-healer/` is a zero-dep Node project whose tests run via `cd self-healer && node --test` (`self-healer/package.json` → `"test": "node --test"`). Because no required check exercises them, **a PR that breaks the self-healer tests merges green** — this actually happened during deploy #49.

## The fix

Add `.github/workflows/self-healer-tests.yml`:

- Triggers on `pull_request` and `push` to `main`, scoped with `paths: ['self-healer/**']`.
- Runs on `ubuntu-latest`: `actions/checkout@v4` → `actions/setup-node@v4` (node 20) → `node --test` with `working-directory: self-healer`.
- Job name **`Self-healer Tests`** so it can be added to branch protection required checks.

## Verification

- `node --test` is green locally: **41/41 pass** on node v20.
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`) and is clean under the repo's yamllint config (`{extends: relaxed, rules: {line-length: {max: 150}}}`).
- Secret scan of the diff is clean.

## Follow-up (not in this PR)

Add **`Self-healer Tests`** to branch-protection required checks so the gate is enforced at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)