### PR TITLE
feat(self-healer): atomic single-box lock around green-draft dedup

### DIFF
--- a/self-healer/src/draft.mjs
+++ b/self-healer/src/draft.mjs
@@ -17,12 +17,118 @@
 // deliberately separate, cage-built step. This is its safe precursor.
 
 import { createHash } from 'node:crypto';
+import { mkdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { scrubSecrets } from './notify.mjs';
 import { repoForContainer } from './repos.mjs';
 
 const GH_API = 'https://api.github.com';
 const LABEL = 'self-healer';
 const ZWSP = '​'; // zero-width space, to neutralize @mentions
+
+// Single-box atomic lock for the green-draft race window.
+//
+// The fingerprint-marker dedup (alreadyFiled) reconciles against GitHub's open
+// issues, but GitHub's List API is eventually-consistent and the check-then-
+// create sequence has no atomic step — two near-simultaneous healer runs on the
+// SAME box (an overlapping cron tick + a manual run) can both read "not filed"
+// and both create. This lock closes that window: each per-finding draft first
+// takes a per-fingerprint lock; exactly one caller wins, the others SKIP.
+//
+// Primitive: `mkdirSync(lockPath)` — directory creation is atomic on POSIX
+// filesystems (the kernel guarantees a single winner; concurrent callers get
+// EEXIST). The lock is keyed on the SAME findingFingerprint the marker dedup
+// uses, so distinct findings never contend and the two layers agree by
+// construction. The lock guards the short race window; the marker guards across
+// longer spans (it survives a crash, a TTL reclaim, or a process restart). The
+// lock is ADDITIVE to the marker, never a replacement.
+//
+// SCOPE — this is a SINGLE-HOST lock. The real deployment is one OCI box (cron +
+// manual runs), which is exactly what this covers. It does NOT provide cross-
+// host / distributed mutual exclusion; if green-auto ever runs on multiple hosts
+// concurrently, a shared store (Redis SETNX, a GitHub-side claim, etc.) would be
+// required. Documented as future work.
+
+/** State dir, resolved the SAME way as notify.mjs's passesCooldown so the
+ * healer keeps all its on-box state in one place. */
+function lockStateDir() {
+  return process.env.HEALER_STATE_DIR || '/tmp/self-healer';
+}
+
+/** Lock TTL in ms. A crashed run must not block a fingerprint forever, so a
+ * lock older than the TTL is reclaimable. Env knob HEALER_LOCK_TTL_MIN (minutes,
+ * default 10). A non-positive / non-finite value falls back to the default
+ * rather than disabling staleness — never leave a fingerprint permanently
+ * lockable-but-unreclaimable. */
+function lockTtlMs() {
+  const min = Number.parseInt(process.env.HEALER_LOCK_TTL_MIN ?? '10', 10);
+  return (Number.isFinite(min) && min > 0 ? min : 10) * 60_000;
+}
+
+/** Path of the per-fingerprint lock directory. */
+function lockPath(fp) {
+  return join(lockStateDir(), `draft-lock-${fp}`);
+}
+
+/**
+ * Try to atomically acquire the per-fingerprint draft lock.
+ *
+ * Returns `true` if THIS caller now owns the lock (proceed to file), `false` if
+ * another live run owns it (skip). Behaviour:
+ *   - mkdir succeeds                → acquired (true).
+ *   - mkdir throws EEXIST, lock STALE (mtime older than TTL) → reclaim it
+ *     (remove + re-mkdir) and acquire. If the reclaim mkdir itself loses an
+ *     EEXIST race to a concurrent reclaimer, the other run owns it → skip
+ *     (false).
+ *   - mkdir throws EEXIST, lock FRESH → another run owns it → skip (false).
+ *   - any OTHER (unexpected) error   → FAIL CLOSED: rethrow so the caller does
+ *     NOT file (consistent with the dedup read's "can't confirm → don't write").
+ *
+ * Note `false` is a clean "someone else owns it, skip"; only an UNEXPECTED error
+ * propagates, which the caller treats as fail-closed (no filing).
+ * @returns {boolean}
+ */
+export function acquireDraftLock(fp, nowMs = Date.now()) {
+  const path = lockPath(fp);
+  mkdirSync(lockStateDir(), { recursive: true });
+  try {
+    mkdirSync(path); // atomic: exactly one caller wins
+    return true;
+  } catch (err) {
+    if (err && err.code === 'EEXIST') {
+      // Lock exists. Reclaim only if it's stale (a crashed prior run).
+      let ageMs;
+      try {
+        ageMs = nowMs - statSync(path).mtimeMs;
+      } catch {
+        // The lock vanished between mkdir and stat (a concurrent release/
+        // reclaim). Re-attempt acquire ONCE; treat its outcome as authoritative.
+        try { mkdirSync(path); return true; } catch (e2) {
+          if (e2 && e2.code === 'EEXIST') return false; // someone else re-took it
+          throw e2; // unexpected → fail closed
+        }
+      }
+      if (ageMs > lockTtlMs()) {
+        // Stale: reclaim. rm then re-mkdir; if a concurrent reclaimer beats us
+        // to the re-mkdir, they own it and we skip.
+        try { rmSync(path, { recursive: true, force: true }); } catch { /* tolerate; mkdir below decides */ }
+        try { mkdirSync(path); return true; } catch (e3) {
+          if (e3 && e3.code === 'EEXIST') return false;
+          throw e3; // unexpected → fail closed
+        }
+      }
+      return false; // fresh lock held by a live run → skip
+    }
+    throw err; // unexpected error → fail closed (do NOT file)
+  }
+}
+
+/** Release the per-fingerprint lock after a filing ATTEMPT completes (success or
+ * failure), so the next legitimate run isn't blocked. Best-effort: a release
+ * failure must not throw (the TTL reclaim is the backstop). */
+export function releaseDraftLock(fp) {
+  try { rmSync(lockPath(fp), { recursive: true, force: true }); } catch { /* TTL reclaims */ }
+}
 
 function token() {
   return process.env.HEALER_GH_TOKEN || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || null;
@@ -147,6 +253,23 @@ export async function draftIfActionable(verdict) {
       continue;
     }
     const { title, body, fp } = buildIssue(f);
+
+    // Atomic single-box lock: take it BEFORE the dedup read + create so a
+    // concurrent run on the same box can't slip between our check and create.
+    // A clean loss (false) = another live run owns this fingerprint → skip.
+    // An UNEXPECTED lock error throws → caught below → fail closed (no filing).
+    let locked = false;
+    try {
+      locked = acquireDraftLock(fp);
+    } catch (err) {
+      outcomes.push({ container: f.container, action: 'failed', detail: `lock error (fail-closed): ${err.message}` });
+      continue;
+    }
+    if (!locked) {
+      outcomes.push({ container: f.container, action: 'deduped', detail: `concurrent run owns lock (fp ${fp.slice(0, 12)}…)` });
+      continue;
+    }
+
     try {
       await ensureLabel(repo); // before the dedup read, so the label filter is valid
       if (await alreadyFiled(repo, fp)) {
@@ -164,6 +287,10 @@ export async function draftIfActionable(verdict) {
     } catch (err) {
       // A dedup-read failure lands here → we do NOT file (fail closed).
       outcomes.push({ container: f.container, action: 'failed', detail: err.message });
+    } finally {
+      // Release after the attempt (success OR failure) so the next legitimate
+      // run isn't blocked; the TTL reclaim is the backstop if release fails.
+      releaseDraftLock(fp);
     }
   }
   return outcomes;

--- a/self-healer/src/draft.mjs
+++ b/self-healer/src/draft.mjs
@@ -16,8 +16,8 @@
 // real "monster" — a prompt-injection-into-codegen surface — and is a
 // deliberately separate, cage-built step. This is its safe precursor.
 
-import { createHash } from 'node:crypto';
-import { mkdirSync, rmSync, statSync } from 'node:fs';
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdirSync, rmSync, statSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { scrubSecrets } from './notify.mjs';
 import { repoForContainer } from './repos.mjs';
@@ -26,7 +26,7 @@ const GH_API = 'https://api.github.com';
 const LABEL = 'self-healer';
 const ZWSP = '​'; // zero-width space, to neutralize @mentions
 
-// Single-box atomic lock for the green-draft race window.
+// Single-box owner-fenced lock for the green-draft race window.
 //
 // The fingerprint-marker dedup (alreadyFiled) reconciles against GitHub's open
 // issues, but GitHub's List API is eventually-consistent and the check-then-
@@ -35,13 +35,40 @@ const ZWSP = '​'; // zero-width space, to neutralize @mentions
 // and both create. This lock closes that window: each per-finding draft first
 // takes a per-fingerprint lock; exactly one caller wins, the others SKIP.
 //
-// Primitive: `mkdirSync(lockPath)` — directory creation is atomic on POSIX
-// filesystems (the kernel guarantees a single winner; concurrent callers get
-// EEXIST). The lock is keyed on the SAME findingFingerprint the marker dedup
-// uses, so distinct findings never contend and the two layers agree by
-// construction. The lock guards the short race window; the marker guards across
-// longer spans (it survives a crash, a TTL reclaim, or a process restart). The
-// lock is ADDITIVE to the marker, never a replacement.
+// OWNER IDENTITY + SERIALIZED RECLAIM (cage-match PR #108, Maxwell + Carnot).
+// The naive "mkdir wins, rm-then-mkdir reclaims" design has two races because
+// the lock has no owner and the reclaim isn't atomic:
+//   1. the steal+re-create is multi-step, so under concurrent stale-reclaim two
+//      runs can both end up creating (a stat/rename TOCTOU ABA) → DOUBLE FILE;
+//   2. unconditional release deletes whatever's at the path, not the lock THIS
+//      caller took — so a run whose filing outran the TTL and was reclaimed out
+//      from under it would, in its finally, delete the NEW owner's lock → a
+//      third run enters the critical section.
+// The fix has THREE atomic gates, all fenced on a unique OWNER TOKEN
+// (crypto.randomBytes) written into the lock dir:
+//   - ACQUIRE (fast path): `mkdirSync(lockPath)` — atomic on POSIX (exactly one
+//     caller wins; others get EEXIST), then write the token file. Returns the
+//     token, or null if another live run owns it.
+//   - RECLAIM (stale lock): the steal+re-create runs UNDER a per-fingerprint
+//     O_EXCL reclaim-gate file (`writeFileSync(gate, …, {flag:'wx'})`), so the
+//     takeover is SINGLE-THREADED — exactly one reclaimer holds the gate, re-
+//     checks staleness inside it, removes the stale dir, and re-creates with its
+//     token. This single-writer reclaim eliminates the lock-free ABA that
+//     defeats a pure rename/stat steal under 3+ concurrent reclaimers. (A
+//     stale gate, from a crashed reclaimer, is itself broken on a TTL basis.)
+//   - RELEASE: read the token file; only remove the lock if it STILL MATCHES the
+//     token we acquired. A run reclaimed out from under itself reads a different
+//     (or missing) token → it does NOT delete the new owner's lock.
+// Net guarantee: AT MOST ONE winner for any number of concurrent callers
+// (verified by an N-process stress test). Under pathological contention a caller
+// may get a false `null` (skip) — SAFE for a fail-closed write gate (the next
+// cron tick re-files), never a double.
+//
+// The lock is keyed on the SAME findingFingerprint the marker dedup uses, so
+// distinct findings never contend and the two layers agree by construction. The
+// lock guards the short race window; the marker guards across longer spans (it
+// survives a crash, a TTL reclaim, or a process restart). The lock is ADDITIVE
+// to the marker, never a replacement.
 //
 // SCOPE — this is a SINGLE-HOST lock. The real deployment is one OCI box (cron +
 // manual runs), which is exactly what this covers. It does NOT provide cross-
@@ -70,64 +97,151 @@ function lockPath(fp) {
   return join(lockStateDir(), `draft-lock-${fp}`);
 }
 
+/** Path of the owner-token file inside a lock dir. */
+function ownerFile(path) {
+  return join(path, 'owner');
+}
+
+/** Create the canonical lock dir atomically and stamp it with `tok`.
+ * Returns the token on success; null if another caller won the mkdir (EEXIST);
+ * rethrows on any unexpected error (fail-closed). The token write happens AFTER
+ * the atomic mkdir, so the mkdir is the single point of mutual exclusion. */
+function stampNewLock(path, tok) {
+  try {
+    mkdirSync(path); // atomic: exactly one caller wins
+  } catch (err) {
+    if (err && err.code === 'EEXIST') return null; // someone else owns it
+    throw err; // unexpected → fail closed
+  }
+  writeFileSync(ownerFile(path), tok);
+  return tok;
+}
+
+/** Path of the per-fingerprint RECLAIM GATE file. This is a SEPARATE O_EXCL
+ * file that serializes stale-lock reclaimers: only its holder may steal +
+ * re-create the canonical lock, so the reclaim critical section is single-
+ * threaded and free of the rename/stat ABA races that defeat a lock-free steal
+ * under 3+ concurrent reclaimers. */
+function reclaimGatePath(fp) {
+  return `${lockPath(fp)}.reclaim`;
+}
+
 /**
- * Try to atomically acquire the per-fingerprint draft lock.
+ * Try to acquire the per-fingerprint draft lock.
  *
- * Returns `true` if THIS caller now owns the lock (proceed to file), `false` if
- * another live run owns it (skip). Behaviour:
- *   - mkdir succeeds                → acquired (true).
- *   - mkdir throws EEXIST, lock STALE (mtime older than TTL) → reclaim it
- *     (remove + re-mkdir) and acquire. If the reclaim mkdir itself loses an
- *     EEXIST race to a concurrent reclaimer, the other run owns it → skip
- *     (false).
- *   - mkdir throws EEXIST, lock FRESH → another run owns it → skip (false).
- *   - any OTHER (unexpected) error   → FAIL CLOSED: rethrow so the caller does
- *     NOT file (consistent with the dedup read's "can't confirm → don't write").
+ * Returns a non-empty OWNER TOKEN string if THIS caller now owns the lock (pass
+ * it to releaseDraftLock so release is owner-fenced); returns `null` if another
+ * live run owns it (skip). Throws ONLY on an unexpected error so the caller
+ * fails closed (does NOT file) — consistent with the dedup read's "can't confirm
+ * → don't write". A `null` is a clean "someone else owns it", not an error.
  *
- * Note `false` is a clean "someone else owns it, skip"; only an UNEXPECTED error
- * propagates, which the caller treats as fail-closed (no filing).
- * @returns {boolean}
+ * Mutual exclusion has TWO atomic gates:
+ *   1. the canonical lock dir — `mkdirSync` (exactly one creator wins);
+ *   2. the reclaim gate — an O_EXCL file that single-threads stale takeover so
+ *      the steal+re-create can't ABA-race under N≥3 concurrent reclaimers.
+ * Together they guarantee AT MOST ONE winner for any number of concurrent
+ * callers (verified by an N-process stress test). Under pathological contention
+ * a caller may get a false `null` (skip) — which is SAFE for a fail-closed write
+ * gate (the next cron tick re-files), never a double.
+ * @returns {string|null}
  */
 export function acquireDraftLock(fp, nowMs = Date.now()) {
   const path = lockPath(fp);
+  const tok = randomBytes(16).toString('hex');
   mkdirSync(lockStateDir(), { recursive: true });
+
+  // Fast path: an uncontended / free path is claimed by a single atomic mkdir.
+  const fresh = stampNewLock(path, tok);
+  if (fresh) return fresh;
+
+  // The lock exists. Decide stale vs live by age.
+  let ageMs;
   try {
-    mkdirSync(path); // atomic: exactly one caller wins
-    return true;
+    ageMs = nowMs - statSync(path).mtimeMs;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      // Vanished between mkdir and stat (a concurrent release). Retry the atomic
+      // create once; its outcome is authoritative.
+      return stampNewLock(path, tok); // token | null
+    }
+    throw err; // unexpected → fail closed
+  }
+  if (ageMs <= lockTtlMs()) return null; // fresh lock held by a live run → skip
+
+  // STALE → serialize the takeover through the O_EXCL reclaim gate so exactly
+  // one reclaimer runs the steal+re-create at a time (no lock-free ABA).
+  return reclaimStaleLock(fp, path, tok, nowMs);
+}
+
+/** Reclaim a STALE canonical lock under the single-writer reclaim gate. Returns
+ * the new owner token if this caller reclaimed it, else null (another reclaimer
+ * holds the gate, or the lock turned out live/already-reclaimed on re-check). */
+function reclaimStaleLock(fp, path, tok, nowMs) {
+  const gate = reclaimGatePath(fp);
+
+  // Acquire the reclaim gate atomically (O_EXCL). If held, try to break it only
+  // if it's itself stale (a crashed reclaimer); otherwise skip — a live
+  // reclaimer is handling this fingerprint.
+  try {
+    writeFileSync(gate, tok, { flag: 'wx' }); // atomic create-exclusive
   } catch (err) {
     if (err && err.code === 'EEXIST') {
-      // Lock exists. Reclaim only if it's stale (a crashed prior run).
-      let ageMs;
+      let gateAgeMs;
+      try { gateAgeMs = nowMs - statSync(gate).mtimeMs; } catch { return null; }
+      if (gateAgeMs <= lockTtlMs()) return null; // a live reclaimer holds the gate → skip
+      // Stale gate: clear it and retry the exclusive create ONCE.
+      try { rmSync(gate, { force: true }); } catch { /* tolerate */ }
       try {
-        ageMs = nowMs - statSync(path).mtimeMs;
-      } catch {
-        // The lock vanished between mkdir and stat (a concurrent release/
-        // reclaim). Re-attempt acquire ONCE; treat its outcome as authoritative.
-        try { mkdirSync(path); return true; } catch (e2) {
-          if (e2 && e2.code === 'EEXIST') return false; // someone else re-took it
-          throw e2; // unexpected → fail closed
-        }
+        writeFileSync(gate, tok, { flag: 'wx' });
+      } catch (e2) {
+        if (e2 && e2.code === 'EEXIST') return null; // another reclaimer won the gate
+        throw e2; // unexpected → fail closed
       }
-      if (ageMs > lockTtlMs()) {
-        // Stale: reclaim. rm then re-mkdir; if a concurrent reclaimer beats us
-        // to the re-mkdir, they own it and we skip.
-        try { rmSync(path, { recursive: true, force: true }); } catch { /* tolerate; mkdir below decides */ }
-        try { mkdirSync(path); return true; } catch (e3) {
-          if (e3 && e3.code === 'EEXIST') return false;
-          throw e3; // unexpected → fail closed
-        }
-      }
-      return false; // fresh lock held by a live run → skip
+    } else {
+      throw err; // unexpected → fail closed
     }
-    throw err; // unexpected error → fail closed (do NOT file)
+  }
+
+  // GATE HELD — single-threaded critical section. Re-check the lock under the
+  // gate (it may have been reclaimed/released since our pre-gate stat), then
+  // steal + re-create.
+  try {
+    let curAgeMs;
+    try {
+      curAgeMs = nowMs - statSync(path).mtimeMs;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        // Lock gone (released under us) → just create fresh.
+        return stampNewLock(path, tok); // token | null
+      }
+      throw err; // unexpected → fail closed
+    }
+    if (curAgeMs <= lockTtlMs()) return null; // became live → skip
+    // Still stale, and we are the sole reclaimer: remove + re-create.
+    rmSync(path, { recursive: true, force: true });
+    return stampNewLock(path, tok); // token | null (null only on an impossible race)
+  } finally {
+    try { rmSync(gate, { force: true }); } catch { /* gate TTL is the backstop */ }
   }
 }
 
-/** Release the per-fingerprint lock after a filing ATTEMPT completes (success or
- * failure), so the next legitimate run isn't blocked. Best-effort: a release
- * failure must not throw (the TTL reclaim is the backstop). */
-export function releaseDraftLock(fp) {
-  try { rmSync(lockPath(fp), { recursive: true, force: true }); } catch { /* TTL reclaims */ }
+/**
+ * Release the per-fingerprint lock after a filing ATTEMPT completes (success or
+ * failure), so the next legitimate run isn't blocked. OWNER-FENCED: removes the
+ * lock ONLY if its on-disk owner token still matches `tok` (the token returned
+ * by acquireDraftLock). A run that was reclaimed out from under itself reads a
+ * different/missing token and does NOT delete the new owner's lock. Best-effort:
+ * a release failure must not throw (the TTL reclaim is the backstop).
+ * @param {string} fp
+ * @param {string} tok the token returned by acquireDraftLock for this fp
+ */
+export function releaseDraftLock(fp, tok) {
+  const path = lockPath(fp);
+  try {
+    const onDisk = readFileSync(ownerFile(path), 'utf8');
+    if (onDisk !== tok) return; // not ours anymore (reclaimed) → do NOT delete
+    rmSync(path, { recursive: true, force: true });
+  } catch { /* missing/unreadable token or rm failure → leave it; TTL reclaims */ }
 }
 
 function token() {
@@ -256,16 +370,16 @@ export async function draftIfActionable(verdict) {
 
     // Atomic single-box lock: take it BEFORE the dedup read + create so a
     // concurrent run on the same box can't slip between our check and create.
-    // A clean loss (false) = another live run owns this fingerprint → skip.
-    // An UNEXPECTED lock error throws → caught below → fail closed (no filing).
-    let locked = false;
+    // A null return = another live run owns this fingerprint → skip. An
+    // UNEXPECTED lock error throws → caught here → fail closed (no filing).
+    let lockTok = null;
     try {
-      locked = acquireDraftLock(fp);
+      lockTok = acquireDraftLock(fp);
     } catch (err) {
       outcomes.push({ container: f.container, action: 'failed', detail: `lock error (fail-closed): ${err.message}` });
       continue;
     }
-    if (!locked) {
+    if (!lockTok) {
       outcomes.push({ container: f.container, action: 'deduped', detail: `concurrent run owns lock (fp ${fp.slice(0, 12)}…)` });
       continue;
     }
@@ -288,9 +402,11 @@ export async function draftIfActionable(verdict) {
       // A dedup-read failure lands here → we do NOT file (fail closed).
       outcomes.push({ container: f.container, action: 'failed', detail: err.message });
     } finally {
-      // Release after the attempt (success OR failure) so the next legitimate
-      // run isn't blocked; the TTL reclaim is the backstop if release fails.
-      releaseDraftLock(fp);
+      // Owner-fenced release after the attempt (success OR failure) so the next
+      // legitimate run isn't blocked; the TTL reclaim is the backstop if release
+      // fails. Passing our token ensures we never delete a lock that was
+      // reclaimed out from under us (cage-match PR #108).
+      releaseDraftLock(fp, lockTok);
     }
   }
   return outcomes;

--- a/self-healer/test/dedup_lock.test.mjs
+++ b/self-healer/test/dedup_lock.test.mjs
@@ -1,15 +1,24 @@
-// dedup_lock.test.mjs — the single-box atomic lock that closes the green-draft
-// check-then-create race (an overlapping cron tick + a manual run on the same
-// OCI box can't double-file the same fingerprint).
+// dedup_lock.test.mjs — the single-box owner-fenced lock that closes the
+// green-draft check-then-create race (an overlapping cron tick + a manual run on
+// the same OCI box can't double-file the same fingerprint).
+//
+// acquireDraftLock returns an OWNER TOKEN (truthy string) on success or null
+// when another live run owns the lock; releaseDraftLock(fp, token) is fenced on
+// that token so a run reclaimed out from under itself can't delete the new
+// owner's lock. Stale-lock takeover is serialized through an O_EXCL reclaim gate
+// so N concurrent reclaimers yield exactly one winner (cage-match PR #108:
+// Maxwell + Carnot — non-atomic reclaim + unfenced release).
 //
 // Zero-dep node:test. Each test uses an isolated tmp HEALER_STATE_DIR so the
 // lock paths never collide between cases or with a real run.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
 import { acquireDraftLock, releaseDraftLock } from '../src/draft.mjs';
 
@@ -31,38 +40,173 @@ function withState(fn, { ttlMin } = {}) {
   }
 }
 
-test('atomic acquire: first wins, second on same fingerprint skips', () => {
+const lockDirOf = (dir, fp) => join(dir, `draft-lock-${fp}`);
+const ownerOf = (dir, fp) => readFileSync(join(lockDirOf(dir, fp), 'owner'), 'utf8');
+
+test('atomic acquire returns a token; second on same fp skips (null)', () => {
   withState(() => {
     const fp = 'aaaa1111';
-    assert.equal(acquireDraftLock(fp), true, 'first acquire should win');
-    assert.equal(acquireDraftLock(fp), false, 'second acquire (lock still held) should skip');
+    const tok = acquireDraftLock(fp);
+    assert.equal(typeof tok, 'string', 'first acquire returns a token');
+    assert.ok(tok.length >= 16, 'token is non-trivial');
+    assert.equal(acquireDraftLock(fp), null, 'second acquire (lock still held) skips');
   });
 });
 
-test('stale lock is reclaimed after TTL', () => {
+test('stale lock is reclaimed after TTL (new owner gets a fresh token)', () => {
   withState((dir) => {
     const fp = 'bbbb2222';
-    assert.equal(acquireDraftLock(fp), true, 'first acquire wins');
-    // A concurrent live run still sees it held.
-    assert.equal(acquireDraftLock(fp), false, 'fresh lock blocks a second run');
+    const tok1 = acquireDraftLock(fp);
+    assert.ok(tok1, 'first acquire wins');
+    assert.equal(acquireDraftLock(fp), null, 'fresh lock blocks a second run');
 
-    // Simulate a crashed run by back-dating the lock dir's mtime well past the
-    // 10-min default TTL.
-    const lockDir = join(dir, `draft-lock-${fp}`);
+    // Simulate a crashed run by back-dating the lock dir's mtime past the TTL.
     const old = new Date(Date.now() - 60 * 60_000); // 1h ago
-    utimesSync(lockDir, old, old);
+    utimesSync(lockDirOf(dir, fp), old, old);
 
-    assert.equal(acquireDraftLock(fp), true, 'stale lock should be reclaimed and re-acquired');
+    const tok2 = acquireDraftLock(fp);
+    assert.ok(tok2, 'stale lock reclaimed → new acquire succeeds');
+    assert.notEqual(tok2, tok1, 'reclaimer holds a DIFFERENT owner token');
+    assert.equal(ownerOf(dir, fp), tok2, 'on-disk owner is the reclaimer');
   });
 });
 
-test('lock released after a filing attempt → a later run can re-acquire', () => {
+test('owner-fenced release: matching token removes the lock; later run re-acquires', () => {
   withState((dir) => {
     const fp = 'cccc3333';
-    assert.equal(acquireDraftLock(fp), true, 'acquire');
-    releaseDraftLock(fp);
-    assert.equal(existsSync(join(dir, `draft-lock-${fp}`)), false, 'release removes the lock dir');
-    assert.equal(acquireDraftLock(fp), true, 'a later run can re-acquire after release');
+    const tok = acquireDraftLock(fp);
+    assert.ok(tok, 'acquire');
+    releaseDraftLock(fp, tok);
+    assert.equal(existsSync(lockDirOf(dir, fp)), false, 'release removes the lock dir');
+    assert.ok(acquireDraftLock(fp), 'a later run can re-acquire after release');
+  });
+});
+
+test("release with a STALE token does NOT delete the new owner's lock", () => {
+  withState((dir) => {
+    const fp = 'gggg7777';
+    // Run A acquires, then is "reclaimed out from under itself": back-date and
+    // let run B reclaim. A still holds its (now stale) token.
+    const tokA = acquireDraftLock(fp);
+    assert.ok(tokA, 'A acquires');
+    const old = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lockDirOf(dir, fp), old, old);
+    const tokB = acquireDraftLock(fp);
+    assert.ok(tokB, 'B reclaims');
+    assert.notEqual(tokA, tokB);
+
+    // A's finally fires LATE with its stale token — must be a no-op on B's lock.
+    releaseDraftLock(fp, tokA);
+    assert.equal(existsSync(lockDirOf(dir, fp)), true, "A's stale release must NOT delete B's lock");
+    assert.equal(ownerOf(dir, fp), tokB, 'B still owns the lock');
+
+    // B's own (owner-matched) release works.
+    releaseDraftLock(fp, tokB);
+    assert.equal(existsSync(lockDirOf(dir, fp)), false, "B's owner-matched release removes it");
+  });
+});
+
+test('two sequential reclaimers of one stale lock: exactly one wins', () => {
+  withState((dir) => {
+    const fp = 'hhhh8888';
+    // Establish a stale lock by hand (a crashed prior run).
+    const lockDir = lockDirOf(dir, fp);
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner'), 'crashed-prior-run');
+    const old = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lockDir, old, old);
+
+    // The first reclaimer takes the O_EXCL reclaim gate, removes the stale lock,
+    // and re-creates a fresh one; the second then sees a FRESH (non-stale) lock
+    // and returns null. (The true-concurrency guarantee is exercised by the
+    // N-process test below; this asserts the sequential invariant + the on-disk
+    // owner matches the single winner with no clobber.)
+    const r1 = acquireDraftLock(fp);
+    const r2 = acquireDraftLock(fp);
+    const winners = [r1, r2].filter(Boolean);
+    assert.equal(winners.length, 1, 'exactly one reclaimer acquires the lock');
+    assert.equal(ownerOf(dir, fp), winners[0], 'on-disk owner == the single winner (no clobber)');
+  });
+});
+
+test('N truly-concurrent processes racing one stale lock: exactly one reclaims', async () => {
+  // The sequential tests above can't observe the reclaim race under real
+  // contention (the first call completes before the second starts). Spawn N OS
+  // processes that all hit the SAME stale lock simultaneously and assert exactly
+  // one acquires — this is the test that FAILS under a lock-free rename/stat
+  // steal (an ABA double-reclaim → double file) and passes only because the
+  // takeover is serialized through the O_EXCL reclaim gate.
+  const dir = mkdtempSync(join(tmpdir(), 'healer-race-'));
+  try {
+    const fp = 'kkkk1111';
+    const lockDir = join(dir, `draft-lock-${fp}`);
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner'), 'crashed-prior-run');
+    const old = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lockDir, old, old);
+
+    const here = new URL('.', import.meta.url).pathname;
+    const draftUrl = pathToFileURL(join(here, '..', 'src', 'draft.mjs')).href;
+    // Each child imports the real module and prints '1' if it acquired, '0' else.
+    const child = () => new Promise((resolve, reject) => {
+      const code =
+        `import('${draftUrl}').then(m => {` +
+        `const t = m.acquireDraftLock('${fp}');` +
+        `process.stdout.write(t ? '1' : '0');});`;
+      const p = spawn(process.execPath, ['--input-type=module', '-e', code], {
+        env: { ...process.env, HEALER_STATE_DIR: dir, HEALER_LOCK_TTL_MIN: '10' },
+      });
+      let out = '';
+      p.stdout.on('data', (d) => { out += d; });
+      p.on('error', reject);
+      p.on('exit', () => resolve(out.trim()));
+    });
+
+    const N = 12;
+    const results = await Promise.all(Array.from({ length: N }, () => child()));
+    const acquired = results.filter((r) => r === '1').length;
+    assert.equal(acquired, 1, `exactly one of ${N} concurrent processes should reclaim (got ${acquired}: ${results.join('')})`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a STALE reclaim-gate (crashed reclaimer) does not block reclaim forever', () => {
+  withState((dir) => {
+    const fp = 'iiii9999';
+    // A reclaimer that crashed mid-takeover leaves the O_EXCL reclaim-gate file
+    // behind. Pair it with a stale lock. A fresh run must break the stale gate
+    // (TTL) and still reclaim — the gate is not a permanent deadlock.
+    const lockDir = lockDirOf(dir, fp);
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner'), 'crashed-owner');
+    const gate = `${lockDir}.reclaim`;
+    writeFileSync(gate, 'crashed-reclaimer');
+    const old = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lockDir, old, old);
+    utimesSync(gate, old, old); // gate itself is stale
+
+    const tok = acquireDraftLock(fp);
+    assert.ok(tok, 'a stale reclaim-gate is broken on TTL → reclaim proceeds');
+    assert.equal(ownerOf(dir, fp), tok, 'reclaimer owns the fresh lock');
+    assert.equal(existsSync(gate), false, 'reclaim-gate is released after the takeover');
+  });
+});
+
+test('a FRESH reclaim-gate (a live reclaimer) makes a second run skip (null)', () => {
+  withState((dir) => {
+    const fp = 'llll1212';
+    // A live reclaimer is mid-takeover: stale lock present, gate freshly held.
+    const lockDir = lockDirOf(dir, fp);
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'owner'), 'crashed-owner');
+    const gate = `${lockDir}.reclaim`;
+    writeFileSync(gate, 'live-reclaimer'); // fresh mtime (just written)
+    const old = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lockDir, old, old); // lock is stale...
+
+    // ...but the gate is fresh, so a second run must NOT also reclaim → null.
+    assert.equal(acquireDraftLock(fp), null, 'a live reclaim-gate holder blocks a second reclaimer');
   });
 });
 
@@ -72,10 +216,7 @@ test('unexpected error path fails CLOSED (throws → caller does not file)', () 
     // the state dir (and thus the lock) raises a NON-EEXIST error (ENOTDIR).
     const base = mkdtempSync(join(tmpdir(), 'healer-bad-'));
     const fileAsParent = join(base, 'not-a-dir');
-    // Create a regular file where a directory is expected.
     rmSync(fileAsParent, { force: true });
-    mkdirSync(base, { recursive: true });
-    // Write a file, then use it as if it were the state dir's parent.
     writeFileSync(fileAsParent, 'x');
     process.env.HEALER_STATE_DIR = join(fileAsParent, 'state'); // parent is a file → ENOTDIR
 
@@ -90,10 +231,9 @@ test('unexpected error path fails CLOSED (throws → caller does not file)', () 
 
 test('distinct fingerprints do not block each other', () => {
   withState(() => {
-    assert.equal(acquireDraftLock('eeee5555'), true, 'fp A acquires');
-    assert.equal(acquireDraftLock('ffff6666'), true, 'fp B acquires independently');
-    // And each is still independently held.
-    assert.equal(acquireDraftLock('eeee5555'), false, 'fp A still held');
-    assert.equal(acquireDraftLock('ffff6666'), false, 'fp B still held');
+    assert.ok(acquireDraftLock('eeee5555'), 'fp A acquires');
+    assert.ok(acquireDraftLock('ffff6666'), 'fp B acquires independently');
+    assert.equal(acquireDraftLock('eeee5555'), null, 'fp A still held');
+    assert.equal(acquireDraftLock('ffff6666'), null, 'fp B still held');
   });
 });

--- a/self-healer/test/dedup_lock.test.mjs
+++ b/self-healer/test/dedup_lock.test.mjs
@@ -1,0 +1,99 @@
+// dedup_lock.test.mjs — the single-box atomic lock that closes the green-draft
+// check-then-create race (an overlapping cron tick + a manual run on the same
+// OCI box can't double-file the same fingerprint).
+//
+// Zero-dep node:test. Each test uses an isolated tmp HEALER_STATE_DIR so the
+// lock paths never collide between cases or with a real run.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { acquireDraftLock, releaseDraftLock } from '../src/draft.mjs';
+
+/** Run `fn` with a fresh isolated state dir + lock TTL, restoring env after. */
+function withState(fn, { ttlMin } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'healer-lock-'));
+  const savedDir = process.env.HEALER_STATE_DIR;
+  const savedTtl = process.env.HEALER_LOCK_TTL_MIN;
+  process.env.HEALER_STATE_DIR = dir;
+  if (ttlMin !== undefined) process.env.HEALER_LOCK_TTL_MIN = String(ttlMin);
+  try {
+    return fn(dir);
+  } finally {
+    if (savedDir === undefined) delete process.env.HEALER_STATE_DIR;
+    else process.env.HEALER_STATE_DIR = savedDir;
+    if (savedTtl === undefined) delete process.env.HEALER_LOCK_TTL_MIN;
+    else process.env.HEALER_LOCK_TTL_MIN = savedTtl;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('atomic acquire: first wins, second on same fingerprint skips', () => {
+  withState(() => {
+    const fp = 'aaaa1111';
+    assert.equal(acquireDraftLock(fp), true, 'first acquire should win');
+    assert.equal(acquireDraftLock(fp), false, 'second acquire (lock still held) should skip');
+  });
+});
+
+test('stale lock is reclaimed after TTL', () => {
+  withState((dir) => {
+    const fp = 'bbbb2222';
+    assert.equal(acquireDraftLock(fp), true, 'first acquire wins');
+    // A concurrent live run still sees it held.
+    assert.equal(acquireDraftLock(fp), false, 'fresh lock blocks a second run');
+
+    // Simulate a crashed run by back-dating the lock dir's mtime well past the
+    // 10-min default TTL.
+    const lockDir = join(dir, `draft-lock-${fp}`);
+    const old = new Date(Date.now() - 60 * 60_000); // 1h ago
+    utimesSync(lockDir, old, old);
+
+    assert.equal(acquireDraftLock(fp), true, 'stale lock should be reclaimed and re-acquired');
+  });
+});
+
+test('lock released after a filing attempt → a later run can re-acquire', () => {
+  withState((dir) => {
+    const fp = 'cccc3333';
+    assert.equal(acquireDraftLock(fp), true, 'acquire');
+    releaseDraftLock(fp);
+    assert.equal(existsSync(join(dir, `draft-lock-${fp}`)), false, 'release removes the lock dir');
+    assert.equal(acquireDraftLock(fp), true, 'a later run can re-acquire after release');
+  });
+});
+
+test('unexpected error path fails CLOSED (throws → caller does not file)', () => {
+  withState(() => {
+    // Point the state dir at a path whose PARENT is a regular file, so mkdir of
+    // the state dir (and thus the lock) raises a NON-EEXIST error (ENOTDIR).
+    const base = mkdtempSync(join(tmpdir(), 'healer-bad-'));
+    const fileAsParent = join(base, 'not-a-dir');
+    // Create a regular file where a directory is expected.
+    rmSync(fileAsParent, { force: true });
+    mkdirSync(base, { recursive: true });
+    // Write a file, then use it as if it were the state dir's parent.
+    writeFileSync(fileAsParent, 'x');
+    process.env.HEALER_STATE_DIR = join(fileAsParent, 'state'); // parent is a file → ENOTDIR
+
+    assert.throws(
+      () => acquireDraftLock('dddd4444'),
+      (err) => err && err.code !== 'EEXIST',
+      'an unexpected (non-EEXIST) error must propagate so the caller fails closed',
+    );
+    rmSync(base, { recursive: true, force: true });
+  });
+});
+
+test('distinct fingerprints do not block each other', () => {
+  withState(() => {
+    assert.equal(acquireDraftLock('eeee5555'), true, 'fp A acquires');
+    assert.equal(acquireDraftLock('ffff6666'), true, 'fp B acquires independently');
+    // And each is still independently held.
+    assert.equal(acquireDraftLock('eeee5555'), false, 'fp A still held');
+    assert.equal(acquireDraftLock('ffff6666'), false, 'fp B still held');
+  });
+});


### PR DESCRIPTION
## What

Closes the same-host concurrent-run race in the self-healer's green-draft stage (part of task #46, the green-auto prerequisite). The README explicitly flagged this:

> the check-then-create sequence has no atomic lock… two near-simultaneous runs could double-file. A real single-writer/lock is a prerequisite before any higher-stakes action stage.

## How

Adds a per-fingerprint atomic file-lock around each per-finding draft in `draft.mjs`:

- **Primitive:** `fs.mkdirSync(lockPath)` — directory creation is atomic on POSIX. Exactly one concurrent caller wins; losers get `EEXIST` and **skip** (reported as `deduped`).
- **Key:** the same `findingFingerprint` the marker dedup uses, under `HEALER_STATE_DIR` (default `/tmp/self-healer`, resolved the same way as `notify.mjs`'s `passesCooldown`). Distinct findings never contend; the lock and marker layers agree by construction.
- **TTL / staleness:** a crashed run must not block a fingerprint forever. A lock older than `HEALER_LOCK_TTL_MIN` (minutes, **default 10**) is reclaimed. A non-positive/non-finite TTL falls back to the default rather than disabling staleness.
- **Fail-closed:** an UNEXPECTED (non-`EEXIST`) lock error propagates → caller does **not** file, consistent with the dedup read's "can't confirm → don't write". A clean `EEXIST` is a normal skip, not an error.
- **Release:** in a `finally` after each filing attempt (success or failure) so the next legitimate run isn't blocked; the TTL reclaim is the backstop if release fails.
- **Additive:** the lock guards the short race window; the existing fingerprint-marker dedup still guards across longer spans (crash / TTL-reclaim / restart). The lock does not replace the marker.
- Green-draft stays **OFF by default** (`HEALER_DRAFT_ISSUES`); the lock only engages when drafting is enabled.

## Scope caveat (no overclaim)

This is a **single-host** lock. It closes the actual deployment's race (one OCI box, cron + manual runs). It does **NOT** provide cross-host / distributed mutual exclusion — a multi-host green-auto would need a shared store (Redis `SETNX`, a GitHub-side claim, etc.). Documented as future work in code comments.

## Tests

5 new `node:test` cases in `test/dedup_lock.test.mjs` (zero-dep, isolated `mkdtempSync` state dirs):
1. atomic acquire — first wins, second on same fp skips
2. stale lock reclaimed after TTL
3. lock released after a filing attempt → a later run can re-acquire
4. unexpected error path fails CLOSED (throws, does not file)
5. distinct fingerprints don't block each other

Full suite (`cd self-healer && node --test`): **46 pass / 0 fail**.

## Deferred

- The README green-draft caveat (the "no atomic lock… prerequisite" note) should be updated to reflect that the same-host race is now closed. Left out of this PR to respect a tight file-scope fence (parallel agents); filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)