### PR TITLE
feat(claude-shim): version source as infra service with sops secret

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@
 
 creation_rules:
   # Match secret yaml files in service and provider directories
-  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus)/.*\.yaml$
+  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim)/.*\.yaml$
     age: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks

--- a/claude-shim/Dockerfile
+++ b/claude-shim/Dockerfile
@@ -1,0 +1,33 @@
+# claude-shim — Max-plan headless Claude Code behind a tiny HTTP endpoint.
+# Mirrors the claudius container's claude-install + non-root pattern, minus the
+# email/Playwright machinery — this image only needs the `claude` CLI and Node.
+
+FROM node:20-slim
+
+# git + ca-certificates: claude's npm install and runtime expect them present.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI globally.
+RUN npm install -g @anthropic-ai/claude-code
+
+# Run as a dedicated non-root user (defense-in-depth — the server only ever
+# spawns `claude -p` for text, never with tool permissions, but least-privilege
+# is cheap insurance for a network-reachable process).
+RUN useradd -m -s /bin/bash shim \
+    && mkdir -p /home/shim/.claude \
+    && chown -R shim:shim /home/shim
+
+WORKDIR /app
+COPY src/package.json ./
+COPY src/server.js ./
+RUN chown -R shim:shim /app
+
+USER shim
+
+# CLAUDE_CODE_OAUTH_TOKEN is supplied at runtime via the compose environment
+# block (generated from the SOPS-encrypted secrets.yaml at deploy time).
+EXPOSE 8088
+CMD ["node", "server.js"]

--- a/claude-shim/README.md
+++ b/claude-shim/README.md
@@ -1,0 +1,94 @@
+# claude-shim
+
+A tiny HTTP front door to **Max-plan headless Claude Code** for callers that
+live in OCI containers. It turns "call Claude" into "call the Max plan at zero
+marginal cost" by spawning `claude -p` under the hood, instead of hitting the
+metered Anthropic API.
+
+## Why it exists
+
+Two callers on the OCI box need Claude inference but were paying per-token (or
+failing on a zero API balance):
+
+- **embodied-dreamfinder's voice brain** — was 400-erroring when the Anthropic
+  credit balance hit zero.
+- **the in-prod log-reading self-healer** (diagnosis stage) — wants Claude to
+  read a log window and propose a fix.
+
+Both need the same thing: *run Claude on the Max plan from this box*. This
+service is that one shared artifact.
+
+## The one gate: mint an OAuth token
+
+Headless Claude Code authenticates via `CLAUDE_CODE_OAUTH_TOKEN` (same as
+`claudius` / `familiars-server`). Mint it once, on the Max account you want
+these calls billed against:
+
+```bash
+claude setup-token      # interactive OAuth; prints a long-lived token
+```
+
+The token is stored as a **SOPS-encrypted secret** in this repo, the same
+convention every other service here uses (`notify/`, `embodied-dreamfinder/`,
+…). The plaintext token is never committed — only the age-encrypted ciphertext
+lives in git.
+
+```bash
+cp claude-shim/secrets.yaml.example claude-shim/secrets.yaml
+# edit claude_code_oauth_token, then encrypt in place:
+sops -e -i claude-shim/secrets.yaml
+```
+
+> **Quota note:** the account that mints the token owns the weekly turn budget
+> these calls consume. `claudius` already burns one Max account on this box
+> (its logs showed ~305/500 weekly). Decide whether the shim shares that
+> account or gets its own — a chatty voice agent can move the needle.
+
+## Contract
+
+```
+POST /chat
+  body: { "system": "...", "messages": [{ "role": "user", "content": "..." }], "model": "haiku" }
+  200:  { "text": "..." }
+  4xx/5xx: { "error": "..." }
+
+GET /health -> { "ok": true }
+```
+
+Callers keep their own conversation history and send the full `messages` array
+each turn; the shim is stateless. `system` and `model` are optional (`model`
+defaults to `haiku` to preserve DF's latency profile).
+
+## Deploy
+
+```bash
+./scripts/deploy-to.sh 149.118.69.221 claude-shim
+```
+
+`deploy_claude_shim` decrypts `secrets.yaml`, generates a local `.env`
+(gitignored via the root `**/.env` rule), rsyncs the dir to the host excluding
+`secrets.yaml`, ensures the shared `imagineering` docker network exists, then
+**builds from the Dockerfile** (it isn't a published image, so it's
+`docker compose build && up -d`, not `pull`). The plaintext token never touches
+git, argv, or a remote shell command line.
+
+## Verify
+
+After the token is in place and the container is up:
+
+```bash
+# from the host
+curl -s 127.0.0.1:8088/health
+curl -s 127.0.0.1:8088/chat \
+  -H 'content-type: application/json' \
+  -d '{"system":"You are terse.","messages":[{"role":"user","content":"reply with exactly: PONG"}]}'
+# -> {"text":"PONG"}  (note the wall-clock — first call is cold)
+```
+
+From another container on the `imagineering` network, the URL is
+`http://claude-shim:8088/chat`.
+
+## Consumers
+
+- `embodied-dreamfinder` — set `DF_BRAIN=maxplan` and `CLAUDE_SHIM_URL=http://claude-shim:8088`.
+- the healer (future) — same endpoint, a stronger `model` per request for diagnosis.

--- a/claude-shim/docker-compose.yml
+++ b/claude-shim/docker-compose.yml
@@ -21,6 +21,11 @@ services:
       # compose ${VAR} interpolation. The real OAuth token lives ONLY in the
       # encrypted secrets.yaml, never in git as plaintext.
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
+      # deploy-#49 floor: the self-healer's sonnet diagnoses take ~60-93s and
+      # time out against server.js's default 60000ms ceiling. Not a secret, so
+      # versioned here as a literal (not in secrets.yaml). Keep below the
+      # healer's own SHIM_HTTP_TIMEOUT_MS=150000, which must sit above this.
+      - SHIM_TIMEOUT_MS=120000
     ports:
       - "127.0.0.1:8088:8088"   # host-local smoke tests; container callers use the network name
     networks:

--- a/claude-shim/docker-compose.yml
+++ b/claude-shim/docker-compose.yml
@@ -1,0 +1,32 @@
+# claude-shim — shared Max-plan inference endpoint for OCI container callers.
+#
+# Deploy: ./scripts/deploy-to.sh 149.118.69.221 claude-shim
+#   (claude-shim builds from ./Dockerfile rather than pulling a published
+#    image, so it needs a `docker compose build` deploy case — see README.)
+#
+# Consumers (embodied-dreamfinder, the healer) reach it over the shared
+# `imagineering` network by service name: http://claude-shim:8088/chat — the
+# same network DF uses to reach the text brain (dreamfinder:8081). The
+# host-published port is for curl-from-host smoke tests only.
+
+services:
+  claude-shim:
+    build:
+      context: .
+    container_name: claude-shim
+    restart: unless-stopped
+    environment:
+      # Generated into ./.env from the SOPS-encrypted secrets.yaml at deploy
+      # time (see deploy_claude_shim in scripts/deploy-to.sh) and read here via
+      # compose ${VAR} interpolation. The real OAuth token lives ONLY in the
+      # encrypted secrets.yaml, never in git as plaintext.
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
+    ports:
+      - "127.0.0.1:8088:8088"   # host-local smoke tests; container callers use the network name
+    networks:
+      - imagineering
+
+# External: created out-of-band, shared with embodied-dreamfinder + the bots.
+networks:
+  imagineering:
+    external: true

--- a/claude-shim/secrets.yaml
+++ b/claude-shim/secrets.yaml
@@ -1,0 +1,16 @@
+claude_code_oauth_token: ENC[AES256_GCM,data:2qIWVFj4sz8tHdAYCSKtCvsLHLU0KIfr7+n82qF+Ga7fYSdyq3wsqwiSy73n/qySRbThEfFQs+rFotgX/oKaZMbZomwtZAAmcZljQ+xsT+oKp6TlQM+XNYFo5JTiMGd6uoucHOExeH0vpOxI,iv:zDhNZfS3zg8cCwcPwA9pOEUMleOMwwX+rPoMjy9CUsQ=,tag:m4DmRiEAtA4Ux84ExfJlcA==,type:str]
+sops:
+    age:
+        - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCdVB4aCtRY241eFA4Tm4x
+            ZnowREVCeUlSNWgycys2Y0RYQkdXdCtSSFNVCkM5UUp6dW83YkVFbVV3UElFc1Uz
+            V0hETE0rQUlnelZydndsQ0xQeWpPSGMKLS0tIDNiek1CR3JJQmg4cjl3ZUpYamE0
+            UXlpRFRwUFZ6NUordG9rWWtNTTZBSEkKkXQtIbQ3MVEbtfEv7frmoi/dJZ6O3UQs
+            DMYeXvRIeRTpWuKw2MhnqutgUNntG6GJGs73GfRhC1zt/k+BI3NhyQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-23T05:55:08Z"
+    mac: ENC[AES256_GCM,data:Xn7C/RERy9Zh8wHmP8dsnPLDJJ/mydgOW2HNSafQe0Yg78lG/pqsK1wsdR22rSitpN4Xn4kZebEqOpCFIUNhvbEQzPYE1FQicvgt+kqJK8IpCVmMT+pdt08kVWookjrKj7+SAq5E+cK5Gi/jRJVAcHKdLUCBFwSUq8mgDbcCfLU=,iv:f5d8uHALK4LGxT+UrFyUQSXrRLd8dnleF559VQanmMk=,tag:fR023hQvkEwIvKDXdtX/0g==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/claude-shim/secrets.yaml.example
+++ b/claude-shim/secrets.yaml.example
@@ -1,0 +1,10 @@
+# claude-shim secrets — template. Copy to secrets.yaml, fill the real value,
+# then encrypt in place:  sops -e -i claude-shim/secrets.yaml
+#
+# The encrypted secrets.yaml IS committed (sops ciphertext); the plaintext
+# value and the generated .env are NOT (root .gitignore: **/.env).
+#
+# claude_code_oauth_token — Max-plan auth for headless Claude Code. Mint with
+# `claude setup-token` on the Max account these calls should bill against (it
+# owns the weekly turn quota). Same auth as claudius / familiars-server.
+claude_code_oauth_token: ""

--- a/claude-shim/src/package.json
+++ b/claude-shim/src/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "claude-shim",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "HTTP front door to Max-plan headless Claude Code (claude -p) for OCI container callers.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/claude-shim/src/server.js
+++ b/claude-shim/src/server.js
@@ -1,0 +1,179 @@
+// claude-shim — a tiny HTTP front door to Max-plan headless Claude Code.
+//
+// WHY THIS EXISTS
+// ---------------
+// Programmatic Claude calls on OCI should run on Nick's Max subscription
+// (zero marginal cost) via headless Claude Code, NOT the metered Anthropic
+// API. But two would-be callers live in Docker containers:
+//   - embodied-dreamfinder's voice brain (was 400-erroring on zero API credit)
+//   - the in-prod log-reading self-healer (diagnosis stage)
+// Both need the same thing: "run Claude on the Max plan from this box."
+// This service is that one shared artifact. It exposes a minimal
+// chat-completion endpoint and, under the hood, spawns `claude -p`.
+//
+// AUTH
+// ----
+// The `claude` CLI reads CLAUDE_CODE_OAUTH_TOKEN directly from the
+// environment (the output of `claude setup-token` on a Max account). This is
+// the same mechanism claudius uses. No credentials file, no interactive login
+// inside the container. Whichever account mints the token owns the weekly
+// turn quota these calls consume.
+//
+// CONTRACT
+// --------
+//   POST /chat
+//     body: { system?: string, messages: [{ role, content }], model?: string }
+//     200:  { text: string }
+//     4xx/5xx: { error: string }
+//   GET /health -> { ok: true }
+//
+// Callers keep their own conversation history and send the full `messages`
+// array each turn; the shim is stateless (`--no-session-persistence`).
+
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+
+const PORT = Number(process.env.PORT || 8088);
+// Default to the same Haiku tier DF used on the API, to preserve its latency
+// profile. Callers may override per-request (e.g. the healer wants a stronger
+// model for diagnosis).
+const DEFAULT_MODEL = process.env.SHIM_DEFAULT_MODEL || 'haiku';
+// Hard ceiling so a wedged `claude` process can't pin a request forever. DF's
+// own pipeline budgets 4-8s per turn; give generous headroom for cold starts.
+const TIMEOUT_MS = Number(process.env.SHIM_TIMEOUT_MS || 60_000);
+
+if (!process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_API_KEY) {
+  // Fail loud at boot rather than 500 on every request — a missing token is
+  // an ops mistake, not a runtime condition to limp through.
+  console.error(
+    '[claude-shim] FATAL: neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY set. ' +
+    'Mint a token with `claude setup-token` and put it in .env.',
+  );
+  process.exit(1);
+}
+
+/**
+ * Render a chat-style messages array into a single prompt string for `claude
+ * -p`. The CLI takes one prompt, not a structured turn list, so we flatten the
+ * transcript with explicit role markers. The system prompt is passed
+ * separately via --system-prompt (it replaces Claude Code's coding-agent
+ * framing entirely). History is capped by the caller (DF keeps ~20 turns).
+ */
+function renderPrompt(messages) {
+  return messages
+    .map((m) => {
+      const who = m.role === 'assistant' ? 'Assistant' : 'Human';
+      return `${who}: ${m.content}`;
+    })
+    .join('\n\n');
+}
+
+/**
+ * Spawn `claude -p` and resolve with its text output. Rejects on non-zero
+ * exit, spawn error, or timeout.
+ *
+ * SECURITY: this is a network-reachable endpoint with caller-supplied input,
+ * so it must NOT be able to take actions. We deliberately do NOT pass
+ * --dangerously-skip-permissions. In -p (non-interactive) mode there is no
+ * one to answer a permission prompt, so Claude Code auto-denies tool use and
+ * continues with text only — exactly the constrained "pure inference, no
+ * tools" behaviour we want. A prompt-injected message therefore cannot make
+ * the shim execute anything: the worst it can do is produce text.
+ */
+function runClaude({ system, prompt, model }) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '-p', prompt,
+      '--model', model || DEFAULT_MODEL,
+      '--output-format', 'text',
+      '--no-session-persistence',
+    ];
+    if (system) args.push('--system-prompt', system);
+
+    // Empty cwd so there's no project CLAUDE.md / settings to auto-discover —
+    // keeps the call closer to pure inference and trims startup work.
+    const proc = spawn('claude', args, {
+      cwd: '/tmp',
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new Error(`claude timed out after ${TIMEOUT_MS}ms`));
+    }, TIMEOUT_MS);
+
+    proc.stdout.on('data', (d) => { stdout += d; });
+    proc.stderr.on('data', (d) => { stderr += d; });
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`claude exited ${code}: ${stderr.trim() || '(no stderr)'}`));
+    });
+  });
+}
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(payload);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', (c) => {
+      raw += c;
+      // Defensive cap — a chat payload is small; anything huge is a bug or abuse.
+      if (raw.length > 1_000_000) {
+        reject(new Error('request body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => resolve(raw));
+    req.on('error', reject);
+  });
+}
+
+const server = createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    return sendJson(res, 200, { ok: true });
+  }
+
+  if (req.method === 'POST' && req.url === '/chat') {
+    let body;
+    try {
+      body = JSON.parse(await readBody(req));
+    } catch (err) {
+      return sendJson(res, 400, { error: `bad request body: ${err.message}` });
+    }
+
+    const { system, messages, model } = body || {};
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return sendJson(res, 400, { error: 'messages must be a non-empty array' });
+    }
+
+    const started = Date.now();
+    try {
+      const text = await runClaude({ system, prompt: renderPrompt(messages), model });
+      const ms = Date.now() - started;
+      console.log(`[claude-shim] /chat ok in ${ms}ms (${text.length} chars)`);
+      return sendJson(res, 200, { text });
+    } catch (err) {
+      const ms = Date.now() - started;
+      console.error(`[claude-shim] /chat FAILED in ${ms}ms: ${err.message}`);
+      return sendJson(res, 502, { error: err.message });
+    }
+  }
+
+  return sendJson(res, 404, { error: 'not found' });
+});
+
+server.listen(PORT, () => {
+  console.log(`[claude-shim] listening on :${PORT} (default model: ${DEFAULT_MODEL})`);
+});

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -323,6 +323,43 @@ deploy_notify() {
     echo "  Health:   curl https://notify.imagineering.cc/health"
 }
 
+deploy_claude_shim() {
+    echo "Deploying claude-shim (Max-plan inference endpoint)..."
+
+    local SHIM_SECRETS="$REPO_ROOT/claude-shim/secrets.yaml"
+    if [ ! -f "$SHIM_SECRETS" ]; then
+        echo "ERROR: claude-shim/secrets.yaml not found"
+        echo "Create from claude-shim/secrets.yaml.example and encrypt with: sops -e -i claude-shim/secrets.yaml"
+        return 1
+    fi
+
+    # Decrypt once, then route every value through dotenv_quote so a secret with
+    # dotenv-significant bytes survives docker compose's dotenv parser intact
+    # (see deploy_outline for rationale).
+    echo "Generating .env from encrypted secrets..."
+    local SHIM_PLAINTEXT
+    SHIM_PLAINTEXT=$(sops -d "$SHIM_SECRETS")
+    shim_field() { echo "$SHIM_PLAINTEXT" | yq -r "$1 // \"\""; }
+    {
+        printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "$(dotenv_quote "$(shim_field '.claude_code_oauth_token')")"
+    } > "$REPO_ROOT/claude-shim/.env"
+
+    ssh "$REMOTE" "mkdir -p ~/apps/claude-shim"
+    rsync -avz --delete --exclude 'secrets.yaml' "$REPO_ROOT/claude-shim/" "$REMOTE":~/apps/claude-shim/
+
+    rm -f "$REPO_ROOT/claude-shim/.env"
+
+    # Ensure shared network exists (consumers reach it as http://claude-shim:8088).
+    ssh "$REMOTE" "docker network inspect imagineering >/dev/null 2>&1 || docker network create imagineering"
+
+    # Builds from its Dockerfile (not a published image), so build+up, not pull.
+    ssh "$REMOTE" "cd ~/apps/claude-shim && docker compose build && docker compose up -d"
+
+    echo "claude-shim deployed!"
+    echo "  Network URL (consumers): http://claude-shim:8088/chat"
+    echo "  Health (host-local):     curl 127.0.0.1:8088/health"
+}
+
 deploy_familiars_server() {
     echo "Deploying familiars-server..."
 
@@ -1369,6 +1406,9 @@ case $SERVICE in
         ;;
     notify)
         deploy_notify
+        ;;
+    claude-shim|shim)
+        deploy_claude_shim
         ;;
     familiars-server|familiars)
         deploy_familiars_server


### PR DESCRIPTION
## What

Moves **claude-shim** (the Max-plan inference HTTP shim — `claude -p` behind `POST /chat`, used by the embodied-dreamfinder voice brain and the in-prod self-healer) from "source only on the OCI box, rsync-deployed, never checked in" into **house convention**: a sibling service dir alongside `notify/`, `embodied-dreamfinder/`, etc., with its secret SOPS-encrypted in-repo and a wired `deploy-to.sh` target.

This was task #48. It supersedes my earlier (off-convention) standalone repo `imagineering-cc/claude-shim`.

## Changes

- **`claude-shim/`** new dir: `Dockerfile`, `docker-compose.yml`, `src/{server.js,package.json}`, `README.md`, `secrets.yaml.example`, and the **sops-encrypted `secrets.yaml`** (`claude_code_oauth_token`).
- **`docker-compose.yml`** reads the token via an `environment:` block fed by a deploy-generated `.env` (gitignored), matching `notify/` — **no `env_file: .env`**.
- **`scripts/deploy-to.sh`**: new `deploy_claude_shim` (modeled exactly on `deploy_notify`) + `claude-shim|shim` case. Flow: `sops -d secrets.yaml` → `dotenv_quote` each field → write local `.env` → `rsync --delete --exclude secrets.yaml` → ensure `imagineering` network → `docker compose build && up -d`. **Builds from the Dockerfile** (not a published image) so `build`, not `pull`.
- **`.sops.yaml`**: added `claude-shim` to the `creation_rules` `path_regex` (same age recipient as every other service).

## Secret handling

- Plaintext OAuth token is **never committed** — only the age-encrypted `ENC[AES256_GCM,...]` ciphertext is in git (recipient `age1mkelwyppmll44…`, same as `notify/`). Round-trip-verified: decrypts back to the live `sk-ant-oat01-…` token.
- Generated `.env` is covered by the root `**/.env` gitignore rule.
- The token was fetched from the box and piped straight into sops via `yq strenv` — never in argv, never echoed, never on a remote command line.
- Secret scans clean: no `.env` staged; no plaintext `sk-ant` anywhere; staged diff has only `ENC[...]` forms.

## Review notes (please check carefully — touches secret + deploy script)

- `deploy_claude_shim` vs `deploy_notify` parity — the only deltas are the single field (`claude_code_oauth_token`), the `docker network` ensure-line (consumers reach it as `http://claude-shim:8088`), and build-not-pull. `bash -n` passes.
- `.sops.yaml` regex change is additive (one alternation arm).

## Follow-up

The standalone **`imagineering-cc/claude-shim`** repo will be **deleted once this is merged** (it's the only other copy until this lands, so not deleted yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)