### PR TITLE
feat(self-healer): green-auto OS-isolation cage + escape-probe gate

### DIFF
--- a/self-healer/cage/Dockerfile.probe
+++ b/self-healer/cage/Dockerfile.probe
@@ -3,12 +3,13 @@
 # enforced by the `docker run` flags (cage.mjs), which are largely image-
 # independent, so this image proves the cage holds for the real agent image too.
 #
-# It deliberately ships a non-root user and NO sudo. If an escape passes here it
-# would pass for the agent; if it fails here the cage holds.
+# DELIBERATELY ROOT (no USER line) — cage-match PR #111, Carnot. If the probe
+# image set its own non-root USER, the "non-root" escape test would prove the
+# IMAGE, not the cage. By shipping a root image we remove the favorable initial
+# condition: the cage's `--user` flag is the ONLY thing that can make `id -u`
+# non-zero, so the test falsifies the cage, not the Dockerfile. The probe also
+# asserts the bare image is uid 0 (a control) to keep this guarantee honest.
 FROM alpine:3.20
 RUN apk add --no-cache curl coreutils
-# A non-root user with a real shell so the fs/priv probes can run as the agent would.
-RUN adduser -D -s /bin/sh agent
-USER agent
 WORKDIR /work
 CMD ["sh"]

--- a/self-healer/cage/Dockerfile.probe
+++ b/self-healer/cage/Dockerfile.probe
@@ -1,0 +1,14 @@
+# probe image — a representative stand-in for the codegen agent, carrying just
+# enough tools to ATTEMPT each escape in cage/README.md. The confinement is
+# enforced by the `docker run` flags (cage.mjs), which are largely image-
+# independent, so this image proves the cage holds for the real agent image too.
+#
+# It deliberately ships a non-root user and NO sudo. If an escape passes here it
+# would pass for the agent; if it fails here the cage holds.
+FROM alpine:3.20
+RUN apk add --no-cache curl coreutils
+# A non-root user with a real shell so the fs/priv probes can run as the agent would.
+RUN adduser -D -s /bin/sh agent
+USER agent
+WORKDIR /work
+CMD ["sh"]

--- a/self-healer/cage/Dockerfile.proxy
+++ b/self-healer/cage/Dockerfile.proxy
@@ -1,0 +1,10 @@
+# egress-proxy image — the cage's hostname-allowlist gate. Tiny on purpose: the
+# only logic is the CONNECT allowlist in egress-proxy.mjs.
+FROM node:20-slim
+# node:20-slim already ships a non-root `node` user (uid 1000); reuse it rather
+# than adding one (Debian's base also reserves a system `proxy` user, uid 13).
+WORKDIR /app
+COPY egress-proxy.mjs ./
+USER node
+EXPOSE 3128
+CMD ["node", "egress-proxy.mjs"]

--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -1,0 +1,102 @@
+# green-auto cage — the boundary contract
+
+> **Status: boundary spec + escape probe.** The cage is the *prerequisite* to
+> turning on green-auto. green-auto itself (the codegen agent that writes a fix →
+> opens a PR → cage-match → auto-merge) is **not enabled** until the escape probe
+> below passes on the production box. *Build the cage before you spawn the monster.*
+
+## What is being caged, and why
+
+green-auto's worker is a **headless `claude -p` codegen agent with tool
+permissions** (it edits files, runs `git`, runs `gh`). It is spawned from a
+*log diagnosis*, so its entire input is **attacker-influenceable**:
+
+- a malicious container log line → became the self-healer's `diagnosis`/`evidence`
+  (the `green-draft` issue body is built from exactly these fields);
+- the target repo's own source — which the agent reads to write its patch — can
+  carry prompt-injection aimed at the agent.
+
+So the threat is a **prompt-injection-into-codegen** surface with **write + network
+capability**. The mechanism (the model, the prompt, the tool-loop) is *not* the
+boundary. The boundary is: *even if the agent is fully subverted mid-run, what can
+it touch?* The cage's job is to make that answer "only its own throwaway clone and
+two allowlisted hosts" — and to **prove it by attempting the escape**, never by
+reading a config.
+
+## Mechanism (box-grounded — see ADR below)
+
+An ephemeral Docker container:
+
+| Property | Flag | Boundary it enforces |
+|---|---|---|
+| non-root | image `USER`, `--user` | no host-uid authority |
+| no new privileges | `--security-opt=no-new-privileges` | setuid/sudo can't escalate |
+| drop all caps | `--cap-drop=ALL` | no raw sockets, mount, ptrace, … |
+| read-only rootfs | `--read-only` | host fs (in-image) immutable |
+| only the clone is writable | one named volume / tmpfs at the workdir | writes can't leave the workdir |
+| no docker socket | (never mounted) | can't control the daemon / sibling containers |
+| ephemeral | `--rm` + fresh volume per run | nothing persists across runs |
+| pid / mem caps | `--pids-limit`, `--memory` | a fork/alloc bomb can't take the box |
+| **egress denied** | `--network <internal>` | **kernel-level: no direct off-box route, no external DNS** |
+| **egress allowlisted** | `HTTPS_PROXY → egress-proxy` | the proxy CONNECTs only to the named hosts |
+
+Egress is **layered**: the internal network denies *all* direct egress (verified:
+`curl https://example.com` → "Could not resolve host"); the only reachable name on
+that network is the **egress-proxy**, which forwards CONNECT **only** to an explicit
+host allowlist. A denylist is a sieve; this is allow-by-exact-host.
+
+## The contract — what the escape probe asserts
+
+Run `cage/escape-probe.sh` **on the production box**. It spawns the real cage around
+each case below. The probe is the gate; a green ruleset grep is **not**.
+
+### MUST FAIL (the escapes — each asserts non-success)
+
+| id | attempt | expected |
+|---|---|---|
+| `egress-forbidden` | `curl https://example.com` (a non-allowlisted host) | blocked (DNS/connit fails) |
+| `egress-metadata` | `curl http://169.254.169.254/…` (cloud metadata) | blocked |
+| `egress-direct-ip` | `curl https://140.82.x.x` (allowlisted host's IP, *bypassing the proxy*) | blocked (only the proxy has egress) |
+| `fs-host-secret` | read the OAuth token / `self-healer.env` / `/etc/shadow` / `~/.ssh` | not present (never mounted) |
+| `fs-host-write` | write outside the workdir (`/`, `/etc`, another path) | read-only → EROFS |
+| `priv-esc` | `sudo`, a setuid binary, raise a capability | denied (no-new-privs, cap-drop, non-root) |
+| `docker-escape` | reach `/var/run/docker.sock` | not present |
+
+### MUST SUCCEED (or the cage is uselessly tight — each asserts success)
+
+| id | attempt | expected |
+|---|---|---|
+| `allow-inference` | reach the inference brain **through the proxy** | 2xx/expected |
+| `allow-github` | reach `api.github.com` **through the proxy** | 2xx |
+| `workdir-rw` | write+read a file in the clone workdir | ok |
+
+A cage that fails an escape-FAIL case is **broken open** (the dangerous direction).
+A cage that fails a MUST-SUCCEED case is **broken shut** (green-auto can't work, but
+it's safe) — fix forward, never relax an escape gate to make a success case pass.
+
+## Credential scope (boundary, partly outside the OS cage)
+
+The GitHub token handed to the agent MUST be scoped to the **one** target repo
+(fine-grained PAT / installation token), so a fully-subverted agent that *does* open
+a malicious PR still cannot reach another repo. The OS cage bounds *reachability*;
+the token scope bounds *authority*. Both are required. Tracked separately from this
+probe.
+
+## ADR — why Docker, not bwrap/systemd (deviates from the original plan)
+
+The original plan named *bwrap sandbox user + systemd confinement + egress filter*.
+Verified on the box (`149.118.69.221`, Ubuntu 24.04 aarch64):
+
+- **bwrap is absent** (so is firejail). It would need an `apt install` (host
+  mutation) and still **can't allowlist egress** — only all-or-nothing
+  `--unshare-net`; the agent needs *some* network (inference + GitHub).
+- **systemd's `IPAddressDeny`/`DynamicUser`** (the egress filter + sandbox uid)
+  require the **system** manager = **root**. The healer cron runs as **`nick`
+  (non-root)**; `systemd-run --user` does *not* support those properties.
+- **Docker is already the box's delegated-confinement primitive** — `nick` is in
+  the `docker` group and the shim, claudius, and DF are all caged this way. It
+  delivers every property in the table above with **no new sudo and no new
+  package**, and matches the existing claude-shim cage precedent.
+
+Net: Docker is the production-substrate-correct mechanism here. The egress filter
+that bwrap/systemd would have provided is delivered by `--internal` + the proxy.

--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -29,16 +29,27 @@ An ephemeral Docker container:
 
 | Property | Flag | Boundary it enforces |
 |---|---|---|
-| non-root | image `USER`, `--user` | no host-uid authority |
+| non-root | **`--user 1000:1000` (forced by the cage, NOT the image)** | no host-uid authority, regardless of image hygiene |
 | no new privileges | `--security-opt=no-new-privileges` | setuid/sudo can't escalate |
 | drop all caps | `--cap-drop=ALL` | no raw sockets, mount, ptrace, … |
 | read-only rootfs | `--read-only` | host fs (in-image) immutable |
-| only the clone is writable | one named volume / tmpfs at the workdir | writes can't leave the workdir |
+| only the clone is writable | a single **rw bind-mount of the fresh host clone** at `/work` (+ a `noexec,nosuid` `/tmp` tmpfs) | writes can't leave the workdir |
 | no docker socket | (never mounted) | can't control the daemon / sibling containers |
-| ephemeral | `--rm` + fresh volume per run | nothing persists across runs |
-| pid / mem caps | `--pids-limit`, `--memory` | a fork/alloc bomb can't take the box |
-| **egress denied** | `--network <internal>` | **kernel-level: no direct off-box route, no external DNS** |
-| **egress allowlisted** | `HTTPS_PROXY → egress-proxy` | the proxy CONNECTs only to the named hosts |
+| ephemeral | `--rm` + a fresh clone dir per run | nothing persists across runs |
+| pid / mem caps | `--pids-limit`, `--memory`, `--cpus` | a fork/alloc bomb can't take the box |
+| **egress denied** | `--network <internal>` — **verified `Internal=true` at spawn** (`run-cage.mjs` refuses a non-internal net) | **kernel-level: no direct off-box route, no external DNS** |
+| **egress allowlisted** | `HTTPS_PROXY → egress-proxy` | the proxy CONNECTs only to the named hosts, and only to **public** resolved IPs (SSRF guard) |
+
+`/work` is a **bind-mount of a fresh single-repo clone on the host**, chowned to the
+cage uid by the orchestrator (the host user is uid 1002, the cage is 1000). It is
+the only writable reservoir connected to the host. The cage prevents *host escape*;
+it does **not** stop the agent executing the (malicious) code it generates *inside*
+that clone — that's the codegen threat, bounded by the repo-scoped token + the
+cage-match on the resulting PR, not by this OS boundary.
+
+Seccomp/AppArmor: the cage relies on Docker's **default** seccomp + AppArmor
+profiles (not loosened, not custom-tightened). Stated explicitly so it's a
+conscious reliance, not an unexamined default.
 
 Egress is **layered**: the internal network denies *all* direct egress (verified:
 `curl https://example.com` → "Could not resolve host"); the only reachable name on
@@ -54,13 +65,19 @@ each case below. The probe is the gate; a green ruleset grep is **not**.
 
 | id | attempt | expected |
 |---|---|---|
-| `egress-forbidden` | `curl https://example.com` (a non-allowlisted host) | blocked (DNS/connit fails) |
-| `egress-metadata` | `curl http://169.254.169.254/…` (cloud metadata) | blocked |
-| `egress-direct-ip` | `curl https://140.82.x.x` (allowlisted host's IP, *bypassing the proxy*) | blocked (only the proxy has egress) |
+| `egress-forbidden` | `curl https://example.com` (a non-allowlisted host) | blocked (proxy denies CONNECT) |
+| `egress-metadata` | `curl --noproxy http://169.254.169.254/…` (cloud metadata, direct) | blocked (link-local unrouted) |
+| `egress-direct-ip` | `curl --noproxy https://1.1.1.1` (public IP, *bypassing the proxy*) | blocked (only the proxy has egress) |
+| `egress-ipv6` | `curl --noproxy https://[2606:4700:4700::1111]` (direct IPv6) | blocked (no v6 escape) |
+| `egress-gateway` | `curl --noproxy http://172.17.0.1` (docker bridge gateway) | blocked (internal net has no gateway) |
+| `egress-host-internal` | `curl --noproxy http://host.docker.internal` | blocked (never `--add-host`ed) |
 | `fs-host-secret` | read the OAuth token / `self-healer.env` / `/etc/shadow` / `~/.ssh` | not present (never mounted) |
 | `fs-host-write` | write outside the workdir (`/`, `/etc`, another path) | read-only → EROFS |
-| `priv-esc` | `sudo`, a setuid binary, raise a capability | denied (no-new-privs, cap-drop, non-root) |
+| `priv-esc` | a **root** image, then `sudo` / `id -u` | cage's `--user` forces non-root despite a root image |
 | `docker-escape` | reach `/var/run/docker.sock` | not present |
+| `self-defense` | run the cage on a non-`--internal` network | `run-cage.mjs` refuses to spawn (exit 3) |
+
+The `priv-esc` case deliberately uses a **root** probe image (`Dockerfile.probe` sets no `USER`): if the image were non-root, the test would prove the image, not the cage. Starting from root, only the cage's `--user` can make `id -u` non-zero.
 
 ### MUST SUCCEED (or the cage is uselessly tight — each asserts success)
 
@@ -73,6 +90,23 @@ each case below. The probe is the gate; a green ruleset grep is **not**.
 A cage that fails an escape-FAIL case is **broken open** (the dangerous direction).
 A cage that fails a MUST-SUCCEED case is **broken shut** (green-auto can't work, but
 it's safe) — fix forward, never relax an escape gate to make a success case pass.
+
+## Known residuals (named, not hidden)
+
+- **Writable `HOME` for the real agent.** `--read-only` + only `/work`/`/tmp`
+  writable means a real `claude -p` (writes `~/.claude`) and `git` (writes
+  `$HOME`) will fail until the orchestrator gives the agent a writable HOME
+  (`HOME=/work`, or a small tmpfs). The probe used `alpine sh`, which needs none.
+  Owned by the orchestrator/real-image PR. *Broken-shut, not broken-open.*
+- **Same-subnet host bridge IP.** The probe proves the *default* bridge gateway
+  (`172.17.0.1`) and `host.docker.internal` are unreachable, but does not yet
+  probe the internal network's *own* in-subnet gateway IP. Docker binds no host
+  services to an internal bridge by default, so there's nothing there today;
+  flagged as the next probe to add if any host service is ever bound to it.
+- **Inference host in the allowlist.** The allowlist is only as strong as its
+  entries. The inference endpoint added alongside GitHub must not be an open
+  redirect / SSRF-amplifier / surprisingly-CDN-fronted host. The resolved-IP
+  guard blocks *internal* targets but not a *public* open-proxy.
 
 ## Credential scope (boundary, partly outside the OS cage)
 

--- a/self-healer/cage/cage.mjs
+++ b/self-healer/cage/cage.mjs
@@ -20,6 +20,13 @@ export const CONFINEMENT_FLAGS = Object.freeze([
   '--cpus=2',
 ]);
 
+/** Default non-root uid:gid the cage forces. Pinned by the CAGE, not delegated to
+ * the image's USER directive (cage-match PR #111, Maxwell F1 + Carnot HIGH): an
+ * agent image built without a USER line would otherwise run as ROOT in the cage.
+ * Enforcing --user here makes non-root true regardless of image hygiene, and lets
+ * the escape probe prove the CAGE (start from a root image) rather than the image. */
+export const CAGE_UID_GID = '1000:1000';
+
 /**
  * Build the argv to run `cmd …args` inside the cage.
  *
@@ -32,9 +39,10 @@ export const CONFINEMENT_FLAGS = Object.freeze([
  * @param {Record<string,string>} [o.env]  extra env (e.g. a repo-scoped GH token). NEVER host secrets.
  * @param {string} o.cmd          the command to run (e.g. "claude" or, in the probe, "sh")
  * @param {string[]} [o.args]     args to cmd
+ * @param {string} [o.userGid]    forced non-root uid:gid (default CAGE_UID_GID); never trusts the image
  * @returns {{bin: string, argv: string[]}}
  */
-export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env = {}, cmd, args = [] }) {
+export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env = {}, cmd, args = [], userGid = CAGE_UID_GID }) {
   if (!image) throw new Error('cage: image required');
   if (!network) throw new Error('cage: internal network required');
   if (!workdirHost) throw new Error('cage: workdirHost required');
@@ -42,6 +50,8 @@ export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env
   if (!cmd) throw new Error('cage: cmd required');
 
   const argv = ['run', ...CONFINEMENT_FLAGS];
+  // Force non-root at the CAGE, never trusting the image's USER (cage-match #111).
+  argv.push('--user', userGid);
   if (name) argv.push('--name', name);
 
   // Egress: deny-all internal network is the backstop; the proxy is the only

--- a/self-healer/cage/cage.mjs
+++ b/self-healer/cage/cage.mjs
@@ -1,0 +1,74 @@
+// cage.mjs — build the `docker run` argv that confines the green-auto codegen
+// agent. PURE (no spawn) so the confinement flags can be asserted in CI without
+// a Docker daemon, exactly like host.mjs/buildHostScriptArgv. The LIVE proof
+// that these flags actually hold is cage/escape-probe.sh on the box — an argv
+// assertion is necessary but NOT the boundary (a green flag list ≠ a held
+// boundary; you must attempt the escape).
+//
+// Every flag here maps to a row in cage/README.md's contract table. If you add a
+// capability to the agent, add the matching escape case to the probe FIRST.
+
+/** Flags that drop the container's authority. Order-independent; kept as a frozen
+ * list so the unit test can assert the SET is present regardless of arrangement. */
+export const CONFINEMENT_FLAGS = Object.freeze([
+  '--rm', // ephemeral: nothing persists across runs
+  '--cap-drop=ALL', // no raw sockets, mount, ptrace, …
+  '--security-opt=no-new-privileges', // setuid/sudo cannot escalate
+  '--read-only', // in-image rootfs immutable; only the workdir bind is writable
+  '--pids-limit=512', // a fork bomb can't take the box
+  '--memory=2g', // an alloc bomb can't take the box
+  '--cpus=2',
+]);
+
+/**
+ * Build the argv to run `cmd …args` inside the cage.
+ *
+ * @param {object} o
+ * @param {string} o.image        the agent image (built from the shim image + tools)
+ * @param {string} o.network      the `--internal` docker network name (NO egress)
+ * @param {string} o.workdirHost  host path of the FRESH single-repo clone, bind-mounted rw at /work
+ * @param {string} o.proxyUrl     e.g. http://cage-egress-proxy:3128 — the ONLY egress path
+ * @param {string} [o.name]       container name (ephemeral)
+ * @param {Record<string,string>} [o.env]  extra env (e.g. a repo-scoped GH token). NEVER host secrets.
+ * @param {string} o.cmd          the command to run (e.g. "claude" or, in the probe, "sh")
+ * @param {string[]} [o.args]     args to cmd
+ * @returns {{bin: string, argv: string[]}}
+ */
+export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env = {}, cmd, args = [] }) {
+  if (!image) throw new Error('cage: image required');
+  if (!network) throw new Error('cage: internal network required');
+  if (!workdirHost) throw new Error('cage: workdirHost required');
+  if (!proxyUrl) throw new Error('cage: proxyUrl required (egress is allowlist-only)');
+  if (!cmd) throw new Error('cage: cmd required');
+
+  const argv = ['run', ...CONFINEMENT_FLAGS];
+  if (name) argv.push('--name', name);
+
+  // Egress: deny-all internal network is the backstop; the proxy is the only
+  // reachable name and the only allowlist gate. Set BOTH upper- and lower-case
+  // proxy vars (curl honors lower, many libs honor upper) and NO_PROXY empty so
+  // nothing is exempted. NO direct route exists regardless, but be explicit.
+  argv.push('--network', network);
+  const proxyEnv = {
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    http_proxy: proxyUrl,
+    https_proxy: proxyUrl,
+    NO_PROXY: '',
+    no_proxy: '',
+  };
+
+  // Only the fresh clone is writable; rootfs is read-only. /tmp is a small
+  // noexec/nosuid tmpfs (tools need scratch space but must not run code from it).
+  argv.push('-v', `${workdirHost}:/work:rw`, '-w', '/work');
+  argv.push('--tmpfs', '/tmp:rw,noexec,nosuid,size=64m');
+
+  // Caller env first, proxy env LAST so a caller can never clobber the egress
+  // routing (a clobbered HTTPS_PROXY would let the agent egress directly).
+  for (const [k, v] of Object.entries({ ...env, ...proxyEnv })) {
+    argv.push('-e', `${k}=${v}`);
+  }
+
+  argv.push(image, cmd, ...args);
+  return { bin: 'docker', argv };
+}

--- a/self-healer/cage/egress-proxy.mjs
+++ b/self-healer/cage/egress-proxy.mjs
@@ -1,0 +1,103 @@
+// egress-proxy — the cage's single hostname-allowlist gate.
+//
+// The caged codegen agent runs on an `--internal` Docker network with NO direct
+// egress and NO external DNS. The ONLY name it can resolve+reach on that network
+// is this proxy. So every byte the agent sends to the outside world passes this
+// one CONNECT check. The allowlist below IS the egress security boundary — keep
+// it a literal, glanceable set, never a regex or a wildcard.
+//
+// Design choices that ARE the security property:
+//   - CONNECT-only. We tunnel TLS (we never see plaintext, never MITM). Plain
+//     HTTP proxy requests (GET http://…) are REFUSED — there is no plaintext
+//     egress path to bypass the allowlist with.
+//   - Allowlist by EXACT host (optionally a leading-dot suffix for a known
+//     subdomain family). No substring/regex matching — `evil-github.com` must
+//     not match `github.com`.
+//   - Port allowlist (443 only by default). No exfil over an arbitrary port.
+//   - Fail CLOSED: anything not explicitly allowed → 403, connection closed.
+//
+// The proxy itself sits on a network WITH egress (so it can resolve + reach the
+// allowlisted hosts) AND on the internal network (so the agent can reach it).
+
+import net from 'node:net';
+import http from 'node:http';
+
+const PORT = Number.parseInt(process.env.CAGE_PROXY_PORT ?? '3128', 10);
+
+/** Allowed CONNECT ports. TLS only by default — no plaintext, no odd ports. */
+const ALLOW_PORTS = new Set(
+  (process.env.CAGE_ALLOW_PORTS ?? '443').split(',').map((p) => p.trim()).filter(Boolean),
+);
+
+/**
+ * Exact-host allowlist. An entry beginning with "." is a suffix match for that
+ * subdomain family (".github.com" allows api.github.com AND codeload.github.com
+ * but NOT evilgithub.com). Everything else must match the host EXACTLY.
+ *
+ * Supplied at deploy via CAGE_ALLOW_HOSTS (comma-separated). No default set here
+ * on purpose: an unconfigured proxy allows NOTHING (fail closed), so a misdeploy
+ * can't silently open egress.
+ */
+const ALLOW_HOSTS = (process.env.CAGE_ALLOW_HOSTS ?? '')
+  .split(',')
+  .map((h) => h.trim().toLowerCase())
+  .filter(Boolean);
+
+/** True iff `host` is on the allowlist by exact match or dotted-suffix family. */
+export function hostAllowed(host, allow = ALLOW_HOSTS) {
+  const h = String(host).toLowerCase();
+  for (const entry of allow) {
+    if (entry.startsWith('.')) {
+      // ".github.com" allows "github.com" and "*.github.com", nothing else.
+      if (h === entry.slice(1) || h.endsWith(entry)) return true;
+    } else if (h === entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function log(...a) { process.stderr.write(`[egress-proxy] ${a.join(' ')}\n`); }
+
+const server = http.createServer((req, res) => {
+  // Any non-CONNECT request is a plaintext proxy attempt — refuse it. There is
+  // no plaintext egress path; the agent must use HTTPS through CONNECT.
+  res.writeHead(403, { 'content-type': 'text/plain' });
+  res.end('egress-proxy: plaintext proxying disabled; CONNECT (https) only\n');
+  log('REFUSED plaintext', req.method, req.url ?? '');
+});
+
+server.on('connect', (req, clientSocket, head) => {
+  // req.url for a CONNECT is "host:port".
+  const [host, portStr] = String(req.url).split(':');
+  const port = portStr ?? '443';
+
+  if (!hostAllowed(host) || !ALLOW_PORTS.has(port)) {
+    log('DENY', `${host}:${port}`);
+    clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\negress-proxy: host not on allowlist\r\n');
+    clientSocket.destroy();
+    return;
+  }
+
+  // Allowed: open the upstream tunnel and splice the two sockets together. We
+  // never inspect or alter the tunneled bytes (it's TLS) — only the destination.
+  const upstream = net.connect(Number(port), host, () => {
+    log('ALLOW', `${host}:${port}`);
+    clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    if (head && head.length) upstream.write(head);
+    upstream.pipe(clientSocket);
+    clientSocket.pipe(upstream);
+  });
+  const kill = (why) => { log('tunnel closed', `${host}:${port}`, why ?? ''); upstream.destroy(); clientSocket.destroy(); };
+  upstream.on('error', (e) => kill(`upstream:${e.code || e.message}`));
+  clientSocket.on('error', (e) => kill(`client:${e.code || e.message}`));
+});
+
+// Run only when invoked directly (not when imported by the unit test).
+if (process.argv[1] && process.argv[1].endsWith('egress-proxy.mjs')) {
+  server.listen(PORT, () => {
+    log(`listening on :${PORT}`);
+    log(`allow hosts: ${ALLOW_HOSTS.length ? ALLOW_HOSTS.join(', ') : '(none — fail closed)'}`);
+    log(`allow ports: ${[...ALLOW_PORTS].join(', ')}`);
+  });
+}

--- a/self-healer/cage/egress-proxy.mjs
+++ b/self-healer/cage/egress-proxy.mjs
@@ -21,8 +21,17 @@
 
 import net from 'node:net';
 import http from 'node:http';
+import dns from 'node:dns/promises';
 
 const PORT = Number.parseInt(process.env.CAGE_PROXY_PORT ?? '3128', 10);
+
+/** Max concurrent CONNECT tunnels + per-socket idle timeout. A subverted agent
+ * must not be able to exhaust the proxy's fds/memory by holding open tunnels
+ * (cage-match PR #111, Maxwell F4 + Carnot). The agent's own container has pid/
+ * mem caps; the proxy is a separate process, so it caps itself here. */
+const MAX_TUNNELS = Number.parseInt(process.env.CAGE_PROXY_MAX_CONN ?? '64', 10);
+const IDLE_MS = Number.parseInt(process.env.CAGE_PROXY_IDLE_MS ?? '30000', 10);
+let activeTunnels = 0;
 
 /** Allowed CONNECT ports. TLS only by default — no plaintext, no odd ports. */
 const ALLOW_PORTS = new Set(
@@ -57,6 +66,68 @@ export function hostAllowed(host, allow = ALLOW_HOSTS) {
   return false;
 }
 
+/**
+ * Strictly parse a CONNECT authority ("host:port") into {host, port}, or null if
+ * it isn't exactly one host and one decimal port (cage-match PR #111, Carnot).
+ * Handles a bracketed IPv6 literal ("[2606:::]:443"). Rejects empty host, missing
+ * or non-decimal or out-of-range port, and any extra structure. A loose parse is
+ * a loose door latch on the one gate that matters.
+ * @param {string} url
+ * @returns {{host: string, port: number}|null}
+ */
+export function parseConnectAuthority(url) {
+  const s = String(url);
+  let host; let portStr;
+  if (s.startsWith('[')) {
+    const close = s.indexOf(']');
+    if (close === -1 || s[close + 1] !== ':') return null;
+    host = s.slice(1, close);
+    portStr = s.slice(close + 2);
+  } else {
+    const i = s.lastIndexOf(':');
+    if (i === -1) return null; // a port is mandatory for CONNECT
+    host = s.slice(0, i);
+    portStr = s.slice(i + 1);
+    if (host.includes(':')) return null; // bare (unbracketed) IPv6 / multiple colons → reject
+  }
+  if (!host || !/^[0-9]+$/.test(portStr)) return null;
+  const port = Number(portStr);
+  if (port < 1 || port > 65535) return null;
+  return { host, port };
+}
+
+/**
+ * True if `ip` is a non-public address the proxy must never connect to, even for
+ * an allowlisted hostname (cage-match PR #111, Maxwell F2 SSRF). Covers loopback,
+ * link-local (incl. cloud metadata 169.254/16 and IPv6 fe80::/10), RFC1918
+ * private, IPv6 ULA (fc00::/7), unspecified, and IPv4-mapped IPv6. Without this,
+ * an allowlisted host that resolves to an internal IP would let the agent reach
+ * internal targets THROUGH the proxy (the one process holding real egress).
+ * @param {string} ip  a resolved numeric address
+ */
+export function isForbiddenAddress(ip) {
+  const a = String(ip).toLowerCase();
+  // Normalize an IPv4-mapped IPv6 (::ffff:10.0.0.1) to its IPv4 tail.
+  const mapped = a.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  const v4 = mapped ? mapped[1] : (/^\d+\.\d+\.\d+\.\d+$/.test(a) ? a : null);
+  if (v4) {
+    const [o0, o1] = v4.split('.').map(Number);
+    if (o0 === 127) return true; // loopback
+    if (o0 === 10) return true; // RFC1918
+    if (o0 === 172 && o1 >= 16 && o1 <= 31) return true; // RFC1918
+    if (o0 === 192 && o1 === 168) return true; // RFC1918
+    if (o0 === 169 && o1 === 254) return true; // link-local incl. cloud metadata
+    if (o0 === 100 && o1 >= 64 && o1 <= 127) return true; // CGNAT 100.64/10
+    if (o0 === 0) return true; // unspecified / "this network"
+    return false;
+  }
+  // IPv6
+  if (a === '::' || a === '::1') return true; // unspecified / loopback
+  if (a.startsWith('fe80:')) return true; // link-local
+  if (a.startsWith('fc') || a.startsWith('fd')) return true; // ULA fc00::/7
+  return false;
+}
+
 function log(...a) { process.stderr.write(`[egress-proxy] ${a.join(' ')}\n`); }
 
 const server = http.createServer((req, res) => {
@@ -67,30 +138,62 @@ const server = http.createServer((req, res) => {
   log('REFUSED plaintext', req.method, req.url ?? '');
 });
 
-server.on('connect', (req, clientSocket, head) => {
-  // req.url for a CONNECT is "host:port".
-  const [host, portStr] = String(req.url).split(':');
-  const port = portStr ?? '443';
+function deny(clientSocket, why, detail) {
+  log('DENY', why, detail ?? '');
+  clientSocket.write(`HTTP/1.1 403 Forbidden\r\n\r\negress-proxy: ${why}\r\n`);
+  clientSocket.destroy();
+}
 
-  if (!hostAllowed(host) || !ALLOW_PORTS.has(port)) {
-    log('DENY', `${host}:${port}`);
-    clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\negress-proxy: host not on allowlist\r\n');
-    clientSocket.destroy();
+server.on('connect', async (req, clientSocket, head) => {
+  const parsed = parseConnectAuthority(req.url);
+  if (!parsed) { deny(clientSocket, 'malformed CONNECT authority', String(req.url)); return; }
+  const { host, port } = parsed;
+
+  if (!hostAllowed(host) || !ALLOW_PORTS.has(String(port))) {
+    deny(clientSocket, 'host/port not on allowlist', `${host}:${port}`);
     return;
   }
 
-  // Allowed: open the upstream tunnel and splice the two sockets together. We
-  // never inspect or alter the tunneled bytes (it's TLS) — only the destination.
-  const upstream = net.connect(Number(port), host, () => {
-    log('ALLOW', `${host}:${port}`);
+  if (activeTunnels >= MAX_TUNNELS) {
+    deny(clientSocket, 'too many concurrent tunnels', `${activeTunnels}/${MAX_TUNNELS}`);
+    return;
+  }
+
+  // SSRF guard: resolve the allowlisted name and refuse if it maps to a non-public
+  // address. Connect to the VETTED IP (not the name) so there's no resolve→check→
+  // connect TOCTOU where a re-resolution could differ.
+  let addr;
+  try {
+    const got = await dns.lookup(host, { all: true });
+    addr = got.find((g) => !isForbiddenAddress(g.address));
+    if (!addr) { deny(clientSocket, 'host resolves only to non-public address', host); return; }
+  } catch (e) {
+    deny(clientSocket, 'dns resolution failed', `${host}: ${e.code || e.message}`);
+    return;
+  }
+
+  activeTunnels += 1;
+  let closed = false;
+  const upstream = net.connect(port, addr.address, () => {
+    log('ALLOW', `${host}:${port}`, `→ ${addr.address}`, `(${activeTunnels}/${MAX_TUNNELS})`);
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
     if (head && head.length) upstream.write(head);
     upstream.pipe(clientSocket);
     clientSocket.pipe(upstream);
   });
-  const kill = (why) => { log('tunnel closed', `${host}:${port}`, why ?? ''); upstream.destroy(); clientSocket.destroy(); };
+  const kill = (why) => {
+    if (closed) return;
+    closed = true; activeTunnels -= 1;
+    log('tunnel closed', `${host}:${port}`, why ?? '');
+    upstream.destroy(); clientSocket.destroy();
+  };
+  // Idle timeout: a held-open-but-silent tunnel is reaped so it can't pin an fd.
+  upstream.setTimeout(IDLE_MS, () => kill('upstream idle timeout'));
+  clientSocket.setTimeout(IDLE_MS, () => kill('client idle timeout'));
   upstream.on('error', (e) => kill(`upstream:${e.code || e.message}`));
   clientSocket.on('error', (e) => kill(`client:${e.code || e.message}`));
+  upstream.on('close', () => kill('upstream close'));
+  clientSocket.on('close', () => kill('client close'));
 });
 
 // Run only when invoked directly (not when imported by the unit test).

--- a/self-healer/cage/egress-proxy.mjs
+++ b/self-healer/cage/egress-proxy.mjs
@@ -97,35 +97,49 @@ export function parseConnectAuthority(url) {
 }
 
 /**
- * True if `ip` is a non-public address the proxy must never connect to, even for
- * an allowlisted hostname (cage-match PR #111, Maxwell F2 SSRF). Covers loopback,
- * link-local (incl. cloud metadata 169.254/16 and IPv6 fe80::/10), RFC1918
- * private, IPv6 ULA (fc00::/7), unspecified, and IPv4-mapped IPv6. Without this,
- * an allowlisted host that resolves to an internal IP would let the agent reach
- * internal targets THROUGH the proxy (the one process holding real egress).
+ * True if `ip` is NOT a globally-routable public address the proxy may connect to
+ * (cage-match PR #111, Maxwell F2 SSRF + Carnot re-review). This is an ALLOWLIST,
+ * not a denylist-of-bad-ranges — a hand-rolled denylist is a sieve (the first cut
+ * missed fe80::/10 beyond fe80:, plus v6 multicast and v4 reserved/multicast).
+ *
+ *  - IPv6: forbidden UNLESS it's in global unicast 2000::/3 (first nibble 2 or 3).
+ *    That single rule rejects loopback (::1), unspecified (::), link-local
+ *    (fe80::/10 — ALL of fe80–febf), ULA (fc00::/7), site-local (fec0::/10),
+ *    multicast (ff00::/8), and everything else non-global in one shot.
+ *  - IPv4: forbidden if in any special-use block (loopback, RFC1918, link-local
+ *    incl. cloud metadata, CGNAT, this-network, multicast 224/4, reserved 240/4,
+ *    benchmarking 198.18/15, the TEST-NET/doc/protocol 192.0.0/24 family).
+ *  - IPv4-mapped IPv6 (::ffff:a.b.c.d) is normalized to its IPv4 tail first.
+ *
+ * Without this, an allowlisted host that resolves to an internal IP would let the
+ * agent reach internal targets THROUGH the proxy (the one process with egress).
  * @param {string} ip  a resolved numeric address
  */
 export function isForbiddenAddress(ip) {
   const a = String(ip).toLowerCase();
-  // Normalize an IPv4-mapped IPv6 (::ffff:10.0.0.1) to its IPv4 tail.
   const mapped = a.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
   const v4 = mapped ? mapped[1] : (/^\d+\.\d+\.\d+\.\d+$/.test(a) ? a : null);
   if (v4) {
     const [o0, o1] = v4.split('.').map(Number);
-    if (o0 === 127) return true; // loopback
+    if (o0 === 0) return true; // 0.0.0.0/8 "this network" / unspecified
     if (o0 === 10) return true; // RFC1918
-    if (o0 === 172 && o1 >= 16 && o1 <= 31) return true; // RFC1918
-    if (o0 === 192 && o1 === 168) return true; // RFC1918
-    if (o0 === 169 && o1 === 254) return true; // link-local incl. cloud metadata
+    if (o0 === 127) return true; // loopback
     if (o0 === 100 && o1 >= 64 && o1 <= 127) return true; // CGNAT 100.64/10
-    if (o0 === 0) return true; // unspecified / "this network"
+    if (o0 === 169 && o1 === 254) return true; // link-local incl. cloud metadata
+    if (o0 === 172 && o1 >= 16 && o1 <= 31) return true; // RFC1918
+    if (o0 === 192 && o1 === 0) return true; // 192.0.0/24 protocol assignments + 192.0.2/24 TEST-NET-1
+    if (o0 === 192 && o1 === 168) return true; // RFC1918
+    if (o0 === 198 && (o1 === 18 || o1 === 19)) return true; // 198.18/15 benchmarking
+    if (o0 === 198 && o1 === 51) return true; // 198.51.100/24 TEST-NET-2
+    if (o0 === 203 && o1 === 0) return true; // 203.0.113/24 TEST-NET-3
+    if (o0 >= 224) return true; // 224/4 multicast + 240/4 reserved + 255.255.255.255
     return false;
   }
-  // IPv6
-  if (a === '::' || a === '::1') return true; // unspecified / loopback
-  if (a.startsWith('fe80:')) return true; // link-local
-  if (a.startsWith('fc') || a.startsWith('fd')) return true; // ULA fc00::/7
-  return false;
+  // IPv6: allow ONLY global unicast 2000::/3. The first hextet of a global-unicast
+  // address is 2000–3fff, i.e. its first hex nibble is 2 or 3. Everything else is
+  // non-global (link-local/ULA/multicast/loopback/unspecified) → forbidden.
+  const first = a.replace(/^\[/, '')[0];
+  return !(first === '2' || first === '3');
 }
 
 function log(...a) { process.stderr.write(`[egress-proxy] ${a.join(' ')}\n`); }
@@ -159,14 +173,18 @@ server.on('connect', async (req, clientSocket, head) => {
     return;
   }
 
-  // SSRF guard: resolve the allowlisted name and refuse if it maps to a non-public
-  // address. Connect to the VETTED IP (not the name) so there's no resolve→check→
-  // connect TOCTOU where a re-resolution could differ.
+  // SSRF guard: resolve the allowlisted name and refuse if ANY resolved address is
+  // non-public — a hostname that answers with both a public and a private record is
+  // a DNS-rebinding tell, so we taint the whole hostname rather than cherry-pick the
+  // public record (cage-match PR #111, Carnot re-review). Connect to the VETTED IP
+  // (not the name) so there's no resolve→check→connect TOCTOU.
   let addr;
   try {
     const got = await dns.lookup(host, { all: true });
-    addr = got.find((g) => !isForbiddenAddress(g.address));
-    if (!addr) { deny(clientSocket, 'host resolves only to non-public address', host); return; }
+    if (got.length === 0) { deny(clientSocket, 'host did not resolve', host); return; }
+    const forbidden = got.find((g) => isForbiddenAddress(g.address));
+    if (forbidden) { deny(clientSocket, 'host resolves to a non-public address', `${host} → ${forbidden.address}`); return; }
+    addr = got[0];
   } catch (e) {
     deny(clientSocket, 'dns resolution failed', `${host}: ${e.code || e.message}`);
     return;

--- a/self-healer/cage/escape-probe.sh
+++ b/self-healer/cage/escape-probe.sh
@@ -186,12 +186,14 @@ echo
 echo "=== CAGE SELF-DEFENSE (run-cage refuses an un-internal network) ==="
 # The deny-all egress backstop IS the network being --internal. run-cage.mjs must
 # refuse to spawn on a non-internal network rather than silently leaking egress
-# (cage-match #111, Carnot). Prove it: point the cage at the egress (bridge) net
-# and assert it REFUSES (exit 3), never runs.
-if CAGE_NETWORK="$NET_EGR" node run-cage.mjs -- sh -c 'echo should-not-run' >/dev/null 2>&1; then
-  bad "self-defense: ran on a NON-internal network (egress backstop bypassed)"
+# (cage-match #111, Carnot). Prove the DOCUMENTED failure mode precisely: exit 3
+# AND the inner command never ran (no stdout marker).
+sd_out="$(CAGE_NETWORK="$NET_EGR" node run-cage.mjs -- sh -c 'echo DID-RUN-SHOULD-NOT' 2>/dev/null)"
+sd_rc=$?
+if [ "$sd_rc" -eq 3 ] && ! printf '%s' "$sd_out" | grep -q 'DID-RUN-SHOULD-NOT'; then
+  ok "self-defense: refused non-internal network (exit 3, command never ran)"
 else
-  ok "self-defense: refused to spawn on a non-internal network"
+  bad "self-defense: rc=$sd_rc out='$sd_out' (expected exit 3 and no command output)"
 fi
 
 echo

--- a/self-healer/cage/escape-probe.sh
+++ b/self-healer/cage/escape-probe.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# escape-probe.sh — THE GATE. Run on the production box. Spawns the real cage
+# (via run-cage.mjs → cage.mjs) around each case in README.md's contract and
+# asserts the MUST-FAIL escapes fail and the MUST-SUCCEED cases succeed.
+#
+# "Attempt the escape, expect failure" — a green flag list is NOT this. This is.
+#
+#   bash cage/escape-probe.sh
+#
+# Exit 0 iff every escape is blocked AND every legit path works. Any escape that
+# succeeds → non-zero (the cage is broken OPEN — the unacceptable direction).
+set -uo pipefail
+cd "$(dirname "$0")"
+
+PROXY_IMG=cage-egress-proxy:probe
+PROBE_IMG=cage-probe:probe
+NET_INT=cage-internal-probe
+NET_EGR=cage-egress-probe
+PROXY_NAME=cage-egress-proxy-probe
+WORKDIR="$(mktemp -d /tmp/cage-workdir.XXXXXX)"
+# The cage runs as a fixed non-root image uid (1000) which won't match the host
+# user (nick is 1002), so make the THROWAWAY clone dir writable by it. In real
+# green-auto the orchestrator chowns the fresh clone to the cage uid instead.
+chmod 0777 "$WORKDIR"
+
+# Allowlist for the probe: github is the "allowed" host; example.com is "forbidden".
+ALLOW_HOSTS="api.github.com,.github.com"
+
+pass=0; fail=0
+ok()   { echo "  ✅ $1"; pass=$((pass+1)); }
+bad()  { echo "  ❌ $1"; fail=$((fail+1)); }
+
+cleanup() {
+  docker rm -f "$PROXY_NAME" >/dev/null 2>&1
+  docker network rm "$NET_INT" "$NET_EGR" >/dev/null 2>&1
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "=== build images ==="
+docker build -q -f Dockerfile.proxy -t "$PROXY_IMG" . >/dev/null || { echo "proxy build failed"; exit 3; }
+docker build -q -f Dockerfile.probe -t "$PROBE_IMG" . >/dev/null || { echo "probe build failed"; exit 3; }
+
+echo "=== networks ==="
+docker network create --internal "$NET_INT" >/dev/null
+docker network create "$NET_EGR" >/dev/null
+
+echo "=== start egress proxy (on BOTH nets: egress to reach allowlist, internal to be reachable) ==="
+docker run -d --rm --name "$PROXY_NAME" \
+  --network "$NET_EGR" \
+  -e "CAGE_ALLOW_HOSTS=$ALLOW_HOSTS" \
+  "$PROXY_IMG" >/dev/null
+docker network connect "$NET_INT" "$PROXY_NAME"
+sleep 1
+
+export CAGE_IMAGE="$PROBE_IMG"
+export CAGE_NETWORK="$NET_INT"
+export CAGE_WORKDIR="$WORKDIR"
+export CAGE_PROXY_URL="http://${PROXY_NAME}:3128"
+
+# run a command in the cage, return its exit code
+cage() { node run-cage.mjs -- "$@"; }
+
+echo
+echo "=== MUST FAIL (escapes — each must NOT succeed) ==="
+
+# NOTE on curl exit codes: --fail makes curl return non-zero on an HTTP >= 400,
+# so a proxy 403 (plaintext refused / host denied) counts as BLOCKED. Without it
+# curl exits 0 on a 403 — it got a valid response — and a refusal reads as a reach.
+
+# egress-forbidden: a non-allowlisted host, through the proxy → CONNECT denied
+if cage curl -sS --fail --max-time 8 -o /dev/null https://example.com >/dev/null 2>&1; then
+  bad "egress-forbidden: reached example.com (CAGE BROKEN OPEN)"
+else
+  ok "egress-forbidden: example.com blocked"
+fi
+
+# egress-metadata: cloud metadata is link-local (169.254/16). The real concern is
+# whether the internal net can route to it DIRECTLY (no proxy) — an SSRF-grade
+# escape. Bypass the proxy to test the network boundary itself.
+if cage curl -sS --fail --max-time 6 --noproxy '*' -o /dev/null http://169.254.169.254/latest/meta-data/ >/dev/null 2>&1; then
+  bad "egress-metadata: reached 169.254.169.254 directly (CAGE BROKEN OPEN — link-local routable)"
+else
+  ok "egress-metadata: metadata endpoint blocked"
+fi
+
+# egress-direct-ip: bypass the proxy and hit a public IP directly → no route
+if cage curl -sS --fail --max-time 8 --noproxy '*' -o /dev/null https://1.1.1.1 >/dev/null 2>&1; then
+  bad "egress-direct-ip: reached 1.1.1.1 directly (CAGE BROKEN OPEN — internal net leaks)"
+else
+  ok "egress-direct-ip: direct (proxy-bypass) egress blocked"
+fi
+
+# fs-host-secret: host secrets must not be visible inside the cage
+if cage sh -c 'cat /etc/shadow' >/dev/null 2>&1; then
+  bad "fs-host-secret: read /etc/shadow"
+else
+  ok "fs-host-secret: /etc/shadow not readable"
+fi
+if cage sh -c 'cat /home/nick/apps/self-healer.env' >/dev/null 2>&1; then
+  bad "fs-host-secret: read host self-healer.env (HOST FS LEAKED IN)"
+else
+  ok "fs-host-secret: host self-healer.env not present"
+fi
+
+# fs-host-write: rootfs is read-only outside the workdir
+if cage sh -c 'echo x > /etc/cage-pwned' >/dev/null 2>&1; then
+  bad "fs-host-write: wrote /etc/cage-pwned (rootfs writable)"
+else
+  ok "fs-host-write: rootfs read-only (write rejected)"
+fi
+
+# priv-esc: sudo must be absent / non-functional
+if cage sh -c 'command -v sudo && sudo -n id' >/dev/null 2>&1; then
+  bad "priv-esc: sudo worked"
+else
+  ok "priv-esc: no sudo path"
+fi
+# running as non-root
+uid="$(cage sh -c 'id -u' 2>/dev/null | tr -d '[:space:]')"
+if [ "$uid" = "0" ] || [ -z "$uid" ]; then
+  bad "priv-esc: running as uid='$uid' (want non-zero)"
+else
+  ok "priv-esc: non-root (uid=$uid)"
+fi
+
+# docker-escape: the docker socket must not be mounted
+if cage sh -c 'test -S /var/run/docker.sock' >/dev/null 2>&1; then
+  bad "docker-escape: /var/run/docker.sock present (daemon reachable)"
+else
+  ok "docker-escape: no docker socket"
+fi
+
+echo
+echo "=== MUST SUCCEED (cage must not be uselessly tight) ==="
+
+# allow-github: api.github.com THROUGH the proxy must work
+if cage curl -sS --max-time 12 -o /dev/null -w '%{http_code}' https://api.github.com/zen 2>/dev/null | grep -qE '^(200|30.)$'; then
+  ok "allow-github: api.github.com reachable via proxy"
+else
+  bad "allow-github: api.github.com NOT reachable via proxy (cage broken shut)"
+fi
+
+# workdir-rw: the clone workdir must be writable+readable
+if cage sh -c 'echo hello > /work/probe.txt && cat /work/probe.txt' 2>/dev/null | grep -q hello; then
+  ok "workdir-rw: /work writable+readable"
+else
+  bad "workdir-rw: /work not writable (cage broken shut)"
+fi
+
+echo
+echo "=== RESULT: $pass passed, $fail failed ==="
+[ "$fail" -eq 0 ]

--- a/self-healer/cage/escape-probe.sh
+++ b/self-healer/cage/escape-probe.sh
@@ -91,6 +91,31 @@ else
   ok "egress-direct-ip: direct (proxy-bypass) egress blocked"
 fi
 
+# egress-ipv6: a public IPv6 literal, direct. If the box has no v6 this fails too
+# (still blocked); the point is the internal net must not provide a v6 escape
+# where the v4 path is closed (cage-match #111, Kelvin + Carnot).
+if cage curl -sS --fail --max-time 6 --noproxy '*' -g -o /dev/null 'https://[2606:4700:4700::1111]' >/dev/null 2>&1; then
+  bad "egress-ipv6: reached a public IPv6 directly (CAGE BROKEN OPEN — v6 egress leaks)"
+else
+  ok "egress-ipv6: direct IPv6 egress blocked"
+fi
+
+# egress-gateway: the docker bridge gateway / host services must be unreachable
+# from the internal net (an internal net has no gateway, so this must fail).
+if cage curl -sS --fail --max-time 6 --noproxy '*' -o /dev/null http://172.17.0.1 >/dev/null 2>&1; then
+  bad "egress-gateway: reached docker bridge gateway 172.17.0.1 (CAGE BROKEN OPEN — host reachable)"
+else
+  ok "egress-gateway: docker bridge gateway unreachable"
+fi
+
+# egress-host-internal: host.docker.internal must NOT resolve/route (we never pass
+# --add-host); an internal net + no host mapping means the host is unnamed+unrouted.
+if cage curl -sS --fail --max-time 6 --noproxy '*' -o /dev/null http://host.docker.internal >/dev/null 2>&1; then
+  bad "egress-host-internal: reached host.docker.internal (CAGE BROKEN OPEN — host mapped in)"
+else
+  ok "egress-host-internal: host.docker.internal unreachable"
+fi
+
 # fs-host-secret: host secrets must not be visible inside the cage
 if cage sh -c 'cat /etc/shadow' >/dev/null 2>&1; then
   bad "fs-host-secret: read /etc/shadow"
@@ -116,12 +141,21 @@ if cage sh -c 'command -v sudo && sudo -n id' >/dev/null 2>&1; then
 else
   ok "priv-esc: no sudo path"
 fi
-# running as non-root
+# priv-esc CONTROL: the bare probe image is ROOT (uid 0). This makes the non-root
+# assertion below prove the CAGE's --user flag, not the image's USER directive
+# (cage-match #111, Carnot — the probe must remove the favorable initial state).
+bare_uid="$(docker run --rm "$PROBE_IMG" id -u 2>/dev/null | tr -d '[:space:]')"
+if [ "$bare_uid" = "0" ]; then
+  ok "priv-esc control: bare image is root (uid=0) — so non-root below is the cage's doing"
+else
+  bad "priv-esc control: bare image uid='$bare_uid' (expected 0; probe no longer falsifies the cage)"
+fi
+# running as non-root — forced by the cage's --user, NOT by the (root) image
 uid="$(cage sh -c 'id -u' 2>/dev/null | tr -d '[:space:]')"
 if [ "$uid" = "0" ] || [ -z "$uid" ]; then
-  bad "priv-esc: running as uid='$uid' (want non-zero)"
+  bad "priv-esc: running as uid='$uid' (cage failed to force non-root)"
 else
-  ok "priv-esc: non-root (uid=$uid)"
+  ok "priv-esc: cage forced non-root (uid=$uid) despite a root image"
 fi
 
 # docker-escape: the docker socket must not be mounted
@@ -146,6 +180,18 @@ if cage sh -c 'echo hello > /work/probe.txt && cat /work/probe.txt' 2>/dev/null 
   ok "workdir-rw: /work writable+readable"
 else
   bad "workdir-rw: /work not writable (cage broken shut)"
+fi
+
+echo
+echo "=== CAGE SELF-DEFENSE (run-cage refuses an un-internal network) ==="
+# The deny-all egress backstop IS the network being --internal. run-cage.mjs must
+# refuse to spawn on a non-internal network rather than silently leaking egress
+# (cage-match #111, Carnot). Prove it: point the cage at the egress (bridge) net
+# and assert it REFUSES (exit 3), never runs.
+if CAGE_NETWORK="$NET_EGR" node run-cage.mjs -- sh -c 'echo should-not-run' >/dev/null 2>&1; then
+  bad "self-defense: ran on a NON-internal network (egress backstop bypassed)"
+else
+  ok "self-defense: refused to spawn on a non-internal network"
 fi
 
 echo

--- a/self-healer/cage/run-cage.mjs
+++ b/self-healer/cage/run-cage.mjs
@@ -30,22 +30,29 @@ const [cmd, ...args] = process.argv.slice(sep + 1);
 // a normal bridge network would keep every proxy-env flag yet retain direct
 // egress (cage-match PR #111, Carnot). So verify Internal==true at spawn time and
 // refuse otherwise — the one boundary property the pure builder can't assert.
-function assertInternalNetwork(network) {
-  const r = spawnSync('docker', ['network', 'inspect', network, '--format', '{{.Internal}}'], { encoding: 'utf8' });
+function resolveInternalNetwork(network) {
+  // Read Internal AND the immutable network Id in one inspect. Returning the Id and
+  // spawning against THAT (not the name) closes the inspect-then-run race: a name
+  // could be deleted+recreated as a bridge between check and run, but the Id of a
+  // recreated network differs, so `docker run --network <stale-id>` fails rather
+  // than silently attaching to a non-internal replacement (cage-match #111, Carnot).
+  const r = spawnSync('docker', ['network', 'inspect', network, '--format', '{{.Internal}} {{.Id}}'], { encoding: 'utf8' });
   if (r.status !== 0) {
     process.stderr.write(`cage: cannot inspect network "${network}" (refusing to spawn): ${(r.stderr || '').trim()}\n`);
     process.exit(3);
   }
-  if (r.stdout.trim() !== 'true') {
-    process.stderr.write(`cage: network "${network}" is NOT --internal (Internal=${r.stdout.trim()}); egress backstop absent — refusing to spawn.\n`);
+  const [internal, id] = r.stdout.trim().split(/\s+/);
+  if (internal !== 'true') {
+    process.stderr.write(`cage: network "${network}" is NOT --internal (Internal=${internal}); egress backstop absent — refusing to spawn.\n`);
     process.exit(3);
   }
+  return id;
 }
-assertInternalNetwork(process.env.CAGE_NETWORK);
+const networkId = resolveInternalNetwork(process.env.CAGE_NETWORK);
 
 const { bin, argv } = buildCageArgv({
   image: process.env.CAGE_IMAGE,
-  network: process.env.CAGE_NETWORK,
+  network: networkId, // the inspected Id, not the name — closes the inspect→run race
   workdirHost: process.env.CAGE_WORKDIR,
   proxyUrl: process.env.CAGE_PROXY_URL,
   name: process.env.CAGE_NAME,

--- a/self-healer/cage/run-cage.mjs
+++ b/self-healer/cage/run-cage.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// run-cage.mjs — the one entry point that spawns the cage. Both the escape probe
+// AND the (future) green-auto orchestrator go through this, so the flags proven
+// by the probe are byte-identical to the flags green-auto runs. No drift.
+//
+// Config via env; the command to run inside the cage is argv after `--`:
+//   CAGE_IMAGE     agent/probe image                 (required)
+//   CAGE_NETWORK   the --internal network name       (required)
+//   CAGE_WORKDIR   host path of the fresh clone       (required)
+//   CAGE_PROXY_URL http://<proxy>:3128               (required)
+//   CAGE_NAME      container name                     (optional)
+//
+//   node run-cage.mjs -- curl -sS https://example.com
+//
+// Exit code is the caged container's exit code (so the probe can assert it).
+
+import { spawn } from 'node:child_process';
+import { buildCageArgv } from './cage.mjs';
+
+const sep = process.argv.indexOf('--');
+if (sep === -1 || sep === process.argv.length - 1) {
+  process.stderr.write('usage: node run-cage.mjs -- <cmd> [args…]\n');
+  process.exit(2);
+}
+const [cmd, ...args] = process.argv.slice(sep + 1);
+
+const { bin, argv } = buildCageArgv({
+  image: process.env.CAGE_IMAGE,
+  network: process.env.CAGE_NETWORK,
+  workdirHost: process.env.CAGE_WORKDIR,
+  proxyUrl: process.env.CAGE_PROXY_URL,
+  name: process.env.CAGE_NAME,
+  cmd,
+  args,
+});
+
+const proc = spawn(bin, argv, { stdio: 'inherit' });
+proc.on('exit', (code, signal) => {
+  if (signal) { process.stderr.write(`cage killed by ${signal}\n`); process.exit(1); }
+  process.exit(code ?? 1);
+});

--- a/self-healer/cage/run-cage.mjs
+++ b/self-healer/cage/run-cage.mjs
@@ -14,7 +14,7 @@
 //
 // Exit code is the caged container's exit code (so the probe can assert it).
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { buildCageArgv } from './cage.mjs';
 
 const sep = process.argv.indexOf('--');
@@ -23,6 +23,25 @@ if (sep === -1 || sep === process.argv.length - 1) {
   process.exit(2);
 }
 const [cmd, ...args] = process.argv.slice(sep + 1);
+
+// FAIL CLOSED on the egress boundary: the deny-all backstop is the network being
+// `--internal`. cage.mjs can only put the NAME in the argv — it cannot know the
+// network is actually internal. A caller (or a future green-auto bug) that passes
+// a normal bridge network would keep every proxy-env flag yet retain direct
+// egress (cage-match PR #111, Carnot). So verify Internal==true at spawn time and
+// refuse otherwise — the one boundary property the pure builder can't assert.
+function assertInternalNetwork(network) {
+  const r = spawnSync('docker', ['network', 'inspect', network, '--format', '{{.Internal}}'], { encoding: 'utf8' });
+  if (r.status !== 0) {
+    process.stderr.write(`cage: cannot inspect network "${network}" (refusing to spawn): ${(r.stderr || '').trim()}\n`);
+    process.exit(3);
+  }
+  if (r.stdout.trim() !== 'true') {
+    process.stderr.write(`cage: network "${network}" is NOT --internal (Internal=${r.stdout.trim()}); egress backstop absent — refusing to spawn.\n`);
+    process.exit(3);
+  }
+}
+assertInternalNetwork(process.env.CAGE_NETWORK);
 
 const { bin, argv } = buildCageArgv({
   image: process.env.CAGE_IMAGE,

--- a/self-healer/test/cage.test.mjs
+++ b/self-healer/test/cage.test.mjs
@@ -1,0 +1,114 @@
+// cage.test.mjs — CI-safe assertions on the cage's argv shape + the proxy
+// allowlist. These run with no Docker daemon and no box, exactly like
+// host_typed_argv.test.mjs proves the host primitive without spawning.
+//
+// ⚠️ THESE TESTS ARE NECESSARY BUT NOT THE BOUNDARY. An argv that CONTAINS
+// `--read-only` does not prove the rootfs is actually immutable; a `hostAllowed`
+// unit does not prove the kernel drops a forbidden packet. The boundary is
+// proven by cage/escape-probe.sh ON THE BOX (attempt the escape, watch it fail).
+// What these guard is REGRESSION: that a future edit doesn't silently drop a
+// confinement flag or widen the allowlist matcher. Pair, never substitute.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCageArgv, CONFINEMENT_FLAGS } from '../cage/cage.mjs';
+import { hostAllowed } from '../cage/egress-proxy.mjs';
+
+const base = {
+  image: 'cage-agent:latest',
+  network: 'cage-internal',
+  workdirHost: '/tmp/clone.abc',
+  proxyUrl: 'http://cage-egress-proxy:3128',
+  cmd: 'claude',
+  args: ['-p', 'fix it'],
+};
+
+// -- confinement flags: every authority-dropping flag is present --------------
+
+test('buildCageArgv includes every confinement flag', () => {
+  const { bin, argv } = buildCageArgv(base);
+  assert.equal(bin, 'docker');
+  assert.equal(argv[0], 'run');
+  for (const flag of CONFINEMENT_FLAGS) {
+    assert.ok(argv.includes(flag), `missing confinement flag: ${flag}`);
+  }
+  // The specific ones the contract table leans on, spelled out so a rename fails.
+  for (const must of ['--rm', '--cap-drop=ALL', '--security-opt=no-new-privileges', '--read-only']) {
+    assert.ok(argv.includes(must), `missing: ${must}`);
+  }
+});
+
+test('buildCageArgv puts the agent on the internal (no-egress) network', () => {
+  const { argv } = buildCageArgv(base);
+  const i = argv.indexOf('--network');
+  assert.notEqual(i, -1, '--network present');
+  assert.equal(argv[i + 1], 'cage-internal');
+});
+
+test('buildCageArgv mounts ONLY the workdir rw at /work and sets it as cwd', () => {
+  const { argv } = buildCageArgv(base);
+  assert.ok(argv.includes('/tmp/clone.abc:/work:rw'), 'workdir bind-mounted rw at /work');
+  const w = argv.indexOf('-w');
+  assert.equal(argv[w + 1], '/work');
+  // /tmp is a noexec/nosuid tmpfs — scratch space that can't run code.
+  const tmpfs = argv[argv.indexOf('--tmpfs') + 1];
+  assert.match(tmpfs, /^\/tmp:.*noexec.*nosuid/);
+});
+
+test('buildCageArgv sets all proxy env vars and an empty NO_PROXY (nothing exempt)', () => {
+  const { argv } = buildCageArgv(base);
+  const envs = argv.filter((_, i) => argv[i - 1] === '-e');
+  for (const k of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+    assert.ok(envs.includes(`${k}=http://cage-egress-proxy:3128`), `proxy env ${k} set`);
+  }
+  assert.ok(envs.includes('NO_PROXY='), 'NO_PROXY empty — no host exempted from the proxy');
+  assert.ok(envs.includes('no_proxy='), 'no_proxy empty');
+});
+
+test('a caller cannot clobber the egress proxy via env (proxy wins last)', () => {
+  const { argv } = buildCageArgv({ ...base, env: { HTTPS_PROXY: 'http://evil:9999', GH_TOKEN: 't' } });
+  const envs = argv.filter((_, i) => argv[i - 1] === '-e');
+  assert.ok(envs.includes('HTTPS_PROXY=http://cage-egress-proxy:3128'), 'proxy not clobbered');
+  assert.ok(!envs.includes('HTTPS_PROXY=http://evil:9999'), 'evil proxy override rejected');
+  assert.ok(envs.includes('GH_TOKEN=t'), 'non-proxy caller env still passes through');
+});
+
+test('buildCageArgv ends with image then the command + args', () => {
+  const { argv } = buildCageArgv(base);
+  const img = argv.indexOf('cage-agent:latest');
+  assert.notEqual(img, -1);
+  assert.deepEqual(argv.slice(img), ['cage-agent:latest', 'claude', '-p', 'fix it']);
+});
+
+for (const missing of ['image', 'network', 'workdirHost', 'proxyUrl', 'cmd']) {
+  test(`buildCageArgv throws when ${missing} is missing (fail closed)`, () => {
+    const bad = { ...base }; delete bad[missing];
+    assert.throws(() => buildCageArgv(bad), new RegExp(missing.replace('Host', '')));
+  });
+}
+
+// -- proxy allowlist: exact + dotted-suffix, never substring ------------------
+
+test('hostAllowed: exact host matches', () => {
+  assert.ok(hostAllowed('api.github.com', ['api.github.com']));
+  assert.ok(!hostAllowed('api.github.com', ['github.com']), 'exact entry does not match a subdomain');
+});
+
+test('hostAllowed: a leading-dot entry matches the family but not look-alikes', () => {
+  const allow = ['.github.com'];
+  assert.ok(hostAllowed('github.com', allow), 'apex matches');
+  assert.ok(hostAllowed('api.github.com', allow), 'subdomain matches');
+  assert.ok(hostAllowed('codeload.github.com', allow), 'another subdomain matches');
+  assert.ok(!hostAllowed('evilgithub.com', allow), 'look-alike must NOT match');
+  assert.ok(!hostAllowed('github.com.evil.com', allow), 'suffix-injection must NOT match');
+});
+
+test('hostAllowed: empty allowlist denies everything (fail closed)', () => {
+  assert.ok(!hostAllowed('api.github.com', []));
+  assert.ok(!hostAllowed('anything', []));
+});
+
+test('hostAllowed: case-insensitive', () => {
+  assert.ok(hostAllowed('API.GitHub.com', ['api.github.com']));
+});

--- a/self-healer/test/cage.test.mjs
+++ b/self-healer/test/cage.test.mjs
@@ -12,8 +12,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildCageArgv, CONFINEMENT_FLAGS } from '../cage/cage.mjs';
-import { hostAllowed } from '../cage/egress-proxy.mjs';
+import { buildCageArgv, CONFINEMENT_FLAGS, CAGE_UID_GID } from '../cage/cage.mjs';
+import { hostAllowed, parseConnectAuthority, isForbiddenAddress } from '../cage/egress-proxy.mjs';
 
 const base = {
   image: 'cage-agent:latest',
@@ -37,6 +37,17 @@ test('buildCageArgv includes every confinement flag', () => {
   for (const must of ['--rm', '--cap-drop=ALL', '--security-opt=no-new-privileges', '--read-only']) {
     assert.ok(argv.includes(must), `missing: ${must}`);
   }
+});
+
+test('buildCageArgv FORCES non-root via --user (not delegated to the image) — cage-match #111', () => {
+  const { argv } = buildCageArgv(base);
+  const u = argv.indexOf('--user');
+  assert.notEqual(u, -1, '--user present');
+  assert.equal(argv[u + 1], CAGE_UID_GID);
+  assert.ok(!/^0:/.test(argv[u + 1]), 'must not be uid 0');
+  // a caller can override the uid:gid but it is always emitted
+  const custom = buildCageArgv({ ...base, userGid: '65532:65532' });
+  assert.equal(custom.argv[custom.argv.indexOf('--user') + 1], '65532:65532');
 });
 
 test('buildCageArgv puts the agent on the internal (no-egress) network', () => {
@@ -66,12 +77,18 @@ test('buildCageArgv sets all proxy env vars and an empty NO_PROXY (nothing exemp
   assert.ok(envs.includes('no_proxy='), 'no_proxy empty');
 });
 
-test('a caller cannot clobber the egress proxy via env (proxy wins last)', () => {
+test('a caller cannot clobber the egress proxy via env (proxy wins last, exactly once)', () => {
   const { argv } = buildCageArgv({ ...base, env: { HTTPS_PROXY: 'http://evil:9999', GH_TOKEN: 't' } });
   const envs = argv.filter((_, i) => argv[i - 1] === '-e');
   assert.ok(envs.includes('HTTPS_PROXY=http://cage-egress-proxy:3128'), 'proxy not clobbered');
   assert.ok(!envs.includes('HTTPS_PROXY=http://evil:9999'), 'evil proxy override rejected');
   assert.ok(envs.includes('GH_TOKEN=t'), 'non-proxy caller env still passes through');
+  // Docker uses the LAST -e wins, so there must be exactly ONE HTTPS_PROXY emitted
+  // (a duplicate with the evil value last would silently win) — cage-match #111 Carnot.
+  for (const k of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+    const n = envs.filter((e) => e.startsWith(`${k}=`)).length;
+    assert.equal(n, 1, `exactly one ${k} assignment (got ${n})`);
+  }
 });
 
 test('buildCageArgv ends with image then the command + args', () => {
@@ -111,4 +128,38 @@ test('hostAllowed: empty allowlist denies everything (fail closed)', () => {
 
 test('hostAllowed: case-insensitive', () => {
   assert.ok(hostAllowed('API.GitHub.com', ['api.github.com']));
+});
+
+// -- CONNECT authority parse: exactly one host + one decimal port -------------
+
+test('parseConnectAuthority: accepts host:port', () => {
+  assert.deepEqual(parseConnectAuthority('api.github.com:443'), { host: 'api.github.com', port: 443 });
+});
+
+test('parseConnectAuthority: accepts a bracketed IPv6 literal', () => {
+  assert.deepEqual(parseConnectAuthority('[2606:4700:4700::1111]:443'), { host: '2606:4700:4700::1111', port: 443 });
+});
+
+test('parseConnectAuthority: rejects malformed / ambiguous authorities (cage-match #111)', () => {
+  for (const bad of ['', 'api.github.com', ':443', 'api.github.com:', 'api.github.com:0',
+    'api.github.com:99999', 'api.github.com:44a', '2606::1:443', 'a:b:443', 'host:443:extra']) {
+    assert.equal(parseConnectAuthority(bad), null, `must reject "${bad}"`);
+  }
+});
+
+// -- SSRF guard: an allowlisted name that resolves to a private IP is refused --
+
+test('isForbiddenAddress: rejects loopback/link-local/private/metadata (cage-match #111 F2)', () => {
+  for (const ip of ['127.0.0.1', '169.254.169.254', '10.0.0.5', '172.16.4.4', '172.31.255.1',
+    '192.168.1.1', '100.64.0.1', '0.0.0.0', '::1', '::', 'fe80::1', 'fc00::1', 'fd12::3',
+    '::ffff:10.0.0.1', '::ffff:169.254.169.254']) {
+    assert.ok(isForbiddenAddress(ip), `must forbid ${ip}`);
+  }
+});
+
+test('isForbiddenAddress: allows public addresses', () => {
+  for (const ip of ['1.1.1.1', '140.82.112.3', '8.8.8.8', '172.15.0.1', '172.32.0.1',
+    '2606:4700:4700::1111']) {
+    assert.ok(!isForbiddenAddress(ip), `must allow ${ip}`);
+  }
 });

--- a/self-healer/test/cage.test.mjs
+++ b/self-healer/test/cage.test.mjs
@@ -157,9 +157,25 @@ test('isForbiddenAddress: rejects loopback/link-local/private/metadata (cage-mat
   }
 });
 
+test('isForbiddenAddress: rejects the WHOLE fe80::/10 link-local range, not just fe80: (cage-match #111 re-review)', () => {
+  // The first cut only caught fe80:; link-local is fe80–febf. The allowlist
+  // rewrite (global unicast 2000::/3 only) fixes the whole family at once.
+  for (const ip of ['fe80::1', 'fe90::1', 'fea0::1', 'febf::dead', 'fec0::1', 'ff02::1', 'ff00::1']) {
+    assert.ok(isForbiddenAddress(ip), `must forbid non-global IPv6 ${ip}`);
+  }
+});
+
+test('isForbiddenAddress: rejects IPv4 multicast/reserved/benchmark/TEST-NET (cage-match #111 re-review)', () => {
+  for (const ip of ['224.0.0.1', '239.255.255.250', '240.0.0.1', '255.255.255.255',
+    '198.18.0.1', '198.19.255.1', '192.0.2.1', '198.51.100.7', '203.0.113.9', '192.0.0.8']) {
+    assert.ok(isForbiddenAddress(ip), `must forbid special-use IPv4 ${ip}`);
+  }
+});
+
 test('isForbiddenAddress: allows public addresses', () => {
   for (const ip of ['1.1.1.1', '140.82.112.3', '8.8.8.8', '172.15.0.1', '172.32.0.1',
-    '2606:4700:4700::1111']) {
+    '198.17.0.1', '198.20.0.1', '223.255.255.255',
+    '2606:4700:4700::1111', '2001:4860:4860::8888', '3fff::1']) {
     assert.ok(!isForbiddenAddress(ip), `must allow ${ip}`);
   }
 });


### PR DESCRIPTION
## What

The **OS-isolation cage** for green-auto's codegen agent — the prerequisite to merging green-auto (#571). green-auto stays **OFF**; nothing invokes the cage yet. **This PR is the cage and its proof, only.** *Build the cage before you spawn the monster.*

The agent green-auto will spawn is a headless `claude -p` with tool permissions, fed by a **log diagnosis** → its entire input is attacker-influenceable (a malicious log line becomes the diagnosis; target-repo source can carry prompt-injection). The cage bounds what a *fully-subverted* agent can touch: its own throwaway clone + two allowlisted hosts.

## ⚠️ Mechanism deviates from the original plan (bwrap/systemd → Docker)

The plan named *bwrap + systemd confinement + egress filter*. Verified on the box (Ubuntu 24.04 aarch64):
- **bwrap is absent** — would need `apt install` (host mutation) and still can't allowlist egress (only all-or-nothing `--unshare-net`; the agent needs inference + GitHub).
- **systemd `IPAddressDeny`/`DynamicUser`** need the **system manager = root**; the healer cron runs as **nick (non-root)**, and `systemd-run --user` can't do them.
- **Docker is already the box's delegated-confinement primitive** (nick ∈ docker group; the claude-shim cage precedent). Delivers every property with no new sudo, no new package.

Full ADR in `cage/README.md`.

## The cage

| property | enforced by |
|---|---|
| non-root, no-new-privs, cap-drop ALL | `--user` / `--security-opt` / `--cap-drop=ALL` |
| read-only rootfs, only clone writable | `--read-only` + one rw bind at `/work` |
| no docker socket, ephemeral, pid/mem caps | (never mounted) / `--rm` / `--pids-limit`/`--memory` |
| **egress denied** (backstop) | `--network <internal>` — kernel egress-deny, no external DNS |
| **egress allowlisted** (precision) | forced `HTTPS_PROXY` → CONNECT proxy, exact-host allowlist, fail-closed |

Proxy env vars are non-overridable by caller env (a clobbered `HTTPS_PROXY` would let the agent egress direct).

## Verification — by attempting the escape, not grepping config

`cage/escape-probe.sh` runs the **real cage on the production box**. Result: **11/11**.

```
MUST FAIL (escapes):  egress-forbidden ✅ · egress-metadata(link-local SSRF) ✅ ·
  egress-direct-ip(proxy-bypass) ✅ · fs-host-secret ✅✅ · fs-host-write ✅ ·
  priv-esc(sudo) ✅ · non-root ✅ · docker-escape ✅
MUST SUCCEED:         allow-github-via-proxy ✅ · workdir-rw ✅
```

`test/cage.test.mjs` (15 tests, CI-safe) guards argv-shape + allowlist **regression** — explicitly **not** the boundary (an argv containing `--read-only` ≠ an immutable rootfs; the probe is the boundary).

## Known follow-ups (NOT this PR)
- The green-auto orchestrator itself (verdict → clone → cage(claude) → PR → cage-match → merge) — the monster, a separate higher-blast-radius PR.
- Real agent image (shim base + git/gh/claude); probe used alpine+curl.
- Inference reachability through the proxy (allowlist the inference host alongside GitHub).
- Repo-scoped GitHub token (the OS cage bounds *reachability*; the token bounds *authority* — both required).
- Orchestrator must `chown` each fresh clone to the cage uid (box: nick=1002, image=1000).

## Review tier
**Cage-match (by law — this is the security boundary for an autonomous code-merger).** Different-inductive-bias adversary, not self-review.