### PR TITLE
Wire ASCEND_INGEST_KEY for the ascend night-loop → DF

### DIFF
--- a/embodied-dreamfinder/docker-compose.yml
+++ b/embodied-dreamfinder/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       # (it's also fine to lose — ascend re-delivers every morning — but a same-day restart keeps it).
       - ASCEND_INGEST_KEY=${ASCEND_INGEST_KEY:-}
       - ASCEND_NIGHT_FILE=/data/last-night.json
+      # Second password scoping a session to "ascend" — unlocks the DF that knows last night
+      # (AUTH_PASSWORD alone gives plain "base" DF, blind to it). See server.js /auth/login.
+      - ASCEND_PASSWORD=${ASCEND_PASSWORD:-}
     volumes:
       - embodied-dreamfinder-data:/data
       - /home/nick/whisper.cpp/build/bin:/opt/whisper/bin:ro

--- a/embodied-dreamfinder/docker-compose.yml
+++ b/embodied-dreamfinder/docker-compose.yml
@@ -51,7 +51,13 @@ services:
       - KOKORO_VOICE=${KOKORO_VOICE:-bm_fable}
       - KOKORO_MODEL_DIR=/opt/kokoro
       - LD_LIBRARY_PATH=/opt/whisper/lib:/opt/whisper/ggml-lib
+      # ascend night-loop: bearer for POST /api/ascend/night + where the stored night persists.
+      # ASCEND_NIGHT_FILE points at the writable named volume below so the night survives a redeploy
+      # (it's also fine to lose — ascend re-delivers every morning — but a same-day restart keeps it).
+      - ASCEND_INGEST_KEY=${ASCEND_INGEST_KEY:-}
+      - ASCEND_NIGHT_FILE=/data/last-night.json
     volumes:
+      - embodied-dreamfinder-data:/data
       - /home/nick/whisper.cpp/build/bin:/opt/whisper/bin:ro
       - /home/nick/whisper.cpp/build/src:/opt/whisper/lib:ro
       - /home/nick/whisper.cpp/build/ggml/src:/opt/whisper/ggml-lib:ro
@@ -67,3 +73,7 @@ services:
 networks:
   imagineering:
     external: true
+
+# Persists the ascend night across container recreation (redeploys rebuild the container).
+volumes:
+  embodied-dreamfinder-data:

--- a/embodied-dreamfinder/secrets.yaml
+++ b/embodied-dreamfinder/secrets.yaml
@@ -20,6 +20,7 @@ tts_engine: ENC[AES256_GCM,data:/SteIGEI,iv:sHLPP8Om1/ftvLmZC2QEe49VmyUtl7z3ccRk
 lyra_ssh_key: ENC[AES256_GCM,data:LVW4AAVJGdUB0Trdpv1STs13/Gj4,iv:0kQRpOo71ooQc+FvPW9TdAYRQ24uk22Mv1UzDpPE+3Q=,tag:icO2sxON75msJdgQ1fgIDg==,type:str]
 claude_code_oauth_token: ENC[AES256_GCM,data:RZ5KofRdsuORdcqTwL2djLSn1Ak0jjI3qhdhzikHULUZ9exq6qUNFy65X0YUaOVWKBDO/jB4F0UacZ6jaUCkShlP8YqswQDR6nfN3r2EPQB7WJOl2mX3MNu8ArGFQ5+Jbww18usz8+yYKU0e,iv:I2t4ueYF3DbR0RwV7QLrB2i3SAWYMPjblhmOc5g7XBo=,tag:9AHSAQkvD1n7VSSajs+IKw==,type:str]
 ascend_ingest_key: ENC[AES256_GCM,data:CC5X+YK7hZqEjTgRs2+jzBMSAkY6uGYiGtSfLaY8x0frdufw+19ZV3G64qVjSeUYn9Ffq9WnS2Ii/NHiBhJ2gw==,iv:SeWwwxzGiftfemiJ5aibeOMXDU/zkyupAWDdJuj4Ty4=,tag:CEcRKElyld4fZPyxjRfONg==,type:str]
+ascend_password: ENC[AES256_GCM,data:qzc7+8jf,iv:XIxOGdxDhTDa+3MCB3hxSAhDgi9mWvr/sWSCg+dN+kY=,tag:wOQeFXAM8HDQs2yka36Wcg==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -31,7 +32,7 @@ sops:
             aTliSGZZNTJWeTVCeTJUTWI1QTBtZ2sKKS8eDR70HQgZ4vXcuUkaqhD3xH+AKsgM
             ZlT0Knz3kFt3ENRgOB9xPlN6WfpGwtcor2UCfTXAZpCWEqC51Ht3bg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-23T09:57:59Z"
-    mac: ENC[AES256_GCM,data:tNJpahfGxW8Q/SNlZAgw4JrUE4fy5UzPLOze5Zk3Drh5aboW3HY2xL+C+Yyf4+bzj8k7Bx4WmbBsHKZ33OEqSzjaFacerJduh2NeUoD6H3yFdEJ+Z63TldwQ8JROnBDQ+SwtZJYy1G5j8biKRMZLkJvtecxEnP4cStW1UbYbZvE=,iv:ZAdiJKAvuFKDA08LDEIB0nX1B2/AVcIvY+rW5LD/amc=,tag:X6IBpilgfIXLZMHahETi+A==,type:str]
+    lastmodified: "2026-07-03T01:30:00Z"
+    mac: ENC[AES256_GCM,data:Euy8YAQj4NBHzWB+bqPMXvbAHoH0ycbP/gPnLgngsVqtx6h9M2d4Tkleg0bZCpfja29ufrq2Bb0AcAIYcp1suS0hqTDzOddevALqnr257Uhc1RPLQwOvt+UJuWIQkovUyGcJ1pI4PXiqcqhqhT/l2AgKmKzhevwWC3cQF05zRgA=,iv:IDp/9CaeoEWs3npmms4nwB97PLdnsz5U1n33mTs00Ro=,tag:n7g1DcX/Kkg4LAvyRYS6aQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/embodied-dreamfinder/secrets.yaml
+++ b/embodied-dreamfinder/secrets.yaml
@@ -19,6 +19,7 @@ df_brain: ENC[AES256_GCM,data:foYVWYcMXtd1,iv:gbWh1FC2AAu9/o7eE56spgvfgr+7hLRXJF
 tts_engine: ENC[AES256_GCM,data:/SteIGEI,iv:sHLPP8Om1/ftvLmZC2QEe49VmyUtl7z3ccRkJahagl8=,tag:L9QHzy0fTojQBGAxoKYYQQ==,type:str]
 lyra_ssh_key: ENC[AES256_GCM,data:LVW4AAVJGdUB0Trdpv1STs13/Gj4,iv:0kQRpOo71ooQc+FvPW9TdAYRQ24uk22Mv1UzDpPE+3Q=,tag:icO2sxON75msJdgQ1fgIDg==,type:str]
 claude_code_oauth_token: ENC[AES256_GCM,data:RZ5KofRdsuORdcqTwL2djLSn1Ak0jjI3qhdhzikHULUZ9exq6qUNFy65X0YUaOVWKBDO/jB4F0UacZ6jaUCkShlP8YqswQDR6nfN3r2EPQB7WJOl2mX3MNu8ArGFQ5+Jbww18usz8+yYKU0e,iv:I2t4ueYF3DbR0RwV7QLrB2i3SAWYMPjblhmOc5g7XBo=,tag:9AHSAQkvD1n7VSSajs+IKw==,type:str]
+ascend_ingest_key: ENC[AES256_GCM,data:CC5X+YK7hZqEjTgRs2+jzBMSAkY6uGYiGtSfLaY8x0frdufw+19ZV3G64qVjSeUYn9Ffq9WnS2Ii/NHiBhJ2gw==,iv:SeWwwxzGiftfemiJ5aibeOMXDU/zkyupAWDdJuj4Ty4=,tag:CEcRKElyld4fZPyxjRfONg==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -30,7 +31,7 @@ sops:
             aTliSGZZNTJWeTVCeTJUTWI1QTBtZ2sKKS8eDR70HQgZ4vXcuUkaqhD3xH+AKsgM
             ZlT0Knz3kFt3ENRgOB9xPlN6WfpGwtcor2UCfTXAZpCWEqC51Ht3bg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-21T09:02:06Z"
-    mac: ENC[AES256_GCM,data:ypCaw99IbkGnUhOugA6f53qf8lC8ujuGicSLF0WOutawukQ5I0qdYTgLI5V/H3z3s5DVxanz9su/SJMLzha12iyBIorggUr7XHDuHKEl+sdwtajX5EKfFGlNu+LaVBp+0cSiV3fR0sCkBFY+QaX7Mox643uNt1ptalF5CQdfRS8=,iv:EY8B35UjC/KZbyAaMv5wAKjsvsVUd9qV/oLY/v4vOBI=,tag:Odxw8SRGqnaePkYlkqyhZg==,type:str]
+    lastmodified: "2026-06-23T09:57:59Z"
+    mac: ENC[AES256_GCM,data:tNJpahfGxW8Q/SNlZAgw4JrUE4fy5UzPLOze5Zk3Drh5aboW3HY2xL+C+Yyf4+bzj8k7Bx4WmbBsHKZ33OEqSzjaFacerJduh2NeUoD6H3yFdEJ+Z63TldwQ8JROnBDQ+SwtZJYy1G5j8biKRMZLkJvtecxEnP4cStW1UbYbZvE=,iv:ZAdiJKAvuFKDA08LDEIB0nX1B2/AVcIvY+rW5LD/amc=,tag:X6IBpilgfIXLZMHahETi+A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -797,6 +797,8 @@ deploy_embodied_dreamfinder() {
         printf 'OPENAI_TTS_VOICE=%s\n'      "$(dotenv_quote "$(edf_field '.openai_tts_voice' 'sage')")"
         # ascend night-loop ingest bearer (POST /api/ascend/night). Same secret as ascend's ASCEND_DF_KEY.
         printf 'ASCEND_INGEST_KEY=%s\n'     "$(dotenv_quote "$(edf_field '.ascend_ingest_key')")"
+        # Second password scoping a session to "ascend" (unlocks the DF that knows last night).
+        printf 'ASCEND_PASSWORD=%s\n'       "$(dotenv_quote "$(edf_field '.ascend_password')")"
     } > "$REPO_ROOT/embodied-dreamfinder/.env"
 
     # Compose-file selection: only apply the lyra-live override (which mounts the

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -795,6 +795,8 @@ deploy_embodied_dreamfinder() {
         printf 'LYRA_SSH_KEY=%s\n'          "$(dotenv_quote "$(edf_field '.lyra_ssh_key')")"
         printf 'LYRA_SSH_HOST=%s\n'         "$(dotenv_quote "$(edf_field '.lyra_ssh_host' 'ubuntu@207.211.145.30')")"
         printf 'OPENAI_TTS_VOICE=%s\n'      "$(dotenv_quote "$(edf_field '.openai_tts_voice' 'sage')")"
+        # ascend night-loop ingest bearer (POST /api/ascend/night). Same secret as ascend's ASCEND_DF_KEY.
+        printf 'ASCEND_INGEST_KEY=%s\n'     "$(dotenv_quote "$(edf_field '.ascend_ingest_key')")"
     } > "$REPO_ROOT/embodied-dreamfinder/.env"
 
     # Compose-file selection: only apply the lyra-live override (which mounts the


### PR DESCRIPTION
The ascend night-loop POSTs each night's adventure to embodied-dreamfinder (`POST /api/ascend/night`, bearer-authed) so Nick talks to the avatar about it at dawn instead of getting a Telegram push. This adds the **deploy-side plumbing** so that bearer reaches the container.

The bearer has to traverse three links — all in this repo (the app repo has no compose):

1. **`embodied-dreamfinder/secrets.yaml`** — `ascend_ingest_key` added (sops/age-encrypted, same value as ascend's `ASCEND_DF_KEY`). Encrypted at rest; safe to commit.
2. **`scripts/deploy-to.sh`** — emits `ASCEND_INGEST_KEY` into the generated `.env` (explicit per-field render, routed through `dotenv_quote` like every other secret).
3. **`embodied-dreamfinder/docker-compose.yml`** — `${ASCEND_INGEST_KEY}` passthrough into the container, plus `ASCEND_NIGHT_FILE=/data/last-night.json` on a new named volume so the stored night survives a container recreate.

### ⚠️ Heads-up — overlaps the in-flight DF deploy rework
This was opened while DF's deploy is being changed in a parallel session. It touches `deploy-to.sh` (`deploy_embodied_dreamfinder`) and `embodied-dreamfinder/docker-compose.yml` — so it may **conflict with the deploy rewrite** and should be reconciled at merge (the *secrets.yaml* addition is independent and won't conflict). If the rewrite changes how `.env` is generated or how the container gets its env, fold links #2/#3 into that instead — only `ascend_ingest_key` in secrets.yaml is non-negotiable.

### Pairs with
- `imagineering-cc/embodied-dreamfinder#68` — the code that reads `ASCEND_INGEST_KEY` (+ `/api/ascend/night`, `get_last_night`).
- `nickmeinhold/ascend#2` — the sender.

**Not deployed by this PR** — needs #68 merged + a deploy run. No deploy is triggered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)