### PR TITLE
fix(backups): stagger imagineering backup cron to 04:30 to un-race xdeca-backup

### DIFF
--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -438,7 +438,17 @@ deploy_backups() {
     # Set up backup cron job and log directory
     echo "Setting up backup cron job..."
     ssh "$REMOTE" "mkdir -p ~/logs"
-    ssh "$REMOTE" "echo '0 4 * * * nick /opt/scripts/backup.sh all >> /home/nick/logs/backup.log 2>&1' | sudo tee /etc/cron.d/backup > /dev/null"
+    # Staggered to 04:30, NOT 04:00, to avoid racing the xdeca-infra deploy's
+    # `/etc/cron.d/xdeca-backup` (xdeca-infra scripts/deploy-to.sh), which also
+    # fires `backup.sh all` at `0 4 * * *`. Both backups push to the SAME GitHub
+    # backup clone at /tmp/imagineering-backups (and run the SAME on-host
+    # /opt/scripts/backup.sh), so a same-minute start makes them collide on that
+    # shared working tree — concurrent `git add`/`commit`/`push` corrupt or lose
+    # each other's commit. A 30-minute offset lets one finish before the other
+    # starts. NOTE: this only un-races THIS repo's cron; the deeper coupling
+    # (both repos overwrite /opt/scripts/backup.sh and contend on one clone) is a
+    # cross-repo concern that xdeca-infra must also acknowledge — see PR body.
+    ssh "$REMOTE" "echo '30 4 * * * nick /opt/scripts/backup.sh all >> /home/nick/logs/backup.log 2>&1' | sudo tee /etc/cron.d/backup > /dev/null"
 
     # --- GitHub backup setup ---
     echo ""


### PR DESCRIPTION
## The race

On the OCI host, **two** cron entries both run `backup.sh all` at `0 4 * * *`:

| Cron file | Owner repo | Telegram env |
|---|---|---|
| `/etc/cron.d/backup` | **imagineering-infra** (this repo, `scripts/deploy-to.sh` `deploy_backups`) | none inline — sourced at runtime from `/etc/imagineering-secrets/telegram.env` (0640) via `scripts/lib/telegram.sh` |
| `/etc/cron.d/xdeca-backup` | **xdeca-infra** (`scripts/deploy-to.sh`, line ~95) | **inlined** in the cron line (`TELEGRAM_BOT_TOKEN=… CHAT_ID=… THREAD_ID=…`) from `gremlin/secrets.yaml` |

Both run the **same** on-host `/opt/scripts/backup.sh` and both push to the **same** GitHub backup clone at `/tmp/imagineering-backups`. Firing at the same minute means two `backup.sh` processes race on that one git working tree — concurrent `git add`/`commit`/`push` can corrupt or silently drop each other's commit. Pre-existing.

## Why this isn't a clean dedupe

The task framing assumed both cron definitions live in this repo. They don't — `/etc/cron.d/xdeca-backup` is created by a **separate repo** (`xdeca-infra`), confirmed at `~/git/orgs/xdeca/xdeca-infra/scripts/deploy-to.sh:95`. This repo can't delete or own the xdeca cron. So a true single-cron dedupe would require coordinated changes across both repos.

The two are **not fully redundant**, either: imagineering's `backup.sh` covers kanbn/outline/radicale/pm-bot/claudius/matrix/continuwuity; xdeca's covers only kanbn/outline/radicale. They also fight over `/opt/scripts/backup.sh` itself — whichever repo deploys last wins the script (latent coverage-depends-on-deploy-order bug). That deeper coupling is out of scope for a minimal single-repo fix.

## The fix: stagger

Move **this repo's** cron from `0 4` → `30 4`. A 30-minute offset lets one backup finish before the other starts, eliminating the shared-clone race from this side. Telegram env is unchanged (this repo's sourced-from-secrets-file approach is strictly better than xdeca's inlined-in-cron secret exposure; no reason to touch it).

## Which Telegram env is canonical

This repo's: secrets sourced at runtime from `/etc/imagineering-secrets/telegram.env` (mode 0640 root:nick) via `scripts/lib/telegram.sh`, so no token touches the world-readable cron file. xdeca's inlines the token directly in `/etc/cron.d/xdeca-backup` — a secret-exposure smell that should eventually migrate to the same secrets-file pattern (noted for the xdeca-infra side, not changed here).

## Host sync required (orchestrator)

This PR only changes the **repo source of truth**. The live host still has the old `0 4` entry until re-deployed. To apply on the OCI host:

```
# from a deployed imagineering-infra checkout on/targeting the OCI host:
./scripts/deploy-to.sh <target> backups
# or minimally, rewrite just the cron file:
ssh <oci> "echo '30 4 * * * nick /opt/scripts/backup.sh all >> /home/nick/logs/backup.log 2>&1' | sudo tee /etc/cron.d/backup > /dev/null"
```
Then verify: `ssh <oci> "cat /etc/cron.d/backup /etc/cron.d/xdeca-backup"` — confirm `backup` shows `30 4` and `xdeca-backup` still `0 4` (no longer the same minute). No service restart needed; cron re-reads `/etc/cron.d` automatically.

## Follow-up (cross-repo, out of scope here)

The real fix is one source of truth: have **only one** repo own `backup.sh all` + the cron, or split into two genuinely-disjoint scripts that don't share `/opt/scripts/backup.sh` or the `/tmp/imagineering-backups` clone. That needs an xdeca-infra change and a decision on ownership.

## CI
`shellcheck --severity=warning scripts/deploy-to.sh` → exit 0 (matches CI's `severity: warning` gate). No new findings on the changed line.

Closes nickmeinhold/claude-tasks#680