### PR TITLE
feat(self-healer): green-auto orchestrator (caged remediation, shipped OFF)

### DIFF
--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -98,11 +98,51 @@ real prod signals before any hands are wired. In order:
 2. **amber ping:** notify on amber+ via the `notify` proxy. ✅ (still read-only)
 3. **green draft:** file a remediation *issue* for a confident-green finding. ✅
    (the first ACTION stage — bounded blast radius: issue, never code/merge/deploy)
-4. **green auto:** behind an explicit flag, run the full green-tier loop
-   (fix → cage-match → merge → deploy → re-sense to confirm the symptom is gone).
+4. **green auto:** behind an explicit flag, run the green-tier remediation agent
+   inside the cage. **Scaffolded + SHIPPED OFF** (`src/auto.mjs`) — see below.
 
 Each step is gated on the previous one being *observed correct in prod*, not
 just coded. The cage is built before the monster.
+
+### green-auto (the caged action stage — built, OFF, not yet enabled)
+
+`src/auto.mjs` is the orchestrator for the first stage that runs the **monster** —
+a codegen agent that writes a fix from a log diagnosis. It does not relax any
+earlier guarantee; it **routes** each eligible finding through the already-proven
+cage (`cage/run-cage.mjs`, gated by `cage/escape-probe.sh`), never around it, and
+enforces the one boundary the OS cage can't: that the agent's GitHub authority is
+**bounded to the single target repo**.
+
+It mirrors `green-draft` exactly — same `actionableFindings` filter, same
+fingerprint, same single-box owner-fenced lock — with the cage swapped in for the
+GitHub-issue POST. Its outcome reports the **cage run**, never a merged fix; the
+PR / cage-match / merge / deploy happen (eventually) inside/after the caged agent,
+bounded by the repo-scoped token and the cage-match on the resulting PR.
+
+**Five independent fail-closed gates, ALL required before a single spawn:**
+
+| # | Gate | Env / condition | Why |
+| - | ---- | --------------- | --- |
+| 1 | feature flag | `HEALER_GREEN_AUTO=1` | OFF by default |
+| 2 | on-box | `HEALER_HOST` unset | the cage is a host-local Docker primitive — refuse remote runs rather than pretend |
+| 3 | **bounded authority** | `HEALER_GREEN_AUTO_TOKEN` set **and distinct** from the broad host token | the agent gets a repo-scoped token, never the healer's org-wide one |
+| 4 | cage substrate | `HEALER_CAGE_IMAGE` / `HEALER_CAGE_NETWORK` / `HEALER_CAGE_PROXY_URL` | the proven cage must exist to spawn into |
+| 5 | agent command | `HEALER_CAGE_AGENT_CMD` | the codegen "monster" is operator-installed, never hardcoded |
+
+> ⚠️ **DO NOT enable green-auto until a repo-scoped token bounds authority.**
+> Gate 3 is the *enforced* form of `cage/README.md`'s "Credential scope" contract:
+> the orchestrator structurally refuses to hand the agent the broad host token.
+> **Named residual:** distinct-from-broad guarantees a *dedicated* token; it does
+> not by itself prove the token is fine-grained-scoped to exactly one repo — that
+> narrowing is the operator's provisioning responsibility (a fine-grained PAT / App
+> installation token for the one repo). An online control-repo reachability probe
+> to verify the bound is tracked as follow-up.
+
+The token rides into the cage as `CAGE_GH_TOKEN` (→ `GH_TOKEN`/`GITHUB_TOKEN`
+inside the container) via `run-cage.mjs`'s bounded forward allowlist; the finding
+context rides as scrubbed+capped `CAGE_AGENT_*` vars; `HOME=/work` is set for the
+agent. Nothing else crosses, and the proxy routing is appended LAST so none of it
+can clobber egress.
 
 ### green-draft (the first action stage)
 

--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -139,10 +139,11 @@ bounded by the repo-scoped token and the cage-match on the resulting PR.
 > to verify the bound is tracked as follow-up.
 
 The token rides into the cage as `CAGE_GH_TOKEN` (→ `GH_TOKEN`/`GITHUB_TOKEN`
-inside the container) via `run-cage.mjs`'s bounded forward allowlist; the finding
-context rides as scrubbed+capped `CAGE_AGENT_*` vars; `HOME=/work` is set for the
-agent. Nothing else crosses, and the proxy routing is appended LAST so none of it
-can clobber egress.
+inside the container) via `run-cage.mjs`'s bounded forward allowlist — **key-only
+(`-e GH_TOKEN`, no value), so the secret never enters the `docker run` argv / host
+`ps`**; the finding context rides as scrubbed+capped `CAGE_AGENT_*` vars;
+`HOME=/work` is set for the agent. Nothing else crosses, and the proxy routing is
+appended LAST so none of it can clobber egress.
 
 ### green-draft (the first action stage)
 

--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -86,6 +86,8 @@ The `priv-esc` case deliberately uses a **root** probe image (`Dockerfile.probe`
 | `allow-inference` | reach the inference brain **through the proxy** | 2xx/expected |
 | `allow-github` | reach `api.github.com` **through the proxy** | 2xx |
 | `workdir-rw` | write+read a file in the clone workdir | ok |
+| `token-forward` | with `CAGE_GH_TOKEN` set, `$GITHUB_TOKEN`/`$GH_TOKEN` inside the cage match it | forwarded (the agent can auth) |
+| `token-not-leaked` | with `CAGE_GH_TOKEN` **unset**, no GitHub token in the cage env | absent (no stray credential) |
 
 A cage that fails an escape-FAIL case is **broken open** (the dangerous direction).
 A cage that fails a MUST-SUCCEED case is **broken shut** (green-auto can't work, but
@@ -113,8 +115,19 @@ it's safe) — fix forward, never relax an escape gate to make a success case pa
 The GitHub token handed to the agent MUST be scoped to the **one** target repo
 (fine-grained PAT / installation token), so a fully-subverted agent that *does* open
 a malicious PR still cannot reach another repo. The OS cage bounds *reachability*;
-the token scope bounds *authority*. Both are required. Tracked separately from this
-probe.
+the token scope bounds *authority*. Both are required.
+
+**Now partly enforced (`src/auto.mjs` gate 3, `boundedAuthority`).** The green-auto
+orchestrator refuses to spawn unless `HEALER_GREEN_AUTO_TOKEN` is set AND **distinct
+from the healer's broad host token** (`HEALER_GH_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`) —
+so the agent can never receive the org-wide token. The token reaches the cage only
+as `CAGE_GH_TOKEN`, forwarded by `run-cage.mjs` into `GH_TOKEN`/`GITHUB_TOKEN` inside
+the container (alongside `HOME=/work` and the scrubbed `CAGE_AGENT_*` task context;
+nothing else). **Residual (named, not enforced):** distinct-from-broad guarantees a
+*dedicated* token, not that it is *fine-grained-scoped to exactly one repo* — that
+narrowing is the operator's provisioning duty. A control-repo reachability probe
+(reach a forbidden repo with the token, expect 404/403) to verify the bound online
+is the next gate to add.
 
 ## ADR — why Docker, not bwrap/systemd (deviates from the original plan)
 

--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -122,8 +122,9 @@ orchestrator refuses to spawn unless `HEALER_GREEN_AUTO_TOKEN` is set AND **dist
 from the healer's broad host token** (`HEALER_GH_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`) —
 so the agent can never receive the org-wide token. The token reaches the cage only
 as `CAGE_GH_TOKEN`, forwarded by `run-cage.mjs` into `GH_TOKEN`/`GITHUB_TOKEN` inside
-the container (alongside `HOME=/work` and the scrubbed `CAGE_AGENT_*` task context;
-nothing else). **Residual (named, not enforced):** distinct-from-broad guarantees a
+the container — **key-only (`-e GH_TOKEN`, no value), so the secret rides in the
+docker client env, never the `docker run` argv / host `ps`** (cage-match #114) —
+alongside `HOME=/work` and the scrubbed `CAGE_AGENT_*` task context; nothing else. **Residual (named, not enforced):** distinct-from-broad guarantees a
 *dedicated* token, not that it is *fine-grained-scoped to exactly one repo* — that
 narrowing is the operator's provisioning duty. A control-repo reachability probe
 (reach a forbidden repo with the token, expect 404/403) to verify the bound online

--- a/self-healer/cage/cage.mjs
+++ b/self-healer/cage/cage.mjs
@@ -36,13 +36,14 @@ export const CAGE_UID_GID = '1000:1000';
  * @param {string} o.workdirHost  host path of the FRESH single-repo clone, bind-mounted rw at /work
  * @param {string} o.proxyUrl     e.g. http://cage-egress-proxy:3128 — the ONLY egress path
  * @param {string} [o.name]       container name (ephemeral)
- * @param {Record<string,string>} [o.env]  extra env (e.g. a repo-scoped GH token). NEVER host secrets.
+ * @param {Record<string,string>} [o.env]  extra VALUE-carrying env (non-secret context). A value here lands in the argv (host `ps`), so NEVER a secret — for a secret use passEnv.
+ * @param {string[]} [o.passEnv]  env var NAMES passed through key-only (`-e NAME`, no value) — docker reads the VALUE from the SPAWNING process's env, so a SECRET (a repo-scoped token) never appears in this argv / host `ps` (cage-match #114, Maxwell F1). Caller must have the var set in its own env.
  * @param {string} o.cmd          the command to run (e.g. "claude" or, in the probe, "sh")
  * @param {string[]} [o.args]     args to cmd
  * @param {string} [o.userGid]    forced non-root uid:gid (default CAGE_UID_GID); never trusts the image
  * @returns {{bin: string, argv: string[]}}
  */
-export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env = {}, cmd, args = [], userGid = CAGE_UID_GID }) {
+export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env = {}, passEnv = [], cmd, args = [], userGid = CAGE_UID_GID }) {
   if (!image) throw new Error('cage: image required');
   if (!network) throw new Error('cage: internal network required');
   if (!workdirHost) throw new Error('cage: workdirHost required');
@@ -73,8 +74,18 @@ export function buildCageArgv({ image, network, workdirHost, proxyUrl, name, env
   argv.push('-v', `${workdirHost}:/work:rw`, '-w', '/work');
   argv.push('--tmpfs', '/tmp:rw,noexec,nosuid,size=64m');
 
+  // Key-only `-e NAME` pass-through: docker reads NAME's VALUE from the SPAWNING
+  // process's env, so a secret (the repo-scoped token) rides in the docker
+  // client's env, NEVER in this argv / host `ps` (cage-match #114, Maxwell F1).
+  // Disjoint by construction from `env` and the proxy keys.
+  for (const k of passEnv) {
+    argv.push('-e', k); // bare name, no "=value"
+  }
+
   // Caller env first, proxy env LAST so a caller can never clobber the egress
-  // routing (a clobbered HTTPS_PROXY would let the agent egress directly).
+  // routing (a clobbered HTTPS_PROXY would let the agent egress directly). The
+  // spread dedupes by key, so a caller-set proxy key is OVERWRITTEN (not
+  // duplicated) by proxyEnv — docker's last-wins then can't be turned against us.
   for (const [k, v] of Object.entries({ ...env, ...proxyEnv })) {
     argv.push('-e', `${k}=${v}`);
   }

--- a/self-healer/cage/escape-probe.sh
+++ b/self-healer/cage/escape-probe.sh
@@ -182,6 +182,24 @@ else
   bad "workdir-rw: /work not writable (cage broken shut)"
 fi
 
+# token-forward: the green-auto credential path. run-cage.mjs must forward
+# CAGE_GH_TOKEN into the cage as GITHUB_TOKEN (the agent authenticates git/gh with
+# it) — and ONLY into the cage. The exfil direction is already covered by the
+# egress-forbidden/direct-ip cases above: a token present in the cage env still
+# can't leave except CONNECT-through-the-proxy to an allowlisted host.
+if CAGE_GH_TOKEN='probe-sentinel-token' cage sh -c 'test "$GITHUB_TOKEN" = probe-sentinel-token && test "$GH_TOKEN" = probe-sentinel-token' >/dev/null 2>&1; then
+  ok "token-forward: CAGE_GH_TOKEN reaches the cage as GITHUB_TOKEN/GH_TOKEN"
+else
+  bad "token-forward: CAGE_GH_TOKEN NOT forwarded into the cage (green-auto agent can't auth)"
+fi
+# token-not-leaked: WITHOUT CAGE_GH_TOKEN, no GitHub token must appear in the cage
+# env (the probe's normal cases must never carry a stray credential).
+if cage sh -c 'test -z "$GITHUB_TOKEN" && test -z "$GH_TOKEN"' >/dev/null 2>&1; then
+  ok "token-not-leaked: no GitHub token in the cage when CAGE_GH_TOKEN is unset"
+else
+  bad "token-not-leaked: a GitHub token leaked into the cage with CAGE_GH_TOKEN unset"
+fi
+
 echo
 echo "=== CAGE SELF-DEFENSE (run-cage refuses an un-internal network) ==="
 # The deny-all egress backstop IS the network being --internal. run-cage.mjs must

--- a/self-healer/cage/escape-probe.sh
+++ b/self-healer/cage/escape-probe.sh
@@ -184,9 +184,11 @@ fi
 
 # token-forward: the green-auto credential path. run-cage.mjs must forward
 # CAGE_GH_TOKEN into the cage as GITHUB_TOKEN (the agent authenticates git/gh with
-# it) — and ONLY into the cage. The exfil direction is already covered by the
-# egress-forbidden/direct-ip cases above: a token present in the cage env still
-# can't leave except CONNECT-through-the-proxy to an allowlisted host.
+# it) — and ONLY into the cage. The token is passed KEY-ONLY (`-e GH_TOKEN`), so
+# its VALUE rides in the docker client env, never the `docker run` argv / host
+# `ps` (cage-match #114, Maxwell F1). The exfil direction is already covered by
+# the egress-forbidden/direct-ip cases above: a token present in the cage env
+# still can't leave except CONNECT-through-the-proxy to an allowlisted host.
 if CAGE_GH_TOKEN='probe-sentinel-token' cage sh -c 'test "$GITHUB_TOKEN" = probe-sentinel-token && test "$GH_TOKEN" = probe-sentinel-token' >/dev/null 2>&1; then
   ok "token-forward: CAGE_GH_TOKEN reaches the cage as GITHUB_TOKEN/GH_TOKEN"
 else

--- a/self-healer/cage/run-cage.mjs
+++ b/self-healer/cage/run-cage.mjs
@@ -53,32 +53,45 @@ const networkId = resolveInternalNetwork(process.env.CAGE_NETWORK);
 // Forward a BOUNDED allowlist into the cage (the green-auto credential path). Set
 // by the orchestrator (src/auto.mjs), absent in the escape probe — so this block
 // is a no-op for the probe and its flags stay byte-identical:
-//   - CAGE_GH_TOKEN  → GH_TOKEN + GITHUB_TOKEN: the REPO-SCOPED token the agent
-//     authenticates `git`/`gh` with. cage.mjs bounds its reachability; the token
-//     scope bounds its authority (cage/README.md "Credential scope").
-//   - CAGE_AGENT_*   → forwarded verbatim: the agent's task context (repo,
-//     finding signature/diagnosis/action, fingerprint), already scrubbed+capped.
+//   - CAGE_GH_TOKEN  → GH_TOKEN + GITHUB_TOKEN, passed KEY-ONLY (`-e GH_TOKEN`):
+//     the repo-scoped token the agent authenticates `git`/`gh` with. Its VALUE is
+//     exported into THIS process's env (inherited by the spawned docker) so docker
+//     reads it from the client env — it never lands in the argv / host `ps`
+//     (cage-match #114, Maxwell F1). cage.mjs bounds reachability; token scope
+//     bounds authority (cage/README.md "Credential scope").
+//   - CAGE_AGENT_*   → value-carrying (non-secret task context: repo, finding
+//     signature/diagnosis/action, fingerprint), already scrubbed+capped.
 //   - HOME=/work     → the writable-HOME the real agent needs (the residual
 //     cage/README.md assigns to the orchestrator); only when a token is present.
 // NOTHING else crosses, and buildCageArgv appends the proxy routing LAST so none
 // of these can clobber egress (a clobbered HTTPS_PROXY would mean direct egress).
 function forwardedCageEnv() {
-  const env = {};
+  const setEnv = {}; // value-carrying (non-secret) → `-e k=v`
+  const passNames = []; // key-only (secret) → `-e NAME`, value from this process's env
   const tok = process.env.CAGE_GH_TOKEN;
-  if (tok) { env.GH_TOKEN = tok; env.GITHUB_TOKEN = tok; env.HOME = '/work'; }
-  for (const k of Object.keys(process.env)) {
-    if (k.startsWith('CAGE_AGENT_')) env[k] = process.env[k];
+  if (tok) {
+    // Export the token into our OWN env so the inherited docker child can read it
+    // for the key-only pass-through; the value stays out of the argv.
+    process.env.GH_TOKEN = tok;
+    process.env.GITHUB_TOKEN = tok;
+    passNames.push('GH_TOKEN', 'GITHUB_TOKEN');
+    setEnv.HOME = '/work';
   }
-  return env;
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith('CAGE_AGENT_')) setEnv[k] = process.env[k];
+  }
+  return { setEnv, passNames };
 }
 
+const { setEnv, passNames } = forwardedCageEnv();
 const { bin, argv } = buildCageArgv({
   image: process.env.CAGE_IMAGE,
   network: networkId, // the inspected Id, not the name — closes the inspect→run race
   workdirHost: process.env.CAGE_WORKDIR,
   proxyUrl: process.env.CAGE_PROXY_URL,
   name: process.env.CAGE_NAME,
-  env: forwardedCageEnv(),
+  env: setEnv,
+  passEnv: passNames,
   cmd,
   args,
 });

--- a/self-healer/cage/run-cage.mjs
+++ b/self-healer/cage/run-cage.mjs
@@ -50,12 +50,35 @@ function resolveInternalNetwork(network) {
 }
 const networkId = resolveInternalNetwork(process.env.CAGE_NETWORK);
 
+// Forward a BOUNDED allowlist into the cage (the green-auto credential path). Set
+// by the orchestrator (src/auto.mjs), absent in the escape probe — so this block
+// is a no-op for the probe and its flags stay byte-identical:
+//   - CAGE_GH_TOKEN  → GH_TOKEN + GITHUB_TOKEN: the REPO-SCOPED token the agent
+//     authenticates `git`/`gh` with. cage.mjs bounds its reachability; the token
+//     scope bounds its authority (cage/README.md "Credential scope").
+//   - CAGE_AGENT_*   → forwarded verbatim: the agent's task context (repo,
+//     finding signature/diagnosis/action, fingerprint), already scrubbed+capped.
+//   - HOME=/work     → the writable-HOME the real agent needs (the residual
+//     cage/README.md assigns to the orchestrator); only when a token is present.
+// NOTHING else crosses, and buildCageArgv appends the proxy routing LAST so none
+// of these can clobber egress (a clobbered HTTPS_PROXY would mean direct egress).
+function forwardedCageEnv() {
+  const env = {};
+  const tok = process.env.CAGE_GH_TOKEN;
+  if (tok) { env.GH_TOKEN = tok; env.GITHUB_TOKEN = tok; env.HOME = '/work'; }
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith('CAGE_AGENT_')) env[k] = process.env[k];
+  }
+  return env;
+}
+
 const { bin, argv } = buildCageArgv({
   image: process.env.CAGE_IMAGE,
   network: networkId, // the inspected Id, not the name — closes the inspect→run race
   workdirHost: process.env.CAGE_WORKDIR,
   proxyUrl: process.env.CAGE_PROXY_URL,
   name: process.env.CAGE_NAME,
+  env: forwardedCageEnv(),
   cmd,
   args,
 });

--- a/self-healer/src/auto.mjs
+++ b/self-healer/src/auto.mjs
@@ -239,11 +239,12 @@ async function prepareWorkdir(repo, token) {
   return dir;
 }
 
-/** Best-effort removal of a finished cage's host clone dir, so /tmp doesn't
- * accumulate one clone per run (cage-match #114, Maxwell F2 + Carnot). on-box =
- * same filesystem, so a direct rm suffices; if chown handed the dir to the cage
- * uid (1000) in sticky /tmp the healer user (1002) may be unable to remove it —
- * tolerated, since it's a leak not a vuln and the dir is a shallow throwaway. */
+/** Best-effort removal of a finished cage's host clone dir, so the workroot
+ * doesn't accumulate one clone per run (cage-match #114, Maxwell F2 + Carnot).
+ * The clone lives under a non-sticky, healer-owned workroot (see CLONE_SCRIPT),
+ * so even when chown hands the dir to the cage uid (1000) the healer (1002) can
+ * still unlink it — unlink permission comes from WRITE on the non-sticky parent,
+ * not file ownership. The try/catch stays as a belt-and-braces backstop. */
 function cleanupWorkdir(dir) {
   if (!dir) return;
   try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort; see note */ }

--- a/self-healer/src/auto.mjs
+++ b/self-healer/src/auto.mjs
@@ -1,0 +1,281 @@
+// auto.mjs — green-auto: the FOURTH stage of the autonomy roadmap, and the first
+// that runs the "monster" — a codegen agent that writes a fix from a log
+// diagnosis. It is built, wired, and SHIPPED OFF. It does not act until an
+// operator provisions every gate below.
+//
+// "Build the cage before you spawn the monster." The cage already exists
+// (cage/run-cage.mjs → cage/cage.mjs → egress-proxy, proven by
+// cage/escape-probe.sh). This orchestrator's only job is to ROUTE each eligible
+// finding through that proven cage — never to bypass it — and to enforce the one
+// boundary the OS cage can't: that the agent's GitHub authority is bounded to the
+// single target repo.
+//
+// FIVE INDEPENDENT GATES, each fail-CLOSED, all required before a single spawn:
+//   1. HEALER_GREEN_AUTO=1            — the feature is OFF by default.
+//   2. on-box (isOnBox())            — the cage is a box-local Docker primitive;
+//      a remote dev run has no daemon to cage into, so refuse rather than pretend.
+//   3. bounded authority             — a DEDICATED repo-scoped token
+//      (HEALER_GREEN_AUTO_TOKEN) that is DISTINCT from the healer's broad host
+//      token. This is the ENFORCED form of cage/README.md's "Credential scope"
+//      contract ("the token handed to the agent MUST be scoped to the one target
+//      repo"): a prose gate, upgraded to a runtime valve. We refuse to hand an
+//      injectable agent the keys to the whole org.
+//   4. cage substrate provisioned    — image / internal network / egress proxy
+//      all named in env; a missing one means the escape probe hasn't been wired,
+//      so there is no proven cage to spawn into.
+//   5. an agent command              — HEALER_CAGE_AGENT_CMD, the codegen
+//      entrypoint. Unset by default; the "monster" is operator-installed, never
+//      hardcoded here.
+//
+// The per-finding loop reuses green-draft's machinery verbatim: the SAME
+// actionable-finding filter, the SAME fingerprint, and the SAME single-box
+// owner-fenced lock (acquireDraftLock/releaseDraftLock) — so a green-draft run
+// and a green-auto run on one box never contend on the same finding, and the two
+// stages agree on "what is actionable" by construction.
+//
+// What this orchestrator deliberately does NOT do: open the PR, merge, or deploy.
+// Those happen (eventually) INSIDE/after the caged agent, bounded by the
+// repo-scoped token and the cage-match on the resulting PR — not by this module.
+// The orchestrator's outcome reports the CAGE RUN, never a merged fix.
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { actionableFindings, findingFingerprint, acquireDraftLock, releaseDraftLock } from './draft.mjs';
+import { repoForContainer } from './repos.mjs';
+import { runOnHostScript, isOnBox } from './host.mjs';
+import { scrubSecrets } from './notify.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** The one spawn door. green-auto and the escape probe share it so the
+ * confinement flags green-auto runs are byte-identical to the ones the probe
+ * proved (run-cage.mjs's "no drift" guarantee). */
+export const RUN_CAGE_PATH = join(HERE, '..', 'cage', 'run-cage.mjs');
+
+/** The healer's BROAD host token (same precedence draft.mjs uses for the GH
+ * API). green-auto must never hand THIS to the caged agent. */
+function broadHostToken(env) {
+  return env.HEALER_GH_TOKEN || env.GITHUB_TOKEN || env.GH_TOKEN || null;
+}
+
+/**
+ * Gate 3 — the bounded-authority valve. Returns the repo-scoped token to hand
+ * the cage, or a refusal reason. PURE (env in, decision out) so it's asserted in
+ * CI without spawning anything.
+ *
+ * ENFORCED: HEALER_GREEN_AUTO_TOKEN must be set AND distinct from the broad host
+ * token. NAMED RESIDUAL (cage/README.md "Credential scope"): this structurally
+ * guarantees a *dedicated* token, not the healer's org-wide one — it does NOT by
+ * itself prove the token is fine-grained-scoped to exactly one repo. That
+ * narrowing is the operator's provisioning responsibility (a fine-grained PAT /
+ * App installation token for the single target repo); a control-repo reachability
+ * probe to verify the bound online is tracked as follow-up. The hard gate here is
+ * "never the broad token"; the fine-grain is disciplined-not-enforced and stated.
+ * @returns {{ok: true, token: string} | {ok: false, reason: string}}
+ */
+export function boundedAuthority(env = process.env) {
+  const bound = env.HEALER_GREEN_AUTO_TOKEN;
+  if (!bound) {
+    return { ok: false, reason: 'no repo-scoped token: set HEALER_GREEN_AUTO_TOKEN to a token scoped to ONLY the target repo' };
+  }
+  const broad = broadHostToken(env);
+  if (broad && bound === broad) {
+    return { ok: false, reason: 'HEALER_GREEN_AUTO_TOKEN must be DISTINCT from the broad host token (a repo-scoped token, not the healer’s own org-wide one)' };
+  }
+  return { ok: true, token: bound };
+}
+
+/**
+ * Gate 4+5 — the cage substrate + agent command, read from env. A missing value
+ * is a refusal (fail closed): without the proven images/network/proxy there is no
+ * cage to spawn into, and without an agent command there is nothing to run.
+ * PURE. @returns {{ok: true, image, network, proxyUrl, agentCmd} | {ok: false, reason}}
+ */
+export function cageSubstrate(env = process.env) {
+  const image = env.HEALER_CAGE_IMAGE;
+  const network = env.HEALER_CAGE_NETWORK;
+  const proxyUrl = env.HEALER_CAGE_PROXY_URL;
+  const agentCmd = env.HEALER_CAGE_AGENT_CMD; // the codegen "monster"; operator-installed
+  const missing = [];
+  if (!image) missing.push('HEALER_CAGE_IMAGE');
+  if (!network) missing.push('HEALER_CAGE_NETWORK');
+  if (!proxyUrl) missing.push('HEALER_CAGE_PROXY_URL');
+  if (!agentCmd) missing.push('HEALER_CAGE_AGENT_CMD');
+  if (missing.length) return { ok: false, reason: `cage substrate not provisioned: ${missing.join(', ')}` };
+  return { ok: true, image, network, proxyUrl, agentCmd };
+}
+
+/** Scrub secrets out of (attacker-influenceable) log-derived text and length-cap
+ * it before it becomes the caged agent's task context. The agent is caged
+ * regardless, but a host secret must not ride into the container env even so. */
+function safeContext(x, max) {
+  const s = scrubSecrets(String(x ?? ''));
+  return s.length > max ? s.slice(0, max) + ' …(truncated)' : s;
+}
+
+/**
+ * PURE: build the `node run-cage.mjs -- <agentCmd>` spawn for one finding —
+ * argv + the env that run-cage.mjs forwards INTO the cage. Exported so a test can
+ * assert, without Docker, that (a) the bounded token rides in as CAGE_GH_TOKEN,
+ * (b) the broad host token NEVER does, (c) the finding context is scrubbed, and
+ * (d) the spawn routes through run-cage.mjs (not a raw `docker run`).
+ *
+ * run-cage.mjs forwards a BOUNDED allowlist into the container: CAGE_GH_TOKEN →
+ * GH_TOKEN/GITHUB_TOKEN, every CAGE_AGENT_* var, and HOME=/work (the writable-HOME
+ * residual cage/README.md assigns to the orchestrator). Nothing else crosses.
+ */
+export function buildRunCageSpawn({ finding, repo, workdirHost, token, substrate, runCagePath = RUN_CAGE_PATH }) {
+  const fp = findingFingerprint(finding);
+  const env = {
+    CAGE_IMAGE: substrate.image,
+    CAGE_NETWORK: substrate.network,
+    CAGE_WORKDIR: workdirHost,
+    CAGE_PROXY_URL: substrate.proxyUrl,
+    CAGE_NAME: `healer-green-auto-${fp.slice(0, 12)}`,
+    // The bounded repo-scoped token. run-cage.mjs maps this to GH_TOKEN/GITHUB_TOKEN
+    // INSIDE the cage; the broad host token is never referenced here.
+    CAGE_GH_TOKEN: token,
+    // Finding context for the agent, scrubbed + capped (it is log-derived =
+    // attacker-influenceable). run-cage forwards CAGE_AGENT_* into the cage.
+    CAGE_AGENT_REPO: repo,
+    CAGE_AGENT_CONTAINER: safeContext(finding.container, 60),
+    CAGE_AGENT_SIGNATURE: safeContext(finding.signature, 150),
+    CAGE_AGENT_DIAGNOSIS: safeContext(finding.diagnosis, 1000),
+    CAGE_AGENT_PROPOSED_ACTION: safeContext(finding.proposedAction, 500),
+    CAGE_AGENT_FP: fp,
+  };
+  // agentCmd is operator-controlled (trusted env); the agent reads its task from
+  // the CAGE_AGENT_* env, so the command itself carries no untrusted data.
+  const agentArgv = substrate.agentCmd.split(/\s+/).filter(Boolean);
+  const argv = [runCagePath, '--', ...agentArgv];
+  return { bin: process.execPath, argv, env, name: env.CAGE_NAME };
+}
+
+// Fixed host script: clone the target repo into a FRESH throwaway dir and make it
+// writable by the cage uid (the host user is 1002, the cage forces 1000). Untrusted
+// values arrive as base64 positionals ($1 repo, $2 token, $3 uid:gid) decoded
+// on-box — the injection-safe host primitive (see host.mjs buildHostScriptArgv).
+// The token never touches argv: it is handed to git via a transient GIT_ASKPASS
+// helper that echoes it from the process env, then removed. Only the workdir path
+// is printed to stdout; all git chatter goes to stderr.
+const CLONE_SCRIPT = [
+  'set -euo pipefail',
+  'repo=$(printf %s "$1" | base64 -d)',
+  'tok=$(printf %s "$2" | base64 -d)',
+  'ug=$(printf %s "$3" | base64 -d)',
+  'dir=$(mktemp -d /tmp/healer-green-auto.XXXXXX)',
+  'askpass=$(mktemp /tmp/healer-askpass.XXXXXX)',
+  "printf '#!/bin/sh\\nprintf %%s \"$HEALER_CLONE_TOKEN\"\\n' > \"$askpass\"",
+  'chmod 0700 "$askpass"',
+  'if ! HEALER_CLONE_TOKEN="$tok" GIT_ASKPASS="$askpass" GIT_TERMINAL_PROMPT=0 \\',
+  '     git clone --depth 1 "https://x-access-token@github.com/$repo" "$dir" 1>&2; then',
+  '  rm -f "$askpass"; rm -rf "$dir"; exit 4',
+  'fi',
+  'rm -f "$askpass"',
+  // Make the clone writable by the cage uid. chown needs privilege; fall back to
+  // a world-writable throwaway (the dir is ephemeral and host-isolated) so the
+  // cage uid can write even where the deploy user can't chown.
+  'chown -R "$ug" "$dir" 2>/dev/null || chmod -R 0777 "$dir"',
+  'printf %s "$dir"',
+].join('\n');
+
+/** Cage uid:gid the fresh clone must be writable by (matches cage.mjs CAGE_UID_GID). */
+const CAGE_UID_GID = '1000:1000';
+
+/** Prepare a fresh, cage-writable clone of `repo`; returns its host path. Throws
+ * on failure so the caller fails closed (no spawn against a missing workdir). */
+async function prepareWorkdir(repo, token) {
+  const { stdout, stderr, code } = await runOnHostScript(CLONE_SCRIPT, [repo, token, CAGE_UID_GID], { timeoutMs: 120_000 });
+  const dir = stdout.trim();
+  if (code !== 0 || !dir) {
+    throw new Error(`workdir clone failed (code ${code}): ${stderr.trim().slice(0, 200)}`);
+  }
+  return dir;
+}
+
+/** Spawn `node run-cage.mjs -- <agentCmd>` for one finding; resolve its exit code.
+ * stdio inherited so the caged agent's output reaches the healer's logs. */
+function spawnCage({ bin, argv, env }) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(bin, argv, { stdio: 'inherit', env: { ...process.env, ...env } });
+    proc.on('error', reject);
+    proc.on('exit', (code, signal) => resolve(signal ? `signal:${signal}` : (code ?? -1)));
+  });
+}
+
+/**
+ * For every confident-green, actionable finding, run a CAGED remediation agent
+ * routed through run-cage.mjs. NO-OP (empty list) when the feature flag is off;
+ * a single refusal outcome when any global gate (on-box / bounded-authority /
+ * substrate) is unmet — spawning NOTHING. Returns a per-finding outcome list.
+ *
+ * Mirrors draft.mjs's draftIfActionable: same filter, same fingerprint, same
+ * owner-fenced lock, same fail-closed posture, same {container, action, detail}
+ * outcome shape — green-auto is green-draft with the cage swapped in for the
+ * GitHub-issue POST.
+ *
+ * @param {{findings: object[]}} verdict
+ * @param {object} [env]
+ * @returns {Promise<Array<{container: string, action: string, detail?: string, workdir?: string, exitCode?: number|string}>>}
+ */
+export async function autoFixIfActionable(verdict, env = process.env) {
+  // Gate 1: OFF by default.
+  if (env.HEALER_GREEN_AUTO !== '1') return [];
+
+  // Gate 2: the cage is a box-local Docker primitive — refuse remote runs.
+  if (!isOnBox()) {
+    return [{ container: '*', action: 'refused', detail: 'green-auto runs on-box only (the cage is a host-local Docker primitive); unset HEALER_HOST to run on the box' }];
+  }
+
+  // Gate 3: bounded authority — a dedicated repo-scoped token, never the broad one.
+  const auth = boundedAuthority(env);
+  if (!auth.ok) return [{ container: '*', action: 'refused', detail: auth.reason }];
+
+  // Gate 4+5: the proven cage substrate + the agent command.
+  const sub = cageSubstrate(env);
+  if (!sub.ok) return [{ container: '*', action: 'refused', detail: sub.reason }];
+
+  const outcomes = [];
+  for (const f of actionableFindings(verdict)) {
+    const repo = repoForContainer(f.container);
+    if (!repo) {
+      outcomes.push({ container: f.container, action: 'skipped', detail: 'no known source repo' });
+      continue;
+    }
+    const fp = findingFingerprint(f);
+
+    // Same single-box owner-fenced lock as green-draft: a concurrent draft or
+    // auto run on this box can't act on the same finding twice. null = another
+    // live run owns it (skip); an UNEXPECTED lock error throws → fail closed.
+    let lockTok = null;
+    try {
+      lockTok = acquireDraftLock(fp);
+    } catch (err) {
+      outcomes.push({ container: f.container, action: 'failed', detail: `lock error (fail-closed): ${err.message}` });
+      continue;
+    }
+    if (!lockTok) {
+      outcomes.push({ container: f.container, action: 'deduped', detail: `concurrent run owns lock (fp ${fp.slice(0, 12)}…)` });
+      continue;
+    }
+
+    try {
+      const workdirHost = await prepareWorkdir(repo, auth.token);
+      const spawnSpec = buildRunCageSpawn({ finding: f, repo, workdirHost, token: auth.token, substrate: sub });
+      const exitCode = await spawnCage(spawnSpec);
+      outcomes.push({
+        container: f.container,
+        action: exitCode === 0 ? 'caged' : 'failed',
+        detail: exitCode === 0 ? `cage exited clean (fp ${fp.slice(0, 12)}…)` : `cage exited ${exitCode}`,
+        workdir: workdirHost,
+        exitCode,
+      });
+    } catch (err) {
+      // A clone failure or spawn error lands here → we did NOT run the agent.
+      outcomes.push({ container: f.container, action: 'failed', detail: err.message });
+    } finally {
+      releaseDraftLock(fp, lockTok);
+    }
+  }
+  return outcomes;
+}

--- a/self-healer/src/auto.mjs
+++ b/self-healer/src/auto.mjs
@@ -29,9 +29,13 @@
 //
 // The per-finding loop reuses green-draft's machinery verbatim: the SAME
 // actionable-finding filter, the SAME fingerprint, and the SAME single-box
-// owner-fenced lock (acquireDraftLock/releaseDraftLock) — so a green-draft run
-// and a green-auto run on one box never contend on the same finding, and the two
-// stages agree on "what is actionable" by construction.
+// owner-fenced lock (acquireDraftLock/releaseDraftLock) — so two CONCURRENT healer
+// PROCESSES on one box never act on the same finding twice, and the two stages
+// agree on "what is actionable" by construction. NOTE: the lock is concurrent-
+// process exclusion, NOT draft-vs-auto mutual exclusion: healer.mjs runs draft to
+// completion THEN auto, each acquiring+releasing per finding, so with BOTH flags
+// on a single run files an issue AND runs the caged agent for the same finding
+// (by design — the issue documents what the agent is fixing).
 //
 // What this orchestrator deliberately does NOT do: open the PR, merge, or deploy.
 // Those happen (eventually) INSIDE/after the caged agent, bounded by the
@@ -171,19 +175,36 @@ export function buildRunCageSpawn({ finding, repo, workdirHost, token, substrate
 }
 
 // Fixed host script: clone the target repo into a FRESH throwaway dir and make it
-// writable by the cage uid (the host user is 1002, the cage forces 1000). Untrusted
-// values arrive as base64 positionals ($1 repo, $2 token, $3 uid:gid) decoded
+// writable by the cage uid (the host user is 1002, the cage forces 1000). The
+// non-secret values arrive as base64 positionals ($1 repo, $2 uid:gid) decoded
 // on-box — the injection-safe host primitive (see host.mjs buildHostScriptArgv).
-// The token never touches argv: it is handed to git via a transient GIT_ASKPASS
-// helper that echoes it from the process env, then removed. Only the workdir path
-// is printed to stdout; all git chatter goes to stderr.
-const CLONE_SCRIPT = [
+//
+// The TOKEN arrives on STDIN, never as a positional (cage-match #114, Maxwell F1
+// + Carnot HIGH): base64 is reversible, so a positional token would sit decodable
+// in the host process argv (`ps` / /proc/<pid>/cmdline, world-readable by default)
+// for the clone's duration — the exact `token not in argv` property the cage-spawn
+// step (run-cage.mjs key-only `-e`) is built to hold. stdin is a pipe: invisible
+// to the process table, and ssh forwards it on the remote path. git reads it via a
+// transient GIT_ASKPASS helper, then it's removed. Only the workdir path is printed
+// to stdout; all git chatter goes to stderr.
+export const CLONE_SCRIPT = [
   'set -euo pipefail',
   'repo=$(printf %s "$1" | base64 -d)',
-  'tok=$(printf %s "$2" | base64 -d)',
-  'ug=$(printf %s "$3" | base64 -d)',
-  'dir=$(mktemp -d /tmp/healer-green-auto.XXXXXX)',
-  'askpass=$(mktemp /tmp/healer-askpass.XXXXXX)',
+  'ug=$(printf %s "$2" | base64 -d)',
+  // The repo-scoped token, read from stdin (see header). $(cat) consumes the whole
+  // pipe and strips a trailing newline, so a sloppily-sourced token is sanitized.
+  'tok=$(cat)',
+  // Clone under a HEALER-OWNED, non-sticky workroot — NOT bare /tmp, which is
+  // sticky. In a sticky dir only the file's owner may unlink it, so if the clone
+  // is chowned to the cage uid (1000) the healer (1002) could no longer remove it
+  // → a systematic leak of shallow clones (cage-match #114, Carnot HIGH). In a
+  // non-sticky, healer-owned parent, unlink permission comes from WRITE on the
+  // parent dir, not file ownership, so cleanupWorkdir always succeeds regardless
+  // of the chown. mkdir -p is idempotent; the healer owns the workroot it creates.
+  'workroot="${HEALER_GREEN_AUTO_WORKROOT:-/tmp/self-healer-green-auto}"',
+  'mkdir -p "$workroot"',
+  'dir=$(mktemp -d "$workroot/clone.XXXXXX")',
+  'askpass=$(mktemp "$workroot/askpass.XXXXXX")',
   "printf '#!/bin/sh\\nprintf %%s \"$HEALER_CLONE_TOKEN\"\\n' > \"$askpass\"",
   'chmod 0700 "$askpass"',
   'if ! HEALER_CLONE_TOKEN="$tok" GIT_ASKPASS="$askpass" GIT_TERMINAL_PROMPT=0 \\',
@@ -193,7 +214,8 @@ const CLONE_SCRIPT = [
   'rm -f "$askpass"',
   // Make the clone writable by the cage uid. chown needs privilege; fall back to
   // a world-writable throwaway (the dir is ephemeral and host-isolated) so the
-  // cage uid can write even where the deploy user can't chown.
+  // cage uid can write even where the deploy user can't chown. Either way the
+  // non-sticky workroot above keeps the dir removable by the healer.
   'chown -R "$ug" "$dir" 2>/dev/null || chmod -R 0777 "$dir"',
   'printf %s "$dir"',
 ].join('\n');
@@ -207,7 +229,9 @@ const CAGE_UID_GID = '1000:1000';
  * throw path leaves nothing behind. A SUCCESSFUL clone's dir is the caller's to
  * remove — see cleanupWorkdir. */
 async function prepareWorkdir(repo, token) {
-  const { stdout, stderr, code } = await runOnHostScript(CLONE_SCRIPT, [repo, token, CAGE_UID_GID], { timeoutMs: 120_000 });
+  // Token via stdin (NOT a positional) so it never lands in host argv/`ps`; repo +
+  // uid:gid are non-secret and ride as base64 positionals (cage-match #114).
+  const { stdout, stderr, code } = await runOnHostScript(CLONE_SCRIPT, [repo, CAGE_UID_GID], { stdin: token, timeoutMs: 120_000 });
   const dir = stdout.trim();
   if (code !== 0 || !dir) {
     throw new Error(`workdir clone failed (code ${code}): ${stderr.trim().slice(0, 200)}`);
@@ -255,7 +279,8 @@ export async function autoFixIfActionable(verdict, env = process.env) {
   if (env.HEALER_GREEN_AUTO !== '1') return [];
 
   // Gate 2: the cage is a box-local Docker primitive — refuse remote runs.
-  if (!isOnBox()) {
+  // Evaluate against the SAME `env` as the other gates (cage-match #114, Carnot).
+  if (!isOnBox(env)) {
     return [{ container: '*', action: AUTO_ACTIONS.REFUSED, detail: 'green-auto runs on-box only (the cage is a host-local Docker primitive); unset HEALER_HOST to run on the box' }];
   }
 

--- a/self-healer/src/auto.mjs
+++ b/self-healer/src/auto.mjs
@@ -39,6 +39,7 @@
 // The orchestrator's outcome reports the CAGE RUN, never a merged fix.
 
 import { spawn } from 'node:child_process';
+import { rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { actionableFindings, findingFingerprint, acquireDraftLock, releaseDraftLock } from './draft.mjs';
@@ -52,10 +53,25 @@ const HERE = dirname(fileURLToPath(import.meta.url));
  * proved (run-cage.mjs's "no drift" guarantee). */
 export const RUN_CAGE_PATH = join(HERE, '..', 'cage', 'run-cage.mjs');
 
-/** The healer's BROAD host token (same precedence draft.mjs uses for the GH
- * API). green-auto must never hand THIS to the caged agent. */
-function broadHostToken(env) {
-  return env.HEALER_GH_TOKEN || env.GITHUB_TOKEN || env.GH_TOKEN || null;
+/** The closed set of per-finding outcome actions. Frozen so the values are a
+ * compile-checkable closed set (the same discipline tiers.mjs uses), not ad-hoc
+ * string literals scattered through the loop (cage-match #114, Carnot). */
+export const AUTO_ACTIONS = Object.freeze({
+  REFUSED: 'refused', // a global gate (on-box / authority / substrate) was unmet — spawned nothing
+  SKIPPED: 'skipped', // this finding has no known source repo
+  DEDUPED: 'deduped', // a concurrent run owns the finding's lock
+  CAGED: 'caged', // the cage ran and exited clean
+  FAILED: 'failed', // clone/spawn error, lock error, or non-zero cage exit
+});
+
+/** EVERY broad host token currently in the env (the healer's own GH-API creds,
+ * any of the three names draft.mjs accepts). The bound green-auto token must
+ * equal NONE of them — checking only the first (a `A || B || C` short-circuit)
+ * was a real hole: with HEALER_GH_TOKEN=a AND GITHUB_TOKEN=b both set, a bound
+ * token of `b` would slip past a first-only check and get forwarded into the
+ * cage (cage-match #114, Carnot). A closed-set check must inspect the WHOLE set. */
+function broadHostTokens(env) {
+  return [env.HEALER_GH_TOKEN, env.GITHUB_TOKEN, env.GH_TOKEN].filter(Boolean);
 }
 
 /**
@@ -78,9 +94,8 @@ export function boundedAuthority(env = process.env) {
   if (!bound) {
     return { ok: false, reason: 'no repo-scoped token: set HEALER_GREEN_AUTO_TOKEN to a token scoped to ONLY the target repo' };
   }
-  const broad = broadHostToken(env);
-  if (broad && bound === broad) {
-    return { ok: false, reason: 'HEALER_GREEN_AUTO_TOKEN must be DISTINCT from the broad host token (a repo-scoped token, not the healer’s own org-wide one)' };
+  if (broadHostTokens(env).includes(bound)) {
+    return { ok: false, reason: 'HEALER_GREEN_AUTO_TOKEN must be DISTINCT from EVERY broad host token (HEALER_GH_TOKEN / GITHUB_TOKEN / GH_TOKEN) — a repo-scoped token, not the healer’s own org-wide one' };
   }
   return { ok: true, token: bound };
 }
@@ -145,7 +160,11 @@ export function buildRunCageSpawn({ finding, repo, workdirHost, token, substrate
     CAGE_AGENT_FP: fp,
   };
   // agentCmd is operator-controlled (trusted env); the agent reads its task from
-  // the CAGE_AGENT_* env, so the command itself carries no untrusted data.
+  // the CAGE_AGENT_* env, so the command itself carries no untrusted data. NOTE:
+  // this whitespace split is quote-HOSTILE — it can't express an arg containing a
+  // space (`-p "fix the bug"`). That's fine because the task rides in env, not
+  // argv; if a future agent needs spaced args, switch to a JSON-argv env var
+  // rather than teaching this a shell-quoting grammar (cage-match #114).
   const agentArgv = substrate.agentCmd.split(/\s+/).filter(Boolean);
   const argv = [runCagePath, '--', ...agentArgv];
   return { bin: process.execPath, argv, env, name: env.CAGE_NAME };
@@ -183,7 +202,10 @@ const CLONE_SCRIPT = [
 const CAGE_UID_GID = '1000:1000';
 
 /** Prepare a fresh, cage-writable clone of `repo`; returns its host path. Throws
- * on failure so the caller fails closed (no spawn against a missing workdir). */
+ * on failure so the caller fails closed (no spawn against a missing workdir). The
+ * clone script itself cleans up after a FAILED clone (rm dir + askpass); this
+ * throw path leaves nothing behind. A SUCCESSFUL clone's dir is the caller's to
+ * remove — see cleanupWorkdir. */
 async function prepareWorkdir(repo, token) {
   const { stdout, stderr, code } = await runOnHostScript(CLONE_SCRIPT, [repo, token, CAGE_UID_GID], { timeoutMs: 120_000 });
   const dir = stdout.trim();
@@ -191,6 +213,16 @@ async function prepareWorkdir(repo, token) {
     throw new Error(`workdir clone failed (code ${code}): ${stderr.trim().slice(0, 200)}`);
   }
   return dir;
+}
+
+/** Best-effort removal of a finished cage's host clone dir, so /tmp doesn't
+ * accumulate one clone per run (cage-match #114, Maxwell F2 + Carnot). on-box =
+ * same filesystem, so a direct rm suffices; if chown handed the dir to the cage
+ * uid (1000) in sticky /tmp the healer user (1002) may be unable to remove it —
+ * tolerated, since it's a leak not a vuln and the dir is a shallow throwaway. */
+function cleanupWorkdir(dir) {
+  if (!dir) return;
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort; see note */ }
 }
 
 /** Spawn `node run-cage.mjs -- <agentCmd>` for one finding; resolve its exit code.
@@ -224,22 +256,22 @@ export async function autoFixIfActionable(verdict, env = process.env) {
 
   // Gate 2: the cage is a box-local Docker primitive — refuse remote runs.
   if (!isOnBox()) {
-    return [{ container: '*', action: 'refused', detail: 'green-auto runs on-box only (the cage is a host-local Docker primitive); unset HEALER_HOST to run on the box' }];
+    return [{ container: '*', action: AUTO_ACTIONS.REFUSED, detail: 'green-auto runs on-box only (the cage is a host-local Docker primitive); unset HEALER_HOST to run on the box' }];
   }
 
   // Gate 3: bounded authority — a dedicated repo-scoped token, never the broad one.
   const auth = boundedAuthority(env);
-  if (!auth.ok) return [{ container: '*', action: 'refused', detail: auth.reason }];
+  if (!auth.ok) return [{ container: '*', action: AUTO_ACTIONS.REFUSED, detail: auth.reason }];
 
   // Gate 4+5: the proven cage substrate + the agent command.
   const sub = cageSubstrate(env);
-  if (!sub.ok) return [{ container: '*', action: 'refused', detail: sub.reason }];
+  if (!sub.ok) return [{ container: '*', action: AUTO_ACTIONS.REFUSED, detail: sub.reason }];
 
   const outcomes = [];
   for (const f of actionableFindings(verdict)) {
     const repo = repoForContainer(f.container);
     if (!repo) {
-      outcomes.push({ container: f.container, action: 'skipped', detail: 'no known source repo' });
+      outcomes.push({ container: f.container, action: AUTO_ACTIONS.SKIPPED, detail: 'no known source repo' });
       continue;
     }
     const fp = findingFingerprint(f);
@@ -251,29 +283,31 @@ export async function autoFixIfActionable(verdict, env = process.env) {
     try {
       lockTok = acquireDraftLock(fp);
     } catch (err) {
-      outcomes.push({ container: f.container, action: 'failed', detail: `lock error (fail-closed): ${err.message}` });
+      outcomes.push({ container: f.container, action: AUTO_ACTIONS.FAILED, detail: `lock error (fail-closed): ${err.message}` });
       continue;
     }
     if (!lockTok) {
-      outcomes.push({ container: f.container, action: 'deduped', detail: `concurrent run owns lock (fp ${fp.slice(0, 12)}…)` });
+      outcomes.push({ container: f.container, action: AUTO_ACTIONS.DEDUPED, detail: `concurrent run owns lock (fp ${fp.slice(0, 12)}…)` });
       continue;
     }
 
+    let workdirHost = null;
     try {
-      const workdirHost = await prepareWorkdir(repo, auth.token);
+      workdirHost = await prepareWorkdir(repo, auth.token);
       const spawnSpec = buildRunCageSpawn({ finding: f, repo, workdirHost, token: auth.token, substrate: sub });
       const exitCode = await spawnCage(spawnSpec);
       outcomes.push({
         container: f.container,
-        action: exitCode === 0 ? 'caged' : 'failed',
+        action: exitCode === 0 ? AUTO_ACTIONS.CAGED : AUTO_ACTIONS.FAILED,
         detail: exitCode === 0 ? `cage exited clean (fp ${fp.slice(0, 12)}…)` : `cage exited ${exitCode}`,
         workdir: workdirHost,
         exitCode,
       });
     } catch (err) {
       // A clone failure or spawn error lands here → we did NOT run the agent.
-      outcomes.push({ container: f.container, action: 'failed', detail: err.message });
+      outcomes.push({ container: f.container, action: AUTO_ACTIONS.FAILED, detail: err.message });
     } finally {
+      cleanupWorkdir(workdirHost); // the cage is --rm; the host clone is not
       releaseDraftLock(fp, lockTok);
     }
   }

--- a/self-healer/src/healer.mjs
+++ b/self-healer/src/healer.mjs
@@ -18,6 +18,7 @@ import { isOnBox } from './host.mjs';
 import { tierExitCode } from './tiers.mjs';
 import { pingIfNoteworthy } from './notify.mjs';
 import { draftIfActionable } from './draft.mjs';
+import { autoFixIfActionable } from './auto.mjs';
 
 /**
  * Load + validate the watch list. Fails CLOSED on a malformed config so a bad
@@ -121,6 +122,20 @@ async function main() {
     }
   } catch (err) {
     process.stderr.write(`[healer] green-draft FAILED (verdict still stands): ${err.message}\n`);
+  }
+
+  // green-auto: the FIRST stage that runs a codegen agent, fully caged. SHIPPED
+  // OFF (HEALER_GREEN_AUTO=1) and additionally gated on on-box + a repo-scoped
+  // token + a provisioned cage + an agent command — it spawns NOTHING until an
+  // operator wires all five. Like the ping/draft, a failure here must not change
+  // the diagnostic exit code (the verdict stands either way).
+  try {
+    const outcomes = await autoFixIfActionable(verdict);
+    for (const o of outcomes) {
+      process.stderr.write(`[healer] green-auto ${o.action}: ${o.container}${o.workdir ? ` [${o.workdir}]` : ''}${o.detail ? ` (${o.detail})` : ''}\n`);
+    }
+  } catch (err) {
+    process.stderr.write(`[healer] green-auto FAILED (verdict still stands): ${err.message}\n`);
   }
 
   // Exit code communicates tier to a cron/monitor without parsing JSON.

--- a/self-healer/src/host.mjs
+++ b/self-healer/src/host.mjs
@@ -164,7 +164,10 @@ export function runOnHostScript(fixedScript, args = [], { stdin, timeoutMs = 70_
   return spawnBuffered(bin, argv, { stdin, timeoutMs, label: fixedScript });
 }
 
-/** True when we're running directly on the OCI box (no SSH hop). */
-export function isOnBox() {
-  return !process.env.HEALER_HOST;
+/** True when we're running directly on the OCI box (no SSH hop). Takes an explicit
+ * `env` so a caller (e.g. green-auto's gate 2) evaluates on-box-ness against the
+ * SAME env object as its other gates, rather than silently reading process.env out
+ * from under a passed env (cage-match #114, Carnot — fail closed against one env). */
+export function isOnBox(env = process.env) {
+  return !env.HEALER_HOST;
 }

--- a/self-healer/test/auto.test.mjs
+++ b/self-healer/test/auto.test.mjs
@@ -1,0 +1,169 @@
+// auto.test.mjs — green-auto orchestrator gating + spawn-shape.
+//
+// green-auto is the first stage that runs a codegen agent, so the SECURITY-
+// relevant surface is the gates: it must spawn NOTHING unless the feature flag,
+// on-box, a DISTINCT repo-scoped token, the cage substrate, and an agent command
+// are ALL present — and when it does spawn, the bounded token (never the broad
+// host token) must ride into the cage and the route must go through run-cage.mjs.
+//
+// The pure decision/builder functions are the testable surface (the live cage
+// proof is cage/escape-probe.sh on the box, exactly as cage.mjs's real proof is).
+// Every test isolates env so a real HEALER_* in the shell can't leak in.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  boundedAuthority,
+  cageSubstrate,
+  buildRunCageSpawn,
+  autoFixIfActionable,
+  RUN_CAGE_PATH,
+} from '../src/auto.mjs';
+
+/** Run `fn` with a fully-cleared green-auto/cage env, restoring after. */
+function withEnv(overrides, fn) {
+  const keys = [
+    'HEALER_GREEN_AUTO', 'HEALER_GREEN_AUTO_TOKEN', 'HEALER_HOST',
+    'HEALER_GH_TOKEN', 'GITHUB_TOKEN', 'GH_TOKEN',
+    'HEALER_CAGE_IMAGE', 'HEALER_CAGE_NETWORK', 'HEALER_CAGE_PROXY_URL', 'HEALER_CAGE_AGENT_CMD',
+  ];
+  const saved = {};
+  for (const k of keys) { saved[k] = process.env[k]; delete process.env[k]; }
+  Object.assign(process.env, overrides);
+  try { return fn(); }
+  finally {
+    for (const k of keys) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+  }
+}
+
+const greenFinding = (over = {}) => ({
+  container: 'embodied-dreamfinder', // mapped in repos.mjs
+  tier: 'green',
+  confidence: 'high',
+  signature: 'null deref on empty transcript',
+  diagnosis: 'guard the empty case',
+  proposedAction: 'add a null-guard before indexing',
+  ...over,
+});
+
+// ── Gate 3: bounded authority ────────────────────────────────────────────────
+
+test('boundedAuthority: refuses when no repo-scoped token is set', () => {
+  const r = boundedAuthority({});
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /HEALER_GREEN_AUTO_TOKEN/);
+});
+
+test('boundedAuthority: accepts a token distinct from the broad host token', () => {
+  const r = boundedAuthority({ HEALER_GREEN_AUTO_TOKEN: 'repo-scoped-xyz', HEALER_GH_TOKEN: 'broad-abc' });
+  assert.equal(r.ok, true);
+  assert.equal(r.token, 'repo-scoped-xyz');
+});
+
+test('boundedAuthority: REFUSES when the bound token equals the broad host token', () => {
+  // The whole point: never hand the agent the healer’s org-wide token.
+  for (const broadKey of ['HEALER_GH_TOKEN', 'GITHUB_TOKEN', 'GH_TOKEN']) {
+    const r = boundedAuthority({ HEALER_GREEN_AUTO_TOKEN: 'same-tok', [broadKey]: 'same-tok' });
+    assert.equal(r.ok, false, `must refuse when bound == ${broadKey}`);
+    assert.match(r.reason, /DISTINCT/);
+  }
+});
+
+// ── Gate 4+5: cage substrate ─────────────────────────────────────────────────
+
+test('cageSubstrate: names every missing var and fails closed', () => {
+  const r = cageSubstrate({});
+  assert.equal(r.ok, false);
+  for (const v of ['HEALER_CAGE_IMAGE', 'HEALER_CAGE_NETWORK', 'HEALER_CAGE_PROXY_URL', 'HEALER_CAGE_AGENT_CMD']) {
+    assert.match(r.reason, new RegExp(v), `reason should name ${v}`);
+  }
+});
+
+test('cageSubstrate: ok when all provisioned', () => {
+  const r = cageSubstrate({
+    HEALER_CAGE_IMAGE: 'agent:1', HEALER_CAGE_NETWORK: 'cage-internal',
+    HEALER_CAGE_PROXY_URL: 'http://proxy:3128', HEALER_CAGE_AGENT_CMD: 'claude -p',
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.agentCmd, 'claude -p');
+});
+
+// ── Pure spawn shape ─────────────────────────────────────────────────────────
+
+test('buildRunCageSpawn: routes through run-cage.mjs and carries the BOUNDED token only', () => {
+  const substrate = { image: 'agent:1', network: 'cage-internal', proxyUrl: 'http://proxy:3128', agentCmd: 'claude -p --headless' };
+  const spec = buildRunCageSpawn({
+    finding: greenFinding(), repo: 'imagineering-cc/embodied-dreamfinder',
+    workdirHost: '/tmp/healer-green-auto.AAA', token: 'repo-scoped-xyz', substrate,
+  });
+
+  // routes through run-cage.mjs (NOT a raw `docker run`), agent argv after `--`
+  assert.equal(spec.argv[0], RUN_CAGE_PATH);
+  assert.equal(spec.argv[1], '--');
+  assert.deepEqual(spec.argv.slice(2), ['claude', '-p', '--headless']);
+
+  // the bounded token rides in; the broad host token name is absent
+  assert.equal(spec.env.CAGE_GH_TOKEN, 'repo-scoped-xyz');
+  assert.equal(spec.env.HEALER_GH_TOKEN, undefined);
+  assert.equal(spec.env.CAGE_WORKDIR, '/tmp/healer-green-auto.AAA');
+  assert.equal(spec.env.CAGE_IMAGE, 'agent:1');
+  assert.equal(spec.env.CAGE_AGENT_REPO, 'imagineering-cc/embodied-dreamfinder');
+
+  // deterministic, fingerprint-derived container name
+  assert.match(spec.name, /^healer-green-auto-[0-9a-f]{12}$/);
+});
+
+test('buildRunCageSpawn: scrubs a secret out of attacker-influenceable finding context', () => {
+  const substrate = { image: 'i', network: 'n', proxyUrl: 'p', agentCmd: 'a' };
+  const spec = buildRunCageSpawn({
+    finding: greenFinding({ diagnosis: 'leak ghp_0123456789012345678901234567890123 oops' }),
+    repo: 'o/r', workdirHost: '/w', token: 't', substrate,
+  });
+  assert.ok(!spec.env.CAGE_AGENT_DIAGNOSIS.includes('ghp_0123456789012345678901234567890123'),
+    'a GitHub PAT in the diagnosis must be scrubbed before it reaches the cage env');
+});
+
+// ── Top-level gating (no spawn) ──────────────────────────────────────────────
+
+test('autoFixIfActionable: OFF by default → empty, spawns nothing', async () => {
+  await withEnv({}, async () => {
+    const out = await autoFixIfActionable({ findings: [greenFinding()] });
+    assert.deepEqual(out, []);
+  });
+});
+
+test('autoFixIfActionable: flag on but remote (HEALER_HOST set) → single refusal, no spawn', async () => {
+  await withEnv({ HEALER_GREEN_AUTO: '1', HEALER_HOST: 'nick@host' }, async () => {
+    const out = await autoFixIfActionable({ findings: [greenFinding()] });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].action, 'refused');
+    assert.match(out[0].detail, /on-box only/);
+  });
+});
+
+test('autoFixIfActionable: on-box + flag on but no bounded token → refusal, no spawn', async () => {
+  await withEnv({ HEALER_GREEN_AUTO: '1' }, async () => {
+    const out = await autoFixIfActionable({ findings: [greenFinding()] });
+    assert.equal(out[0].action, 'refused');
+    assert.match(out[0].detail, /HEALER_GREEN_AUTO_TOKEN/);
+  });
+});
+
+test('autoFixIfActionable: bounded token present but cage substrate missing → refusal, no spawn', async () => {
+  await withEnv({ HEALER_GREEN_AUTO: '1', HEALER_GREEN_AUTO_TOKEN: 'repo-scoped' }, async () => {
+    const out = await autoFixIfActionable({ findings: [greenFinding()] });
+    assert.equal(out[0].action, 'refused');
+    assert.match(out[0].detail, /cage substrate not provisioned/);
+  });
+});
+
+test('autoFixIfActionable: a non-actionable verdict yields no findings even when fully gated', async () => {
+  await withEnv({
+    HEALER_GREEN_AUTO: '1', HEALER_GREEN_AUTO_TOKEN: 'repo-scoped',
+    HEALER_CAGE_IMAGE: 'i', HEALER_CAGE_NETWORK: 'n', HEALER_CAGE_PROXY_URL: 'p', HEALER_CAGE_AGENT_CMD: 'a',
+  }, async () => {
+    // amber finding → not in the green-auto set → empty (gates passed, nothing to do)
+    const out = await autoFixIfActionable({ findings: [greenFinding({ tier: 'amber' })] });
+    assert.deepEqual(out, []);
+  });
+});

--- a/self-healer/test/auto.test.mjs
+++ b/self-healer/test/auto.test.mjs
@@ -18,6 +18,7 @@ import {
   buildRunCageSpawn,
   autoFixIfActionable,
   RUN_CAGE_PATH,
+  CLONE_SCRIPT,
 } from '../src/auto.mjs';
 
 /** Run `fn` with a fully-cleared green-auto/cage env, restoring after. */
@@ -152,6 +153,41 @@ test('autoFixIfActionable: flag on but remote (HEALER_HOST set) → single refus
     assert.equal(out[0].action, 'refused');
     assert.match(out[0].detail, /on-box only/);
   });
+});
+
+test('autoFixIfActionable: gate 2 honors the PASSED env, not process.env (cage-match #114, Carnot)', async () => {
+  // process.env has NO HEALER_HOST (withEnv clears it); HEALER_HOST is supplied
+  // ONLY via the explicit env arg. Before the fix, isOnBox() read process.env and
+  // wrongly passed gate 2 (would have fallen through to the token gate); now
+  // isOnBox(env) reads the SAME env object the other gates use and refuses remote.
+  await withEnv({}, async () => {
+    assert.equal(process.env.HEALER_HOST, undefined); // precondition: not in process.env
+    const out = await autoFixIfActionable(
+      { findings: [greenFinding()] },
+      {
+        HEALER_GREEN_AUTO: '1',
+        HEALER_HOST: 'nick@host', // remote — must trip gate 2 via the passed env
+        HEALER_GREEN_AUTO_TOKEN: 'repo-scoped-xyz',
+        HEALER_CAGE_IMAGE: 'i', HEALER_CAGE_NETWORK: 'n',
+        HEALER_CAGE_PROXY_URL: 'p', HEALER_CAGE_AGENT_CMD: 'a',
+      },
+    );
+    assert.equal(out.length, 1);
+    assert.equal(out[0].action, 'refused');
+    assert.match(out[0].detail, /on-box only/); // the gate-2 refusal, not the token/substrate one
+  });
+});
+
+test('CLONE_SCRIPT: the repo-scoped token rides via STDIN, never a positional arg (cage-match #114)', () => {
+  // The consensus finding: a positional token is base64-decodable in host `ps`.
+  // Lock the fix — token comes from stdin ($(cat)), and only repo ($1) + uid:gid
+  // ($2) are positionals (no $3, which is where the token used to be).
+  assert.match(CLONE_SCRIPT, /tok=\$\(cat\)/); // token from stdin
+  assert.doesNotMatch(CLONE_SCRIPT, /\$3/); // no third positional (token is gone from argv)
+  // And the clone lives under a non-sticky, healer-owned workroot so cleanup can't
+  // leak a chowned dir from sticky /tmp (Carnot HIGH).
+  assert.match(CLONE_SCRIPT, /workroot=/);
+  assert.doesNotMatch(CLONE_SCRIPT, /mktemp -d \/tmp\/healer-green-auto/); // not bare sticky /tmp
 });
 
 test('autoFixIfActionable: on-box + flag on but no bounded token → refusal, no spawn', async () => {

--- a/self-healer/test/auto.test.mjs
+++ b/self-healer/test/auto.test.mjs
@@ -69,6 +69,19 @@ test('boundedAuthority: REFUSES when the bound token equals the broad host token
   }
 });
 
+test('boundedAuthority: refuses when bound matches a NON-FIRST broad token (cage-match #114 regression)', () => {
+  // The Carnot bug: a first-only `A || B || C` check compared the bound token
+  // against HEALER_GH_TOKEN only. With two broad tokens set and the bound token
+  // equal to the SECOND one, the broad token would have slipped into the cage.
+  const r = boundedAuthority({
+    HEALER_GH_TOKEN: 'broad-a',
+    GITHUB_TOKEN: 'broad-b',
+    HEALER_GREEN_AUTO_TOKEN: 'broad-b', // matches the second broad token, not the first
+  });
+  assert.equal(r.ok, false, 'must refuse a bound token equal to ANY present broad token');
+  assert.match(r.reason, /EVERY broad host token/);
+});
+
 // ── Gate 4+5: cage substrate ─────────────────────────────────────────────────
 
 test('cageSubstrate: names every missing var and fails closed', () => {

--- a/self-healer/test/cage.test.mjs
+++ b/self-healer/test/cage.test.mjs
@@ -91,6 +91,30 @@ test('a caller cannot clobber the egress proxy via env (proxy wins last, exactly
   }
 });
 
+test('passEnv emits key-only -e (secret value rides in the client env, never argv) — cage-match #114 F1', () => {
+  const { argv } = buildCageArgv({ ...base, passEnv: ['GH_TOKEN', 'GITHUB_TOKEN'] });
+  // Each name is emitted as a BARE `-e NAME` (no "=value"), so a host `ps` of the
+  // docker run never reveals the token value.
+  for (const name of ['GH_TOKEN', 'GITHUB_TOKEN']) {
+    const i = argv.indexOf(name);
+    assert.notEqual(i, -1, `${name} present`);
+    assert.equal(argv[i - 1], '-e', `${name} emitted as -e ${name}`);
+  }
+  // and crucially NO value-carrying `-e GH_TOKEN=<anything>` anywhere in the argv.
+  const eValues = argv.filter((_, i) => argv[i - 1] === '-e');
+  assert.ok(!eValues.some((e) => /^GH_TOKEN=/.test(e)), 'no GH_TOKEN=value in argv');
+  assert.ok(!eValues.some((e) => /^GITHUB_TOKEN=/.test(e)), 'no GITHUB_TOKEN=value in argv');
+});
+
+test('passEnv does not disturb the proxy-wins-last guarantee (still exactly one HTTPS_PROXY)', () => {
+  const { argv } = buildCageArgv({ ...base, env: { HOME: '/work' }, passEnv: ['GH_TOKEN'] });
+  const eValues = argv.filter((_, i) => argv[i - 1] === '-e');
+  for (const k of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+    assert.equal(eValues.filter((e) => e.startsWith(`${k}=`)).length, 1, `exactly one ${k}`);
+  }
+  assert.ok(eValues.includes('HOME=/work'), 'value-carrying env still passes');
+});
+
 test('buildCageArgv ends with image then the command + args', () => {
   const { argv } = buildCageArgv(base);
   const img = argv.indexOf('cage-agent:latest');


### PR DESCRIPTION
## What

The fourth autonomy stage of the self-healer — and the first that runs the codegen **"monster"** (an agent that writes a fix from a log diagnosis). It **routes** each confident-green actionable finding through the already-proven cage (`cage/run-cage.mjs` → `cage.mjs`, gated by `escape-probe.sh`), never around it.

Mirrors `draft.mjs`'s `draftIfActionable` exactly — same `actionableFindings` filter, same fingerprint, same single-box owner-fenced lock — with the cage swapped in for the GitHub-issue POST.

## SHIPPED OFF — five independent fail-closed gates

| # | Gate | Condition |
|---|------|-----------|
| 1 | feature flag | `HEALER_GREEN_AUTO=1` (off by default) |
| 2 | on-box | `HEALER_HOST` unset (cage is host-local Docker) |
| 3 | **bounded authority** | `HEALER_GREEN_AUTO_TOKEN` set **and distinct** from the broad host token |
| 4 | cage substrate | `HEALER_CAGE_IMAGE`/`NETWORK`/`PROXY_URL` |
| 5 | agent command | `HEALER_CAGE_AGENT_CMD` (operator-installed) |

Gate 3 is the **enforced** form of `cage/README.md`'s "Credential scope" prose contract: the orchestrator structurally refuses to hand an injectable agent the org-wide token.

**Named residual:** distinct-from-broad guarantees a *dedicated* token, not that it is fine-grained-scoped to exactly one repo — that narrowing is the operator's provisioning duty; an online control-repo reachability probe is tracked as follow-up.

## Credential path

`run-cage.mjs` gains a **bounded** forward allowlist into the cage (no-op for the probe; flags byte-identical): `CAGE_GH_TOKEN`→`GH_TOKEN`/`GITHUB_TOKEN`, `HOME=/work`, scrubbed `CAGE_AGENT_*`. Proxy routing stays appended LAST so none of it can clobber egress. Workdir clone uses the injection-safe host primitive; the token reaches `git` via a transient `GIT_ASKPASS`, never argv.

## Tests
12 new (`test/auto.test.mjs`): gating, spawn-shape, secret-scrub. Suite 90 → **102 green** locally. New `token-forward` + `token-not-leaked` cases added to `escape-probe.sh` (require Docker on the box — **not run in this PR**).

## ⚠️ Review gate
This crosses a **trust boundary** (agentic spawn ingesting attacker-influenceable log content + credential handling) → needs **/cage-match** (different-inductive-bias adversary), not self-review, before merge. **Do not enable** green-auto in prod until a repo-scoped token is provisioned (gate 3) and `escape-probe.sh` — including the two new token cases — passes on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)