### PR TITLE
feat(caddy): version-control the quiz-game (live-game) route

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -209,3 +209,12 @@ world.imagineering.cc {
         try_files {path} /index.html
     }
 }
+
+# --- live-game (quiz buzzer) ---
+# Phones are buzzers, the big screen is the board, Claude is the Game Master.
+# Server runs on the box as a systemd/long-running process bound to localhost:7373.
+# Previously this route lived only in Caddy's running config (added via the admin
+# API), so a container restart dropped it — now it's durable in the Caddyfile.
+quiz-game.imagineering.cc {
+    reverse_proxy localhost:7373
+}


### PR DESCRIPTION
## What

Adds the `quiz-game.imagineering.cc → localhost:7373` route to the tracked Caddyfile.

## Why

The quiz-game (live-game) route previously existed **only in Caddy's running config**, injected via the admin API on 2026-06-21. Caddy runs as a Docker container with `restart=always`, so any container restart reloads from the bind-mounted Caddyfile and **silently drops** the admin-API route. A restart this session (2026-06-24) did exactly that — quiz-game went dark until restored. This persists it durably.

## ⚠️ Drift discovered (not fixed here)

While reconciling, I found the **deployed box's Caddyfile had drifted from this repo**:
- **Repo is ahead** on `world.imagineering.cc`: the #15 wasm cache-busting block (`main.dart.wasm` + manifests revalidation) is committed here but **was never deployed** to the box — so the "Refresh does nothing" fix isn't live.
- **Live was ahead** only by the quiz-game block (now captured here).

This PR **preserves the repo's #15 block** and only adds quiz-game. The undeployed-#15 drift is flagged as a separate follow-up — deploying this repo's Caddyfile to the box would also (correctly) apply #15 to `world`.

## Verification

`caddy validate` (real container binary, via stdin) → **Valid configuration**. quiz-game is currently serving `200` on the box (restored durably into the live Caddyfile this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)