### PR TITLE
chore(infra): familiars FIREBASE_* comment + Bash allowlist prefix-match doc

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,44 @@
+# `.claude/` — project Claude Code config
+
+## `settings.json` — the read-only command allowlist
+
+`settings.json` pre-approves a set of **read-only** commands (shellcheck, `bash -n`,
+yamllint, `git status/fetch/log/diff/show/branch/rev-parse/remote`, `gh pr
+view/list/diff/checks`) so a ship/CI cycle in this repo isn't blocked waiting on
+interactive permission prompts. It was added in PR #87 after a classifier outage
+made every prompt a hard stop. `settings.json` is JSON and can't carry comments,
+which is why this note lives here.
+
+### How `Bash(cmd:*)` matching actually works (verified 2026-06-24)
+
+`Bash(git diff:*)` is a **command-prefix** match. The obvious worry is a
+*compound-command escape*: does `Bash(git diff:*)` also pre-approve
+`git diff && rm -rf /`? **No.**
+
+Claude Code is **compound-command aware**: it splits a command on the shell
+operators `&&`, `||`, `;`, `|`, `|&`, `&`, and newlines, and matches **each
+sub-command independently** against the allow rules. So `git diff && rm -rf /`
+still prompts on the `rm` part — the prefix rule only ever satisfies the `git diff`
+sub-command. (Source: Claude Code permissions docs, "Compound commands". When you
+approve a compound command with "don't ask again", it saves a *separate* rule per
+sub-command, not one rule for the whole string.)
+
+### Caveats worth knowing
+
+- **Process wrappers are stripped** before matching: `timeout`, `time`, `nice`,
+  `nohup`, `stdbuf`, and bare `xargs`. So `Bash(yamllint:*)` also matches
+  `timeout 30 yamllint …`. Fine here — these are read-only commands.
+- **Environment/exec runners are NOT stripped** and always prompt: `npx`,
+  `docker exec`, `direnv exec`, `mise exec`, `watch`, `setsid`, `find -exec`,
+  `find -delete`. A prefix rule can't silently cover a command hidden behind one.
+- **Prefix rules are convenience, not a security boundary.** Argument-constraining
+  allow patterns (e.g. trying to pin a URL on `curl`) are fragile and bypassable;
+  the docs recommend **deny** rules for anything security-critical, not clever allow
+  patterns. This allowlist is safe because every entry is intrinsically read-only,
+  not because the matcher is airtight.
+- For an **exact** match (no trailing args), use `Bash(cmd)` with no `:*`.
+
+> Bottom line: the compound-command-escape hole does not exist (sub-commands are
+> re-checked), and this allowlist's low blast radius comes from the commands being
+> read-only — keep it that way. Anything that mutates state should stay out of the
+> allow list (let it prompt) or, if it must be constrained, go in a deny rule.

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -388,6 +388,14 @@ deploy_familiars_server() {
     fam_field() { echo "$FAM_PLAINTEXT" | yq -r "$1 // \"\""; }
     {
         echo "# familiars-server Configuration (auto-generated from secrets.yaml)"
+        # NOTE: these FIREBASE_* values are FAMILIARS-SERVER's, not downstream-server's.
+        # The two services share Firebase FIELD NAMES (FIREBASE_PROJECT_ID,
+        # FIREBASE_SERVICE_ACCOUNT_BASE64), so a FIREBASE_* hunk in this repo's diff
+        # reads ambiguously — but downstream-server has NO env generator here at all
+        # (it's hand-managed from the nickmeinhold/downstream repo since #291 Phase B;
+        # this repo keeps only its Caddy route + shared lib/telegram.sh). So any
+        # FIREBASE_* line in deploy-to.sh is familiars', full stop. (A 2026-06-12 retro
+        # misread exactly this as a "dropped downstream generator hunk" — it never existed.)
         printf 'FIREBASE_PROJECT_ID=%s\n'             "$(dotenv_quote "$(fam_field '.firebase_project_id')")"
         printf 'FIREBASE_SERVICE_ACCOUNT_BASE64=%s\n' "$(dotenv_quote "$(fam_field '.firebase_service_account_base64')")"
         printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n'         "$(dotenv_quote "$(fam_field '.claude_code_oauth_token')")"


### PR DESCRIPTION
Two low-risk hygiene items from the backlog (doc-only; no behavior change).

### #17 — disambiguate the familiars `FIREBASE_*` block (`scripts/deploy-to.sh`)
familiars-server and downstream-server share Firebase **field names**, and downstream-server has **no env generator in this repo** (hand-managed from `nickmeinhold/downstream` since #291 Phase B). A `FIREBASE_*` hunk here therefore reads ambiguously — a 2026-06-12 retro misread it as a "dropped downstream generator hunk" that never existed. Added a comment at the env-gen block so the next reader doesn't repeat it.

### #9 — document `Bash(cmd:*)` allowlist semantics (`.claude/README.md`, new)
**Verified before writing** (the task said don't assume): Claude Code **is compound-command aware** — it splits on `&& || ; | |& &` + newlines and re-checks **each sub-command** independently, so `Bash(git diff:*)` does **not** pre-approve `git diff && rm -rf /`. The feared compound-escape hole **does not exist**. Documented the semantics, the wrapper-stripping caveats (`timeout`/`time`/`nice`… stripped; `npx`/`docker exec`/`find -exec` not), and that prefix rules are convenience, not a security boundary. `settings.json` is JSON (no comments), hence the README.

### Note on #4
Its other half — temp-file traps in `deploy_scripts()` — was **already done** in the live code (`deploy-to.sh:99-120` + the matrix block). Stale task; only the downstream-repo comment-update half remains, tracked separately.

Verification: `shellcheck --severity=warning scripts/deploy-to.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)