### PR TITLE
ci(caddy): fail-closed Caddyfile validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,20 @@ jobs:
         env:
           REQUIRE_ALL: "1"
         run: ./scripts/test-secret-quoting.sh
+
+  caddy-validate:
+    name: Caddyfile Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Validate caddy/Caddyfile with the SAME image the box runs (caddy:2-alpine),
+      # so a syntax error or bad directive is caught HERE — before a deploy reloads
+      # it into the live proxy and takes every domain (*.imagineering.cc, xdeca.com,
+      # callonclare.com.au) down. `caddy validate` only parses + adapts the config;
+      # it does NOT dial upstreams, so the localhost:PORT backends that don't exist
+      # in CI are fine. Fails the build (non-zero) on an invalid Caddyfile.
+      - name: Validate caddy/Caddyfile
+        run: |
+          docker run --rm -v "$PWD/caddy:/etc/caddy:ro" caddy:2-alpine \
+            caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile


### PR DESCRIPTION
Adds a `Caddyfile Validate` CI job that validates `caddy/Caddyfile` with the **same `caddy:2-alpine` image the box runs**, on every push/PR to main.

## Why
The repo↔box config has no CD and once drifted (the box ran a Caddyfile missing a committed fix). A broken Caddyfile reloaded into the live proxy takes **all ~27 domains** down. This gate catches a syntax error / bad directive **at PR time**, before any deploy.

`caddy validate` only parses + adapts the config (no upstream dialing), so the `localhost:PORT` backends absent in CI don't matter. Verified: the exact command returns `Valid configuration` against the real image on the current Caddyfile.

## Scope (the safe half of task #7)
This is **validation only — no deploy**. The auto-deploy leg (push a validated Caddyfile to the box + `docker exec caddy caddy reload`) is intentionally out of scope: the deploy-bus is **image-based** (`image.published` → pull digest → restart container), but the Caddyfile is a **bind-mounted config file** — a different artifact class. A config-CD mechanism with all-domains blast radius warrants a deliberate design decision (GH Action + SSH vs a deploy-bus extension), not an autonomous arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)