### PR TITLE
feat(aiko-chat-gateway): deploy gateway on OCI — Caddy route + SOPS JWT (#1281 incr 3)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@
 
 creation_rules:
   # Match secret yaml files in service and provider directories
-  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim)/.*\.yaml$
+  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway)/.*\.yaml$
     age: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks

--- a/aiko-chat-gateway/secrets.yaml
+++ b/aiko-chat-gateway/secrets.yaml
@@ -1,0 +1,18 @@
+#ENC[AES256_GCM,data:sx09ymgyV1NIchnjsLtR158I8+N34nrIBbinqCSeMYVPwlB99ZRNpX/4AxcmG9WgqYoBsx3w/b6paeyednAtzA4Z3nFQsI+c0T4dlNJALEfBUW0Zigo=,iv:T/jGq3WEQrJVAOIXDcwoAX8yM7q8ZbWa02qg8QY67gc=,tag:WJELiLVysnvvJ9DTqOlnOA==,type:comment]
+#ENC[AES256_GCM,data:v5aYWq9rIcsG/5F3r1GsGFG2/vEs7Ce2uIcqdUN+kvAxda11RN4oAZmNgiqhJcuf9wSPiDSUsjf6K1WIg/wYGanM/4myEZCybI95+eweZTBM,iv:RtMus4DMljlcFKlZpTZW274XMmqltC9OmsepUgLeWFA=,tag:3W0kTEBfTpvQBQ0J+Qj9qg==,type:comment]
+jwt_secret: ENC[AES256_GCM,data:GX86gKZifpJbxy48cEy9y5wvFtVVzO7Z9hQyvxjTkl/i+JlB6s1KgwFkS1iWC0tT,iv:bmUmv0FNCLl6aY5fJFpF5U3HS0BnzEZ7Ni1hPxicwtI=,tag:/Y/2vKQKAE6+Ou/9aFvqNQ==,type:str]
+sops:
+    age:
+        - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsc20rQlArOFUyZkN0M1Nx
+            QTUyMDRuL3QyODJ6RTFkV0ordjZ2TkFqOEVFCnlseGJ6ekdDT2UyUk9xZDRDN3g4
+            c2dER0dMVk54ditIeGJKRWZyVUhmbU0KLS0tIFlJeGdVc3hHT0lXTzhHb2hhWEhy
+            TmlqZ24vL0tRTjFValBWdmcrVjQxREkKgtj0uk5ggLCfEIdZ67MFdpX/zAm7yW16
+            Rpv41HfeNyr9lrJCh2lMYqpg5dDMTXTCuqlP+YLqNXheVJx4Zrb/2g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-25T12:31:32Z"
+    mac: ENC[AES256_GCM,data:lmoB5nY5Hq7lEOup4SpQhpYzgMsooqIOj8Mdbejax0DKmFcCPwh+nLSLGh5wEr3nB3e6TsDHifEyM03FkouidwhmRZ0MurfcxI5QxwArWGR55a4eKgebSAxbAOM+0XRvMoPYg0WxRJARg+o+g+WoGfLx/re+otIlBmYuNr1uOrw=,iv:rI0ZsY64ykD2WFEFrO6O7Cw/2aod/GCsphliiMC8bXE=,tag:Pdp1S8iIEMr8tIeIRDj8SQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/aiko-chat-gateway/secrets.yaml.example
+++ b/aiko-chat-gateway/secrets.yaml.example
@@ -1,0 +1,2 @@
+# Copy to secrets.yaml and `sops -e -i secrets.yaml`. jwt_secret must be >=32 chars.
+jwt_secret: REPLACE_WITH_32+_CHAR_SECRET

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -10,6 +10,10 @@ kan.imagineering.cc {
     reverse_proxy localhost:3013
 }
 
+chat.imagineering.cc {
+    reverse_proxy localhost:8095
+}
+
 dav.imagineering.cc {
     reverse_proxy localhost:5232
 }


### PR DESCRIPTION
## What

Infra side of the gateway prod cutover (gateway repo [PR#13](https://github.com/nickmeinhold/aiko_chat_gateway/pull/13) merged separately). **Already executed and verified live** — this PR lands the config so `main` reflects reality.

- **`caddy/Caddyfile`** — `chat.imagineering.cc → localhost:8095`.
- **`aiko-chat-gateway/secrets.yaml`** — SOPS-encrypted `JWT_SECRET` (48 chars), the durable home for the secret.
- **`.sops.yaml`** — `creation_rules` path_regex extended to cover `aiko-chat-gateway/`.

## Why it must land

The host Caddyfile already serves the `chat.` route. Until this is on `main`, a `deploy-to.sh caddy` run from `main` would `--force-recreate` Caddy **without** the route, dropping the live endpoint. Merging closes that regression window.

## Verified live (cutover already done)

- Real Let's Encrypt cert on `chat.imagineering.cc`; `/health` 200, `aiko_connected:true`.
- All 5 canonical channels (`general, llm, random, robot, yolo`) reconciled from the HyperSpace `channel_list` share into the prod SQLite store — **verified at the DB rows**, not just the API.
- `/v1/channels` correctly 401s without a JWT (auth-gated).
- matrix untouched — graceful `caddy reload`, no `--force-recreate`, no stack bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)