### PR TITLE
feat(backups): back up the aiko-chat-gateway SQLite store (sole copy)

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -50,6 +50,12 @@ tail -f /var/log/backup.log
 /opt/scripts/restore.sh aiko-gateway
 ```
 
+> ⚠️ **`aiko-gateway` restore replaces the SOLE store** of all gateway accounts,
+> messages, and the ACL overlay. It prompts for typed confirmation, validates the
+> dump into a temp DB (`PRAGMA integrity_check` + a `users`-table check) before
+> swapping, and keeps the previous DB as a timestamped `aiko.db.rescue-*` inside
+> the volume. If validation fails, the live DB is left untouched.
+
 ### Restore Process
 
 1. Script clones backup repo from GitHub (shallow)

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -11,6 +11,7 @@ All services backup to **GitHub** (imagineering-cc/imagineering-backups).
 | Radicale | CalDAV/CardDAV collections | Daily 4 AM | 7 days |
 | Dreamfinder | SQLite database | Daily 4 AM | 7 days |
 | Claudius | Agent state files | Daily 4 AM | 7 days |
+| aiko-chat-gateway | SQLite (messages + auth + ACL — the sole copy) | Daily 4 AM | 7 days |
 
 ## Manual Operations
 
@@ -26,6 +27,7 @@ All services backup to **GitHub** (imagineering-cc/imagineering-backups).
 /opt/scripts/backup.sh radicale
 /opt/scripts/backup.sh pm-bot
 /opt/scripts/backup.sh claudius
+/opt/scripts/backup.sh aiko-gateway
 ```
 
 ### Check Backup Logs
@@ -45,6 +47,7 @@ tail -f /var/log/backup.log
 /opt/scripts/restore.sh radicale
 /opt/scripts/restore.sh pm-bot
 /opt/scripts/restore.sh claudius
+/opt/scripts/restore.sh aiko-gateway
 ```
 
 ### Restore Process
@@ -64,6 +67,7 @@ tail -f /var/log/backup.log
 | Radicale | `radicale.tar` | Decompressed collections archive |
 | Dreamfinder | `pm-bot.db` | SQLite database |
 | Claudius | `claudius.tar` | Decompressed state archive |
+| aiko-chat-gateway | `aiko-gateway.sql` | Decompressed SQLite dump |
 
 Files are stored decompressed so git deltas work efficiently.
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -187,6 +187,35 @@ backup_matrix() {
   log "Matrix backup complete"
 }
 
+# aiko-chat-gateway: the gateway's local SQLite store is the SOLE copy of message
+# history + auth credentials + the ACL/membership overlay. Per the #1281
+# HyperSpace-source-of-truth redesign, HyperSpace holds only channel/user
+# EXISTENCE; everything else lives in this one file on the named volume. A
+# `docker volume rm` or host disk loss would vaporize every account with no
+# second copy (aiko_chat_gateway#4). The gateway image ships no sqlite3, so —
+# like the matrix bridges — mount the volume read-only into sqlite-dumper and
+# `.dump` to text SQL (git-diffable). Online-safe: `.dump` reads a consistent
+# snapshot; the read-only mount can't perturb the live DB.
+backup_aiko_gateway() {
+  log "Backing up aiko-chat-gateway..."
+
+  local out="$BACKUP_DIR/aiko-gateway-$DATE.sql.gz"
+
+  if ! docker run --rm -v "aiko-chat-gateway_aiko_gateway_data:/data:ro" sqlite-dumper:latest \
+    sqlite3 -cmd '.timeout 5000' /data/aiko.db .dump 2>/dev/null \
+     | gzip > "$out"; then
+    error "aiko-gateway sqlite3 .dump failed"
+    rm -f "$out"
+    return 1
+  fi
+  if [ ! -s "$out" ]; then
+    error "aiko-gateway dump produced empty output"
+    rm -f "$out"
+    return 1
+  fi
+  log "aiko-gateway backup complete: $(basename "$out") ($(du -h "$out" | cut -f1))"
+}
+
 # Triggers Continuwuity's online RocksDB checkpoint via the admin API
 # (`!admin server backup-database`). Each run wipes the in-volume backup
 # dir first, then triggers the admin command which writes a fresh
@@ -457,7 +486,7 @@ cleanup_old_backups() {
 case $SERVICE in
   all)
     SUCCEEDED=()
-    for svc in kanbn outline radicale pm-bot claudius; do
+    for svc in kanbn outline radicale pm-bot claudius aiko-gateway; do
       if "backup_${svc//-/_}"; then
         SUCCEEDED+=("$svc")
       else
@@ -509,6 +538,9 @@ case $SERVICE in
   claudius)
     backup_claudius && backup_to_github claudius || FAILED_SERVICES+=(claudius)
     ;;
+  aiko-gateway)
+    backup_aiko_gateway && backup_to_github aiko-gateway || FAILED_SERVICES+=(aiko-gateway)
+    ;;
   matrix)
     if backup_matrix; then
       backup_to_github matrix-discord matrix-signal matrix-telegram \
@@ -525,7 +557,7 @@ case $SERVICE in
     cleanup_old_backups
     ;;
   *)
-    echo "Usage: $0 [all|kanbn|outline|radicale|pm-bot|claudius|matrix|continuwuity|cleanup]"
+    echo "Usage: $0 [all|kanbn|outline|radicale|pm-bot|claudius|aiko-gateway|matrix|continuwuity|cleanup]"
     exit 1
     ;;
 esac

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Unified backup script for all services
 # Dumps databases/data, pushes to GitHub (imagineering-cc/imagineering-backups)
-# Usage: ./backup.sh [all|kanbn|outline|radicale|pm-bot|claudius|matrix|continuwuity]
+# Usage: ./backup.sh [all|kanbn|outline|radicale|pm-bot|claudius|aiko-gateway|matrix|continuwuity]
 #
 # NOTE: downstream-server's DB backup moved to the downstream repo
 # (nickmeinhold/downstream deploy/oci/scripts/backup-downstream.sh, cron
@@ -213,12 +213,15 @@ backup_aiko_gateway() {
     rm -f "$tmp" "$err"
     return 1
   fi
-  # A COMPLETE .dump always terminates with `COMMIT;`. Its absence means empty,
-  # truncated, or errored output — reject it BEFORE it can overwrite a good
-  # backup (this DB is the sole copy of auth+messages+ACL; an empty backup is
-  # worse than none because restore would replay it over the live DB).
-  if ! grep -q '^COMMIT;' "$tmp"; then
-    error "aiko-gateway dump invalid (no COMMIT; — empty/truncated): $(tr '\n' ' ' < "$err")"
+  # A COMPLETE .dump's LAST non-blank line is exactly `COMMIT;`. Check the tail
+  # (end-anchored), not `grep '^COMMIT;'` — application data can contain a
+  # multiline string literal whose embedded line starts with `COMMIT;` and would
+  # fool a whole-file grep into accepting a truncated dump. An empty/truncated
+  # backup is worse than none here: restore would replay it over the sole live DB.
+  local lastline
+  lastline=$(grep -ve '^[[:space:]]*$' "$tmp" | tail -n1)
+  if [ "$lastline" != "COMMIT;" ]; then
+    error "aiko-gateway dump invalid (last line '$lastline', not COMMIT; — empty/truncated): $(tr '\n' ' ' < "$err")"
     rm -f "$tmp" "$err"
     return 1
   fi

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -199,20 +199,31 @@ backup_matrix() {
 backup_aiko_gateway() {
   log "Backing up aiko-chat-gateway..."
 
+  local tmp="$BACKUP_DIR/aiko-gateway-$DATE.sql"
+  local err="$BACKUP_DIR/aiko-gateway-$DATE.err"
   local out="$BACKUP_DIR/aiko-gateway-$DATE.sql.gz"
 
+  # Dump to a PLAIN .sql first (no pipe) so sqlite3's REAL exit is seen — piping
+  # to gzip would mask it behind gzip's status (and a gzip of empty input is
+  # still a non-empty container, so an `-s` size check on the .gz lies). Capture
+  # stderr for the error message (a WAL-locked read fails loudly, not silently).
   if ! docker run --rm -v "aiko-chat-gateway_aiko_gateway_data:/data:ro" sqlite-dumper:latest \
-    sqlite3 -cmd '.timeout 5000' /data/aiko.db .dump 2>/dev/null \
-     | gzip > "$out"; then
-    error "aiko-gateway sqlite3 .dump failed"
-    rm -f "$out"
+       sqlite3 -cmd '.timeout 5000' /data/aiko.db .dump > "$tmp" 2>"$err"; then
+    error "aiko-gateway sqlite3 .dump failed: $(tr '\n' ' ' < "$err")"
+    rm -f "$tmp" "$err"
     return 1
   fi
-  if [ ! -s "$out" ]; then
-    error "aiko-gateway dump produced empty output"
-    rm -f "$out"
+  # A COMPLETE .dump always terminates with `COMMIT;`. Its absence means empty,
+  # truncated, or errored output — reject it BEFORE it can overwrite a good
+  # backup (this DB is the sole copy of auth+messages+ACL; an empty backup is
+  # worse than none because restore would replay it over the live DB).
+  if ! grep -q '^COMMIT;' "$tmp"; then
+    error "aiko-gateway dump invalid (no COMMIT; — empty/truncated): $(tr '\n' ' ' < "$err")"
+    rm -f "$tmp" "$err"
     return 1
   fi
+  rm -f "$err"
+  gzip -f "$tmp"   # -> $out (aiko-gateway-$DATE.sql.gz)
   log "aiko-gateway backup complete: $(basename "$out") ($(du -h "$out" | cut -f1))"
 }
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -2,7 +2,7 @@
 # Restore script for all services
 # Restores from GitHub backup repo (imagineering-cc/imagineering-backups)
 # Usage: ./restore.sh <service>
-#   service: kanbn, outline, radicale, pm-bot, claudius, matrix, continuwuity
+#   service: kanbn, outline, radicale, pm-bot, claudius, aiko-gateway, matrix, continuwuity
 #
 # Note: continuwuity requires the age private key path in $AGE_IDENTITY_FILE
 # (default: ~/.config/sops/age/keys.txt — same file SOPS uses; age will try
@@ -30,7 +30,7 @@ AGE_IDENTITY_FILE="${AGE_IDENTITY_FILE:-${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/
 
 if [ -z "$SERVICE" ]; then
   echo "Usage: $0 <service>"
-  echo "  service: kanbn, outline, radicale, pm-bot, claudius, matrix, continuwuity"
+  echo "  service: kanbn, outline, radicale, pm-bot, claudius, aiko-gateway, matrix, continuwuity"
   echo ""
   echo "Examples:"
   echo "  $0 kanbn         # Restore latest from GitHub backup"
@@ -217,8 +217,11 @@ restore_aiko_gateway() {
   if [ ! -s "$sql_file" ]; then
     error "No (non-empty) aiko-gateway.sql in backup repo"; cleanup_backups; exit 1
   fi
-  if ! grep -q '^COMMIT;' "$sql_file"; then
-    error "aiko-gateway.sql looks truncated/invalid (no COMMIT;)"; cleanup_backups; exit 1
+  # End-anchored completeness check (see backup.sh): the LAST non-blank line of a
+  # complete sqlite .dump is exactly `COMMIT;`. A whole-file grep could be fooled
+  # by `COMMIT;` embedded in multiline data, accepting a truncated dump.
+  if [ "$(grep -ve '^[[:space:]]*$' "$sql_file" | tail -n1)" != "COMMIT;" ]; then
+    error "aiko-gateway.sql looks truncated/invalid (last line is not COMMIT;)"; cleanup_backups; exit 1
   fi
 
   # Irreversible: replacing the sole auth+message store. Require typed consent.
@@ -246,10 +249,23 @@ restore_aiko_gateway() {
         integ=$(sqlite3 /data/aiko.db.restore "PRAGMA integrity_check;")
         [ "$integ" = "ok" ] || { echo "integrity_check failed: $integ" >&2; exit 1; }
         sqlite3 /data/aiko.db.restore ".tables" | grep -qw users || { echo "no users table in restored DB" >&2; exit 1; }
-        # Atomic-ish swap on the same filesystem: keep old as rescue, move new in.
-        [ -f /data/aiko.db ] && mv /data/aiko.db "/data/'"$rescue"'"
-        mv /data/aiko.db.restore /data/aiko.db
-        rm -f /data/aiko.db-wal /data/aiko.db-shm
+        # Failure-safe swap. Preserve the OLD db AND its WAL/SHM as the rescue
+        # (an uncheckpointed WAL holds committed-but-unmerged data; rescuing only
+        # aiko.db would lose it). Then move the validated candidate in; if THAT
+        # mv fails, roll the rescue back so we never end up with no aiko.db.
+        rescue="'"$rescue"'"
+        if [ -f /data/aiko.db ]; then
+          mv /data/aiko.db "/data/$rescue"
+          [ -f /data/aiko.db-wal ] && mv /data/aiko.db-wal "/data/$rescue-wal" || true
+          [ -f /data/aiko.db-shm ] && mv /data/aiko.db-shm "/data/$rescue-shm" || true
+        fi
+        if ! mv /data/aiko.db.restore /data/aiko.db; then
+          [ -f "/data/$rescue" ] && mv "/data/$rescue" /data/aiko.db
+          [ -f "/data/$rescue-wal" ] && mv "/data/$rescue-wal" /data/aiko.db-wal || true
+          [ -f "/data/$rescue-shm" ] && mv "/data/$rescue-shm" /data/aiko.db-shm || true
+          echo "swap failed; rolled back to original DB" >&2
+          exit 1
+        fi
       ' < "$sql_file"; then
     error "aiko-gateway restore FAILED validation — live DB left untouched. Restarting."
     docker compose up -d

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -236,7 +236,8 @@ restore_aiko_gateway() {
   # Build + validate the candidate in a TEMP file, and only swap it in on
   # success — the live aiko.db is untouched until a valid replacement exists.
   # The old DB is kept as a timestamped rescue copy inside the volume.
-  local rescue="aiko.db.rescue-$(date +%Y%m%d-%H%M%S)"
+  local rescue
+  rescue="aiko.db.rescue-$(date +%Y%m%d-%H%M%S)"
   log "Building + validating candidate DB (live DB untouched until it passes)..."
   if ! docker run --rm -i -v "aiko-chat-gateway_aiko_gateway_data:/data" sqlite-dumper:latest sh -c '
         set -e

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -199,6 +199,42 @@ restore_claudius() {
   log "Claudius restore complete!"
 }
 
+# Restore the aiko-chat-gateway SQLite store from the latest .sql dump in the
+# backup repo. Mirrors the matrix-bridge sqlite restore: stop the container
+# (never replay against a live DB), replace the DB from the dump inside the
+# sqlite-dumper image (rw mount), restart. The dump carries the current schema
+# (email col, nullable password_hash, social_identities), so the gateway's boot
+# schema guard passes after restore. aiko_chat_gateway#4.
+restore_aiko_gateway() {
+  log "Restoring aiko-chat-gateway..."
+
+  fetch_backups
+
+  local sql_file="$BACKUP_CLONE_DIR/aiko-gateway.sql"
+  if [ ! -f "$sql_file" ]; then
+    error "No aiko-gateway.sql found in backup repo"
+    cleanup_backups
+    exit 1
+  fi
+
+  log "Stopping gateway..."
+  cd ~/apps/aiko-chat-gateway
+  docker compose stop
+
+  log "Restoring DB from aiko-gateway.sql..."
+  # Remove the old DB + WAL/SHM first so stale write-ahead state can't corrupt
+  # the restore, then replay the dump into a fresh aiko.db (rw mount).
+  docker run --rm -i -v "aiko-chat-gateway_aiko_gateway_data:/data" sqlite-dumper:latest sh -c \
+    "rm -f /data/aiko.db /data/aiko.db-wal /data/aiko.db-shm && sqlite3 /data/aiko.db" < "$sql_file" || \
+    error "Restore failed for aiko-gateway"
+
+  log "Restarting gateway..."
+  docker compose up -d
+
+  cleanup_backups
+  log "aiko-gateway restore complete!"
+}
+
 # Restore matrix bridges + relay-bot SQLite DBs from latest SQL dumps in the
 # backup repo. Each .sql file is replayed against a fresh SQLite DB inside
 # the bridge's volume. Bridges must be stopped before the replay (writing
@@ -351,6 +387,9 @@ case $SERVICE in
   claudius)
     restore_claudius
     ;;
+  aiko-gateway)
+    restore_aiko_gateway
+    ;;
   matrix)
     restore_matrix
     ;;
@@ -359,7 +398,7 @@ case $SERVICE in
     ;;
   *)
     error "Unknown service: $SERVICE"
-    echo "Valid services: kanbn, outline, radicale, pm-bot, claudius, matrix, continuwuity"
+    echo "Valid services: kanbn, outline, radicale, pm-bot, claudius, aiko-gateway, matrix, continuwuity"
     exit 1
     ;;
 esac

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -211,24 +211,52 @@ restore_aiko_gateway() {
   fetch_backups
 
   local sql_file="$BACKUP_CLONE_DIR/aiko-gateway.sql"
-  if [ ! -f "$sql_file" ]; then
-    error "No aiko-gateway.sql found in backup repo"
-    cleanup_backups
-    exit 1
+  # Validate the dump BEFORE touching anything: present, non-empty, and complete
+  # (a COMPLETE sqlite .dump ends with COMMIT;). The gateway DB is the SOLE copy
+  # of auth+messages+ACL, so a bad dump must never reach the destructive path.
+  if [ ! -s "$sql_file" ]; then
+    error "No (non-empty) aiko-gateway.sql in backup repo"; cleanup_backups; exit 1
+  fi
+  if ! grep -q '^COMMIT;' "$sql_file"; then
+    error "aiko-gateway.sql looks truncated/invalid (no COMMIT;)"; cleanup_backups; exit 1
+  fi
+
+  # Irreversible: replacing the sole auth+message store. Require typed consent.
+  echo "WARNING: this REPLACES the gateway's SOLE database (all accounts + messages + ACL)."
+  echo "  dump: $sql_file ($(wc -l < "$sql_file") lines, $(du -h "$sql_file" | cut -f1))"
+  read -r -p "Type 'restore aiko-gateway' to proceed: " confirm
+  if [ "$confirm" != "restore aiko-gateway" ]; then
+    error "Aborted (no confirmation)"; cleanup_backups; exit 1
   fi
 
   log "Stopping gateway..."
   cd ~/apps/aiko-chat-gateway
   docker compose stop
 
-  log "Restoring DB from aiko-gateway.sql..."
-  # Remove the old DB + WAL/SHM first so stale write-ahead state can't corrupt
-  # the restore, then replay the dump into a fresh aiko.db (rw mount).
-  docker run --rm -i -v "aiko-chat-gateway_aiko_gateway_data:/data" sqlite-dumper:latest sh -c \
-    "rm -f /data/aiko.db /data/aiko.db-wal /data/aiko.db-shm && sqlite3 /data/aiko.db" < "$sql_file" || \
-    error "Restore failed for aiko-gateway"
+  # Build + validate the candidate in a TEMP file, and only swap it in on
+  # success — the live aiko.db is untouched until a valid replacement exists.
+  # The old DB is kept as a timestamped rescue copy inside the volume.
+  local rescue="aiko.db.rescue-$(date +%Y%m%d-%H%M%S)"
+  log "Building + validating candidate DB (live DB untouched until it passes)..."
+  if ! docker run --rm -i -v "aiko-chat-gateway_aiko_gateway_data:/data" sqlite-dumper:latest sh -c '
+        set -e
+        rm -f /data/aiko.db.restore /data/aiko.db.restore-wal /data/aiko.db.restore-shm
+        sqlite3 /data/aiko.db.restore        # replay dump from stdin
+        integ=$(sqlite3 /data/aiko.db.restore "PRAGMA integrity_check;")
+        [ "$integ" = "ok" ] || { echo "integrity_check failed: $integ" >&2; exit 1; }
+        sqlite3 /data/aiko.db.restore ".tables" | grep -qw users || { echo "no users table in restored DB" >&2; exit 1; }
+        # Atomic-ish swap on the same filesystem: keep old as rescue, move new in.
+        [ -f /data/aiko.db ] && mv /data/aiko.db "/data/'"$rescue"'"
+        mv /data/aiko.db.restore /data/aiko.db
+        rm -f /data/aiko.db-wal /data/aiko.db-shm
+      ' < "$sql_file"; then
+    error "aiko-gateway restore FAILED validation — live DB left untouched. Restarting."
+    docker compose up -d
+    cleanup_backups
+    exit 1
+  fi
 
-  log "Restarting gateway..."
+  log "Restored OK (previous DB kept in the volume as $rescue). Restarting gateway..."
   docker compose up -d
 
   cleanup_backups

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -250,25 +250,26 @@ restore_aiko_gateway() {
         [ "$integ" = "ok" ] || { echo "integrity_check failed: $integ" >&2; exit 1; }
         sqlite3 /data/aiko.db.restore ".tables" | grep -qw users || { echo "no users table in restored DB" >&2; exit 1; }
         rescue="'"$rescue"'"
-        # Rescue the OLD db for human recovery (set -e: a failed rescue of the
-        # main db ABORTS before we touch the live one — never clobber without a
-        # copy). Checkpoint first so the rescue is COMPLETE (an uncheckpointed
-        # WAL holds committed-but-unmerged data); best-effort since a corrupt DB
-        # (the reason for restoring) may not checkpoint.
+        # 1. Rescue the COMPLETE old state (db + any WAL/SHM) by full file copy —
+        #    no checkpoint dependency, so the rescue is faithful even if the old
+        #    DB is too corrupt to checkpoint. Every copy is FATAL under set -e
+        #    (the `if` guards make ABSENCE non-fatal without masking cp failure):
+        #    we never clobber the sole DB unless a complete copy exists first.
         if [ -f /data/aiko.db ]; then
-          sqlite3 /data/aiko.db "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null 2>&1 || true
           cp -p /data/aiko.db "/data/$rescue"
-          [ -f /data/aiko.db-wal ] && cp -p /data/aiko.db-wal "/data/$rescue-wal" || true
-          [ -f /data/aiko.db-shm ] && cp -p /data/aiko.db-shm "/data/$rescue-shm" || true
+          if [ -f /data/aiko.db-wal ]; then cp -p /data/aiko.db-wal "/data/$rescue-wal"; fi
+          if [ -f /data/aiko.db-shm ]; then cp -p /data/aiko.db-shm "/data/$rescue-shm"; fi
         fi
-        # Atomic install: rename clobbers the old db in ONE step — the result is
-        # always old-or-new, never neither, so no rollback window exists.
-        mv -f /data/aiko.db.restore /data/aiko.db
-        # The candidate came fresh from .dump (no WAL); delete any stale WAL/SHM
-        # from the OLD db so SQLite cannot mis-apply it to the new one (corruption).
+        # 2. Remove the old sidecars BEFORE installing the new DB (they are now
+        #    rescued). Ordering matters: a fresh-from-.dump DB must never sit
+        #    beside a stale, salt-mismatched WAL (SQLite corruption). Doing this
+        #    before the install means there is never a new-db + stale-wal window.
         rm -f /data/aiko.db-wal /data/aiko.db-shm
+        # 3. Atomic install LAST: a single rename, always old-or-new, never
+        #    neither. If it fails, the live aiko.db is still the old one.
+        mv -f /data/aiko.db.restore /data/aiko.db
       ' < "$sql_file"; then
-    error "aiko-gateway restore FAILED validation — live DB left untouched. Restarting."
+    error "aiko-gateway restore FAILED. The candidate was rejected before the final install in almost all cases, so the live aiko.db is the original; a complete rescue copy (aiko.db.rescue-*) is also in the volume. Inspect the volume before retrying. Restarting on the current DB."
     docker compose up -d
     cleanup_backups
     exit 1

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -249,23 +249,24 @@ restore_aiko_gateway() {
         integ=$(sqlite3 /data/aiko.db.restore "PRAGMA integrity_check;")
         [ "$integ" = "ok" ] || { echo "integrity_check failed: $integ" >&2; exit 1; }
         sqlite3 /data/aiko.db.restore ".tables" | grep -qw users || { echo "no users table in restored DB" >&2; exit 1; }
-        # Failure-safe swap. Preserve the OLD db AND its WAL/SHM as the rescue
-        # (an uncheckpointed WAL holds committed-but-unmerged data; rescuing only
-        # aiko.db would lose it). Then move the validated candidate in; if THAT
-        # mv fails, roll the rescue back so we never end up with no aiko.db.
         rescue="'"$rescue"'"
+        # Rescue the OLD db for human recovery (set -e: a failed rescue of the
+        # main db ABORTS before we touch the live one — never clobber without a
+        # copy). Checkpoint first so the rescue is COMPLETE (an uncheckpointed
+        # WAL holds committed-but-unmerged data); best-effort since a corrupt DB
+        # (the reason for restoring) may not checkpoint.
         if [ -f /data/aiko.db ]; then
-          mv /data/aiko.db "/data/$rescue"
-          [ -f /data/aiko.db-wal ] && mv /data/aiko.db-wal "/data/$rescue-wal" || true
-          [ -f /data/aiko.db-shm ] && mv /data/aiko.db-shm "/data/$rescue-shm" || true
+          sqlite3 /data/aiko.db "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null 2>&1 || true
+          cp -p /data/aiko.db "/data/$rescue"
+          [ -f /data/aiko.db-wal ] && cp -p /data/aiko.db-wal "/data/$rescue-wal" || true
+          [ -f /data/aiko.db-shm ] && cp -p /data/aiko.db-shm "/data/$rescue-shm" || true
         fi
-        if ! mv /data/aiko.db.restore /data/aiko.db; then
-          [ -f "/data/$rescue" ] && mv "/data/$rescue" /data/aiko.db
-          [ -f "/data/$rescue-wal" ] && mv "/data/$rescue-wal" /data/aiko.db-wal || true
-          [ -f "/data/$rescue-shm" ] && mv "/data/$rescue-shm" /data/aiko.db-shm || true
-          echo "swap failed; rolled back to original DB" >&2
-          exit 1
-        fi
+        # Atomic install: rename clobbers the old db in ONE step — the result is
+        # always old-or-new, never neither, so no rollback window exists.
+        mv -f /data/aiko.db.restore /data/aiko.db
+        # The candidate came fresh from .dump (no WAL); delete any stale WAL/SHM
+        # from the OLD db so SQLite cannot mis-apply it to the new one (corruption).
+        rm -f /data/aiko.db-wal /data/aiko.db-shm
       ' < "$sql_file"; then
     error "aiko-gateway restore FAILED validation — live DB left untouched. Restarting."
     docker compose up -d


### PR DESCRIPTION
Adds `backup_aiko_gateway` + `restore_aiko_gateway` to the unified backup system, mirroring the matrix-bridge sqlite pattern. The gateway's file-backed SQLite is the sole copy of message history + auth credentials + the ACL overlay (per #1281 HyperSpace-source-of-truth; HyperSpace holds only existence). Live since social sign-in shipped 2026-06-27 (aiko_chat_gateway#4).

- **backup** (daily `all` cron, read-only): mount `aiko-chat-gateway_aiko_gateway_data:/data:ro` into `sqlite-dumper`, `.dump` → `.sql.gz` → git-diffable `aiko-gateway.sql` in the backups repo.
- **restore** (manual only): stop the gateway, replace `aiko.db` from the dump (rw mount, wipe WAL/SHM first), restart. Carries the current schema so the gateway boot guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)