### PR TITLE
chore(secrets): rotate leaked OAuth token + fix dreamfinder CALENDAR_URL

### DIFF
--- a/dreamfinder/secrets.yaml
+++ b/dreamfinder/secrets.yaml
@@ -19,7 +19,7 @@ matrix_always_respond_rooms: ENC[AES256_GCM,data:HgVPhJsjYRqASvba5IEU+TRl8PPoKYl
 calendar_url: ENC[AES256_GCM,data:YqkXHhWb1KTzJOLN5jm742Stf/BoNLY2TzvzmxN2mG5FSWG6X6l1RLiYx/0A4iNMzMAJPY3lEp7Ky+K0,iv:gqnydGzMVhSgcirleUxwFWkh+da0Hua54WtXKVjwlCs=,tag:illLnGigADWR/XlJ58Zi9A==,type:str]
 event_timezone: ENC[AES256_GCM,data:3TQqx+qbeJU+25l76fKyLc7OHQ==,iv:Goi/WKwFyMl0IGKG/pWGN3jZIHJmkyUd90M19ZK0CHg=,tag:qr1j5/zVLG7fcgnMtqcC3g==,type:str]
 deploy_announce_group_id: ENC[AES256_GCM,data:S6+bhVlDrI08EgqBiNOw4/ZE8gZJ/TVTUmljyIKbHQ5+VdY=,iv:OxZw4ZK5Q3huNnWF8h5PDm4MreWjbKeSSVEpjEJooP0=,tag:vA1Fgh7LvFK6TxCznJbvkw==,type:str]
-claude_code_oauth_token: ENC[AES256_GCM,data:PFKpkfjhxeZU9r1Y/kHrYGiMCmmDWaum5uM+EsimpDLh1s0txmaz+fbz0kRwaTBkSUKLjUxt19Uiva4UHQ2opRwm5nBdQC3tyB/KHHzNNjqP0OcUaK9BqTOlMrT8kvs+NPK6d/P/GBbQHtxY,iv:iR7fNnepq6EfTBwGbWezAfkocYH21Ijqjb6gbLgiXUk=,tag:LlJ3M9NRTTWAFzYs0za+bQ==,type:str]
+claude_code_oauth_token: ENC[AES256_GCM,data:6mCKvkmJPb5MfXsiIXXSkiLOEoccIdVvS/6O6gsYrPNq2wyUA+kgBZYIDAMaxDqV+9lUvzruQsHYnTKZ61J9eQ4gf5xKxdQQrHMLrZlCLB89wmQjpd6URo5Qiv1doVITNpnDirobqzDsdwKD,iv:yLMwzdm0EodCm6775O9Xv5dOe3kj0oErmw8s+7Bf/NQ=,tag:801zFFc3DJoF+zFPjc5MfA==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -31,7 +31,7 @@ sops:
             cjYremsrWjczcm42QjZDVFQ4czNmMG8Ky2xTXnTpeOAAWjZKvAZ8SuupXqZ+tMFW
             b92n4tsWONqZWY9iALoeIz/N4UhkgYNT5v+gBfNLyq3t9cFXqdXMgQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-21T09:01:38Z"
-    mac: ENC[AES256_GCM,data:iOPaNYT+ohCr08QX+URqqU0mc+o1QkVYC4lHon7B7MnnqQICpbzhONhpeyq+c5WuYRkS1VhzGpn598pF1L/iySFZrBAXY6MpuhwL0fvata1yWdyqPeYaj791zWXChsuYE8k8R+Vi9I//a0CF57kDnwsYZCEKOZ9pBvgqP6XSwI0=,iv:D5kfFLQGFVpdZYHcIQ5LtVI+qV25Xeg30L3vdqz6DE8=,tag:dTxZPuYERp8x3gMRmWVaGQ==,type:str]
+    lastmodified: "2026-06-28T01:30:22Z"
+    mac: ENC[AES256_GCM,data:4Z8qkfOhI/SuutSNWxERA4uOXd6gYtvaevHRq293qo0fprg8RYpn7F6AKN8MjvskoyaGRRvSNvIeWLYuuaXOjaiHjUXzLF/yHF5iud9p4P3SoRypqVcVa6TD95EUxLQRjm8sgomzik8KXk3a2GBOlbfAWONYvf1NLwu1hKyt+pU=,iv:X3qvmfR+KalytdY530FdE2p+T7Hs27jtj2Yf2uqjpZI=,tag:IroaP0gcmasjh1nB0ICd4g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/dreamfinder/secrets.yaml
+++ b/dreamfinder/secrets.yaml
@@ -16,7 +16,7 @@ livekit_api_key: ENC[AES256_GCM,data:NVduA/w4U9TBmPNBJbbuji9Urg==,iv:AA7Y5L1YgW8
 livekit_api_secret: ENC[AES256_GCM,data:R+4ssfUpTVTHiP1e/LcUpgf2ZAJTHnMNX8r29fBpNnWfK7snsXid3kKEiQVuH0W0wiF9MQUHCfaFrN6KvHi9bg==,iv:BcZXEHotQc/3uftpI8Dz3X1cPtt2RoU2XTsoGK3ufiY=,tag:uof7AJGxPejNRuAW0HmJ6Q==,type:str]
 admin_ids: ENC[AES256_GCM,data:1OtYW32mnu8WbuRH7np9yBka3AFcxRxmdxMMhUEBEfEmo3cSyTvQSMEp6BPnz/UA25zPCqn53oUsN05vJLW1w0YtCByYp1Vl03OwzJb3z95FSQ==,iv:aY0Z0c8JtiCcfbQpPufSmNjJBW9liO8CwDAvDRxAbC8=,tag:r35sNmYpEL1aR5hLJHNerg==,type:str]
 matrix_always_respond_rooms: ENC[AES256_GCM,data:HgVPhJsjYRqASvba5IEU+TRl8PPoKYldB4vGY4F2J15Hq5M=,iv:JZ+NE6H2RJ0Pp1myPmEh4AFFm1AUNWwJe4NDeR0+4b4=,tag:syyL8UUX6twGmg3rf+RX3w==,type:str]
-calendar_url: ENC[AES256_GCM,data:YqkXHhWb1KTzJOLN5jm742Stf/BoNLY2TzvzmxN2mG5FSWG6X6l1RLiYx/0A4iNMzMAJPY3lEp7Ky+K0,iv:gqnydGzMVhSgcirleUxwFWkh+da0Hua54WtXKVjwlCs=,tag:illLnGigADWR/XlJ58Zi9A==,type:str]
+calendar_url: ENC[AES256_GCM,data:jJ8+zawc3CGUqRMa7ZiX52+yXErrD7tVkRCyv6WfaGQDSDrjCrXByBz0IgaLZxAw9pIRmE8=,iv:oLgZ5cDxUdAVYaZD/zL2nKWMdAYN0dyNn8k2bTA+Oj4=,tag:+NNZJ0vsz0qvhZBZtW7GiQ==,type:str]
 event_timezone: ENC[AES256_GCM,data:3TQqx+qbeJU+25l76fKyLc7OHQ==,iv:Goi/WKwFyMl0IGKG/pWGN3jZIHJmkyUd90M19ZK0CHg=,tag:qr1j5/zVLG7fcgnMtqcC3g==,type:str]
 deploy_announce_group_id: ENC[AES256_GCM,data:S6+bhVlDrI08EgqBiNOw4/ZE8gZJ/TVTUmljyIKbHQ5+VdY=,iv:OxZw4ZK5Q3huNnWF8h5PDm4MreWjbKeSSVEpjEJooP0=,tag:vA1Fgh7LvFK6TxCznJbvkw==,type:str]
 claude_code_oauth_token: ENC[AES256_GCM,data:6mCKvkmJPb5MfXsiIXXSkiLOEoccIdVvS/6O6gsYrPNq2wyUA+kgBZYIDAMaxDqV+9lUvzruQsHYnTKZ61J9eQ4gf5xKxdQQrHMLrZlCLB89wmQjpd6URo5Qiv1doVITNpnDirobqzDsdwKD,iv:yLMwzdm0EodCm6775O9Xv5dOe3kj0oErmw8s+7Bf/NQ=,tag:801zFFc3DJoF+zFPjc5MfA==,type:str]
@@ -31,7 +31,7 @@ sops:
             cjYremsrWjczcm42QjZDVFQ4czNmMG8Ky2xTXnTpeOAAWjZKvAZ8SuupXqZ+tMFW
             b92n4tsWONqZWY9iALoeIz/N4UhkgYNT5v+gBfNLyq3t9cFXqdXMgQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-28T01:30:22Z"
-    mac: ENC[AES256_GCM,data:4Z8qkfOhI/SuutSNWxERA4uOXd6gYtvaevHRq293qo0fprg8RYpn7F6AKN8MjvskoyaGRRvSNvIeWLYuuaXOjaiHjUXzLF/yHF5iud9p4P3SoRypqVcVa6TD95EUxLQRjm8sgomzik8KXk3a2GBOlbfAWONYvf1NLwu1hKyt+pU=,iv:X3qvmfR+KalytdY530FdE2p+T7Hs27jtj2Yf2uqjpZI=,tag:IroaP0gcmasjh1nB0ICd4g==,type:str]
+    lastmodified: "2026-06-28T01:38:16Z"
+    mac: ENC[AES256_GCM,data:7PVPAbnvBQ72ULe3wHQjp8Ur72HWHM95xGxfJytJ9FwSO/EZ80Pll2bXhWwRiSPy6nGQXfH8RjojEQDN/dUyVx8PAMgs30WZ59sf59d5FahSnUr1+pxBVNlZss3pjRBu7K2hynOMnsZsi5RQ+yFvMLcpbvMub3R27Hg7MKrcDpM=,iv:mgp+TslkzWCjakVB5608juYTbFbawX/5KksR2WotlMM=,tag:DIJOAqCktzNQe6BnQXPiiw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/embodied-dreamfinder/secrets.yaml
+++ b/embodied-dreamfinder/secrets.yaml
@@ -18,7 +18,7 @@ livekit_api_secret: ENC[AES256_GCM,data:qvjfsgBJtlg06vM7yDuPQ3ItglqirGRIWJh1EZC0
 df_brain: ENC[AES256_GCM,data:foYVWYcMXtd1,iv:gbWh1FC2AAu9/o7eE56spgvfgr+7hLRXJF5NsphtDW4=,tag:INKfMXpn0q5BfYKoI66vug==,type:str]
 tts_engine: ENC[AES256_GCM,data:/SteIGEI,iv:sHLPP8Om1/ftvLmZC2QEe49VmyUtl7z3ccRkJahagl8=,tag:L9QHzy0fTojQBGAxoKYYQQ==,type:str]
 lyra_ssh_key: ENC[AES256_GCM,data:LVW4AAVJGdUB0Trdpv1STs13/Gj4,iv:0kQRpOo71ooQc+FvPW9TdAYRQ24uk22Mv1UzDpPE+3Q=,tag:icO2sxON75msJdgQ1fgIDg==,type:str]
-claude_code_oauth_token: ENC[AES256_GCM,data:RZ5KofRdsuORdcqTwL2djLSn1Ak0jjI3qhdhzikHULUZ9exq6qUNFy65X0YUaOVWKBDO/jB4F0UacZ6jaUCkShlP8YqswQDR6nfN3r2EPQB7WJOl2mX3MNu8ArGFQ5+Jbww18usz8+yYKU0e,iv:I2t4ueYF3DbR0RwV7QLrB2i3SAWYMPjblhmOc5g7XBo=,tag:9AHSAQkvD1n7VSSajs+IKw==,type:str]
+claude_code_oauth_token: ENC[AES256_GCM,data:HHk7v/LU1c/4FSrB9WQ70/XIeVXBBf6J3MZY306lw3HUugKX7Pmcf0znM8RC+bF7q6S8twP0q+isIIc9h/MFgEASltlyr94XEA3m70eMtikMl+AV/+MD7mif83SKlErkm0ZejFFIyjl+d82D,iv:/6zq5sgdcTindR3NNmMyqAkLP5Xvdpg0u12Djofkoz4=,tag:SAql2K4nwmm0wALcJj5C5Q==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -30,7 +30,7 @@ sops:
             aTliSGZZNTJWeTVCeTJUTWI1QTBtZ2sKKS8eDR70HQgZ4vXcuUkaqhD3xH+AKsgM
             ZlT0Knz3kFt3ENRgOB9xPlN6WfpGwtcor2UCfTXAZpCWEqC51Ht3bg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-21T09:02:06Z"
-    mac: ENC[AES256_GCM,data:ypCaw99IbkGnUhOugA6f53qf8lC8ujuGicSLF0WOutawukQ5I0qdYTgLI5V/H3z3s5DVxanz9su/SJMLzha12iyBIorggUr7XHDuHKEl+sdwtajX5EKfFGlNu+LaVBp+0cSiV3fR0sCkBFY+QaX7Mox643uNt1ptalF5CQdfRS8=,iv:EY8B35UjC/KZbyAaMv5wAKjsvsVUd9qV/oLY/v4vOBI=,tag:Odxw8SRGqnaePkYlkqyhZg==,type:str]
+    lastmodified: "2026-06-28T01:30:22Z"
+    mac: ENC[AES256_GCM,data:UDYcxBMvVzYLNR6P09yKG6wcRcDMxIEBKQjqvUAl1WnnvWlFG1GUaRb5Hu6afUlhnbXGdv5mVjJHPZy+NkR7BNPRmHJl2JVs0pGpmvheNR1Fq/biVKKva6SDBOtqZHX3E6OzQlkNtbb46LFgoxgUCeFdiAJ6t/HfXq8BNLovIkA=,iv:sgPaAlKQbL4I67SN5pCulwXVMlf3H8Sf3wjznCdSHwg=,tag:slrfBQVqwjtHxz2pfc0DzQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/tech-world-bots/secrets.yaml
+++ b/tech-world-bots/secrets.yaml
@@ -7,7 +7,7 @@ kan_api_key: ENC[AES256_GCM,data:xoO/AbKKWqN8hePwExPxG6GPRKfr30dK4X4D788QTU4CzQI
 kan_board_id: ENC[AES256_GCM,data:TLYcelHGrEeZtiqq,iv:tIM7xgh5bwRLpm/NyHUCg1wZ/JR5I+qiK8gq6Op09Ig=,tag:y8EelezrtPnv7NBXJO+X8g==,type:str]
 outline_base_url: ENC[AES256_GCM,data:qOcgjiEObWsXElPsqkUfQQF+RlShJeuapeWsoMvYZ4u96R0=,iv:5aGsNgmevaEzIIpkdB4kYrLlmCmlCHf7wiyYeaOvneg=,tag:g6JiTV3H9Hn9r/MGegDklg==,type:str]
 outline_api_key: ""
-claude_code_oauth_token: ENC[AES256_GCM,data:8WG7X9wCFYxDLxuULi9QfG8StlHDACI97vPa7WXMctdIblNtgSclSRDCCPLB31YUZjgy8IP2P6cfGvsD6lCNOiXUS8G8u1ZlDcBUkRCoUvzF2VB+jJgLJfWHD3AihKdy4b9LztnSfFkvbRHI,iv:5lvuc7w5A7QICj6oogD0fLLtifL7sq2dnKGxE1uL0pE=,tag:zk4zBpvuAHBZsF242k8BEA==,type:str]
+claude_code_oauth_token: ENC[AES256_GCM,data:2np2BwyK8iP6I+d1KmURhYi9Fqb/q+1mkDWwKQtA0JmSaa4m1zWhcPIiByKaLFkqX7ACo/30jN0nqWHm4fkYY1T/hBgV6RV33HGGwl1/j45bdR+HkT63jHMMq4CX+PCNQOGo1oqjqgH4wjsF,iv:GKqu1Sw2aZSi4wXwmNKOSkC5VjGMOAFaYAOWECrEZwY=,tag:KiRnqsju8MbgXvnBwhLPhA==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -19,7 +19,7 @@ sops:
             b2VzMnBSblJTOTR5RENxYzJ2UUFhVmsKhzhpeH7n7Owwx0qo8TSapANSqYQphbuz
             iJbLwLHDqh8TwWBRa8pChJCO6A3HQWn3u/DNMmRAXJ3eqhNbKAItuQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-21T09:02:06Z"
-    mac: ENC[AES256_GCM,data:p2c53WNoxPdViH9+L6UU6D8A0rTeSsTuuy71w7VsQkIhyELMQB+Lhi/yAEzi4bv0YUUJCFxVCFdHliINfb4WS7fe5CXQLYUvu/8jj45JuTpSIMgsrkoY+CPIhBpK01PG4xzDP1Qe4WybLFC+YDKvnHLPewZe1/2RcknOPH+yaoA=,iv:aq/lbaHc9hJUldhFuh6bWsNfKNA/0eOxm1582TmNp7k=,tag:Pj3F8tDRwFthifObpSqUaA==,type:str]
+    lastmodified: "2026-06-28T01:30:22Z"
+    mac: ENC[AES256_GCM,data:wxTQd7JwqC75Wlik4kOh7XWVgUv1NA8veisUc2D83ynuaweg09u6lM5gZ0Z2+FCutyv6b6ovJ++7yidqCSkocwe2vIK4n6i5FVbXAnjwNZ5pHZBwoewr+BK4OKLKjlN4VWuvadY36Hsoev5YhWvBGVulHFsyACE4lC8/6NCZSj4=,iv:4AvFv/94J619fmI91Frd1Ru64PzWRcNgL0qX3wzN/DE=,tag:jYWITYFRmK8ZoNCHGOcWqw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
Rotates the CLAUDE_CODE_OAUTH_TOKEN shared by dreamfinder + embodied-dreamfinder + tech-world-bots (leaked via sops-d-to-console #26 + docker inspect #1223; new token validated against the API before writing; other 4 services carry distinct tokens, untouched). Also fixes dreamfinder CALENDAR_URL → /nick/imagineering-events/ (was the empty, pm-agent-forbidden /dreamfinder/ path → the 'zero calendar awareness' bug).

**Already deployed** to prod (all 4 token-consuming services on the new token; River verified reading 8 calendar events via the radicale CLI, zero MCP). This PR lands the change on origin/main durably.

⚠️ After merge: the old OAuth token must be REVOKED in the Claude account (all services migrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)