### PR TITLE
feat(self-healer): green-auto Telegram notify + two-way merge approve (Increment C, #571)

### DIFF
--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -246,8 +246,14 @@ phone. The merge gate stays HUMAN; the "yes" is approval, never a bypass.
   NICK_TELEGRAM_USER_ID=<Nick's Telegram user id>     # the ONLY approver (gate 1)
   HEALER_APPROVE_MERGE_TOKEN=<a GH token that can merge>  # SEPARATE from the bot token
   # optional: HEALER_APPROVE_DEFAULT_REPO=owner/name (resolves a bare "#N")
+  # recommended: HEALER_APPROVE_TRUSTED_REVIEWERS=nick,maxwell-merge-slam  (provenance pin)
   # cron (box): */2 * * * * node /opt/self-healer/src/approve-poll.mjs
   ```
+  When `HEALER_APPROVE_TRUSTED_REVIEWERS` is set, gate 3 additionally requires the PR's
+  APPROVE to come from one of those logins — so an `APPROVED` state can't ride a review
+  from an unexpected identity into the merge. Unset → the named tradeoff (reviewDecision
+  already excludes the PR author, so the green-auto bot can't self-approve; pinning the
+  *label* author is task #10).
   Honesty about `--admin`: the merge runs `gh pr merge --admin` because branch
   protection requires CI checks that **never run** (GHA is permanently out of minutes).
   `--admin` bypasses the *absent required* check — but gate 3 has already refused any

--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -223,5 +223,28 @@ act, done in this order (each step is the precondition for the next):
    in its body. Foreground the first run (verify each step) — do not cron-arm it
    until one finding has gone end-to-end and been reviewed.
 
-Remaining beyond this PR (tracked, not in scope here): the Telegram lifecycle notify
-+ two-way "yes merge" approve loop (the merge gate stays human regardless).
+### Telegram approve loop (Increment C — built, provisioned separately)
+
+green-auto pings Nick when it opens a draft PR (the orchestrator sends it — the caged
+agent has no egress to notify), and Nick can reply **"merge #N"** to merge from his
+phone. The merge gate stays HUMAN; the "yes" is approval, never a bypass.
+
+- **Notify (one-way)** rides the existing `notify` proxy — only needs `NOTIFY_API_KEY`
+  (already a healer env). Each draft PR → a ping with the link + the exact "merge #N"
+  reply; a stumble → a warning ping.
+- **Approve (two-way)** is `src/approve-poll.mjs`, run on a short cron on the box. It
+  polls the notify bot's `getUpdates`, and merges ONLY when all three gates hold:
+  (1) the message is from `NICK_TELEGRAM_USER_ID` (his specific id, not "anyone in the
+  chat"); (2) it unambiguously names the PR (URL, or a reply to the ping); (3) a LIVE
+  re-check shows the PR OPEN + mergeable + reviewer-APPROVED + `cage-matched`-labelled.
+  Fail-closed: refuses to start unless its creds are provisioned.
+  ```sh
+  HEALER_APPROVE_BOT_TOKEN=<the notify bot token>     # getUpdates + replies (read-only authority)
+  NICK_TELEGRAM_USER_ID=<Nick's Telegram user id>     # the ONLY approver (gate 1)
+  HEALER_APPROVE_MERGE_TOKEN=<a GH token that can merge>  # SEPARATE from the bot token
+  # optional: HEALER_APPROVE_DEFAULT_REPO=owner/name (resolves a bare "#N")
+  # cron (box): * * * * * node /opt/self-healer/src/approve-poll.mjs   # or every 2 min
+  ```
+  Note: `getUpdates` conflicts with a Telegram webhook — the notify bot must be in
+  polling mode (it is; `notify.py` only sends). The merge token is its OWN credential:
+  the bot only reads/replies, merge authority never rides the bot token.

--- a/self-healer/cage/README.md
+++ b/self-healer/cage/README.md
@@ -233,18 +233,29 @@ phone. The merge gate stays HUMAN; the "yes" is approval, never a bypass.
   (already a healer env). Each draft PR → a ping with the link + the exact "merge #N"
   reply; a stumble → a warning ping.
 - **Approve (two-way)** is `src/approve-poll.mjs`, run on a short cron on the box. It
-  polls the notify bot's `getUpdates`, and merges ONLY when all three gates hold:
+  polls the notify bot's `getUpdates` and merges ONLY when all gates hold:
   (1) the message is from `NICK_TELEGRAM_USER_ID` (his specific id, not "anyone in the
-  chat"); (2) it unambiguously names the PR (URL, or a reply to the ping); (3) a LIVE
-  re-check shows the PR OPEN + mergeable + reviewer-APPROVED + `cage-matched`-labelled.
-  Fail-closed: refuses to start unless its creds are provisioned.
+  chat"); (2) it unambiguously names the PR — a URL, or a reply to the **bot's own**
+  ping (a reply to a non-bot message is not trusted); (3) a LIVE re-check shows the PR
+  OPEN + `mergeable === MERGEABLE` (whitelist, not "not-conflicting") + reviewer-APPROVED
+  + `cage-matched`-labelled + **no status check failing or pending**. Fail-closed: a
+  single-instance lock prevents cron-overlap double-merges, and the poller refuses to
+  start unless its creds are provisioned.
   ```sh
   HEALER_APPROVE_BOT_TOKEN=<the notify bot token>     # getUpdates + replies (read-only authority)
   NICK_TELEGRAM_USER_ID=<Nick's Telegram user id>     # the ONLY approver (gate 1)
   HEALER_APPROVE_MERGE_TOKEN=<a GH token that can merge>  # SEPARATE from the bot token
   # optional: HEALER_APPROVE_DEFAULT_REPO=owner/name (resolves a bare "#N")
-  # cron (box): * * * * * node /opt/self-healer/src/approve-poll.mjs   # or every 2 min
+  # cron (box): */2 * * * * node /opt/self-healer/src/approve-poll.mjs
   ```
-  Note: `getUpdates` conflicts with a Telegram webhook — the notify bot must be in
-  polling mode (it is; `notify.py` only sends). The merge token is its OWN credential:
-  the bot only reads/replies, merge authority never rides the bot token.
+  Honesty about `--admin`: the merge runs `gh pr merge --admin` because branch
+  protection requires CI checks that **never run** (GHA is permanently out of minutes).
+  `--admin` bypasses the *absent required* check — but gate 3 has already refused any
+  check that EXISTS and isn't passing, plus required APPROVED + cage-matched, so it
+  never bypasses a *real* signal. The "yes" is human approval, not a gate bypass.
+  - `getUpdates` conflicts with a Telegram webhook — the notify bot must be in polling
+    mode (it is; `notify.py` only sends).
+  - **Merge-token blast radius (named tradeoff):** `--admin` needs *admin* on each repo
+    green-auto spans, so `HEALER_APPROVE_MERGE_TOKEN` is a broad multi-repo admin
+    credential. A fine-grained per-repo token set would be tighter; for v1 it's one
+    admin token, bounded by the human approval + the green gate above.

--- a/self-healer/src/approve-poll.mjs
+++ b/self-healer/src/approve-poll.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// approve-poll.mjs — the impure half of the Telegram merge-approval loop (C2). It
+// polls the notify bot's getUpdates, runs each through approve.mjs's PURE decision,
+// re-checks the PR is actually green, and merges on Nick's "merge" — then replies.
+//
+// Runs ON THE BOX (the same host as the healer cron) so it shares the notify bot.
+// Fail-CLOSED: refuses to start unless the approver id + bot token + merge token are
+// all provisioned (like green-auto's own gates). The merge token is SEPARATE from the
+// bot token — the bot only reads/replies; merging authority is its own credential.
+//
+//   HEALER_APPROVE_BOT_TOKEN   the notify bot token (getUpdates + sendMessage)
+//   NICK_TELEGRAM_USER_ID      the ONLY user id allowed to approve (gate 1)
+//   HEALER_APPROVE_MERGE_TOKEN a GH token that can merge the target PRs
+//   HEALER_APPROVE_DEFAULT_REPO optional "owner/name" for a bare "#N"
+//   HEALER_APPROVE_OFFSET_FILE  getUpdates offset state (default under the healer state dir)
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { approvalDecision, mergeGateOk } from './approve.mjs';
+
+/**
+ * Run ONE approval cycle over a batch of updates. PURE orchestration over INJECTED
+ * IO (so it's tested with fakes, no network/gh). Advances the offset past every
+ * update it considered — even ignored ones — so a non-approval is not re-examined
+ * forever. A merge is gated twice: approvalDecision (intent + auth + PR ref) AND a
+ * LIVE mergeGateOk on the fetched PR (green/approved/cage-matched) — the "yes" is
+ * approval, not a bypass.
+ * @returns {Promise<{newOffset: number|null, actions: object[]}>}
+ */
+export async function runApproveCycle(updates, io, cfg) {
+  const actions = [];
+  let maxId = null;
+  // Process in update_id order so the offset advances monotonically.
+  for (const u of [...updates].sort((a, b) => (a.update_id ?? 0) - (b.update_id ?? 0))) {
+    if (typeof u.update_id === 'number') maxId = Math.max(maxId ?? -Infinity, u.update_id);
+    const d = approvalDecision(u, cfg);
+    if (d.ignore) { actions.push({ updateId: d.updateId, ignored: d.ignore }); continue; }
+
+    const { repo, pr } = d.merge;
+    const ref = `${repo}#${pr}`;
+    let view;
+    try {
+      view = await io.viewPr(repo, pr);
+    } catch (e) {
+      await io.reply(`⚠️ Couldn't read ${ref}: ${e.message}`);
+      actions.push({ updateId: d.updateId, error: `view ${ref}: ${e.message}` });
+      continue;
+    }
+    const gate = mergeGateOk(view);
+    if (!gate.ok) {
+      await io.reply(`❌ Not merging ${ref}: ${gate.reason}. (Your “merge” is approval, not a bypass — fix the gate and re-approve.)`);
+      actions.push({ updateId: d.updateId, refused: gate.reason });
+      continue;
+    }
+    try {
+      await io.mergePr(repo, pr);
+      await io.reply(`✅ Merged ${ref} on your approval.`);
+      actions.push({ updateId: d.updateId, merged: ref });
+    } catch (e) {
+      await io.reply(`⚠️ Merge of ${ref} failed: ${e.message}`);
+      actions.push({ updateId: d.updateId, error: `merge ${ref}: ${e.message}` });
+    }
+  }
+  return { newOffset: maxId === null ? null : maxId + 1, actions };
+}
+
+// ── real IO wiring (only when run directly) ─────────────────────────────────────
+
+const TG = 'https://api.telegram.org';
+
+function readOffset(file) {
+  try { return Number(JSON.parse(readFileSync(file, 'utf8')).offset) || 0; } catch { return 0; }
+}
+function writeOffset(file, offset) {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify({ offset }), 'utf8');
+}
+
+async function tgGetUpdates(botToken, offset) {
+  const res = await fetch(`${TG}/bot${botToken}/getUpdates?timeout=0&offset=${offset}&allowed_updates=${encodeURIComponent('["message"]')}`,
+    { signal: AbortSignal.timeout(20_000) });
+  if (!res.ok) throw new Error(`getUpdates ${res.status}: ${(await res.text().catch(() => '')).slice(0, 200)}`);
+  const j = await res.json();
+  if (!j.ok) throw new Error(`getUpdates not ok: ${JSON.stringify(j).slice(0, 200)}`);
+  return j.result || [];
+}
+
+function makeRealIO(botToken, chatId, mergeToken) {
+  const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', env: { ...process.env, GH_TOKEN: mergeToken }, stdio: ['ignore', 'pipe', 'pipe'] });
+  return {
+    viewPr(repo, pr) {
+      const out = gh(['pr', 'view', String(pr), '-R', repo, '--json', 'state,mergeable,reviewDecision,labels,isDraft']);
+      return JSON.parse(out);
+    },
+    mergePr(repo, pr) {
+      const view = JSON.parse(gh(['pr', 'view', String(pr), '-R', repo, '--json', 'isDraft']));
+      if (view.isDraft) gh(['pr', 'ready', String(pr), '-R', repo]); // un-draft before merge
+      // --admin: branch protection requires CI checks that never run (GHA out of
+      // minutes); the human approval + cage-matched + APPROVED are the real gate.
+      gh(['pr', 'merge', String(pr), '-R', repo, '--squash', '--admin', '--delete-branch']);
+    },
+    async reply(text) {
+      const res = await fetch(`${TG}/bot${botToken}/sendMessage`, {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, text }), signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) process.stderr.write(`[approve] reply failed ${res.status}\n`);
+    },
+  };
+}
+
+async function main() {
+  const botToken = process.env.HEALER_APPROVE_BOT_TOKEN;
+  const nickUserId = Number(process.env.NICK_TELEGRAM_USER_ID);
+  const mergeToken = process.env.HEALER_APPROVE_MERGE_TOKEN;
+  const missing = [];
+  if (!botToken) missing.push('HEALER_APPROVE_BOT_TOKEN');
+  if (!nickUserId) missing.push('NICK_TELEGRAM_USER_ID');
+  if (!mergeToken) missing.push('HEALER_APPROVE_MERGE_TOKEN');
+  if (missing.length) {
+    process.stderr.write(`[approve] refusing to run — unprovisioned: ${missing.join(', ')}\n`);
+    process.exit(2);
+  }
+  const offsetFile = process.env.HEALER_APPROVE_OFFSET_FILE
+    || `${process.env.HEALER_STATE_DIR || `${process.env.HOME}/.self-healer`}/approve-offset.json`;
+  const cfg = { nickUserId, defaultRepo: process.env.HEALER_APPROVE_DEFAULT_REPO };
+
+  const offset = readOffset(offsetFile);
+  const updates = await tgGetUpdates(botToken, offset);
+  if (!updates.length) { process.stdout.write('[approve] no new updates\n'); return; }
+
+  // The reply chat is Nick's DM with the bot — derive it from the first update's chat
+  // so we answer where he wrote, and only ever to an authorized message's chat.
+  const io = makeRealIO(botToken, updates[0].message?.chat?.id, mergeToken);
+  const { newOffset, actions } = await runApproveCycle(updates, io, cfg);
+  if (newOffset !== null) writeOffset(offsetFile, newOffset);
+  for (const a of actions) process.stdout.write(`[approve] ${JSON.stringify(a)}\n`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('approve-poll.mjs')) {
+  main().catch((e) => { process.stderr.write(`[approve] FAILED: ${e.message}\n`); process.exit(1); });
+}

--- a/self-healer/src/approve-poll.mjs
+++ b/self-healer/src/approve-poll.mjs
@@ -15,7 +15,7 @@
 //   HEALER_APPROVE_OFFSET_FILE  getUpdates offset state (default under the healer state dir)
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, rmdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { approvalDecision, mergeGateOk } from './approve.mjs';
 
@@ -39,26 +39,29 @@ export async function runApproveCycle(updates, io, cfg) {
 
     const { repo, pr } = d.merge;
     const ref = `${repo}#${pr}`;
+    // Reply to the chat of THIS authorized message, never a batch-wide chat
+    // (cage-match #122 — else a success reply could go to a group/impostor chat).
+    const chat = d.chatId;
     let view;
     try {
       view = await io.viewPr(repo, pr);
     } catch (e) {
-      await io.reply(`⚠️ Couldn't read ${ref}: ${e.message}`);
+      await io.reply(chat, `⚠️ Couldn't read ${ref}: ${e.message}`);
       actions.push({ updateId: d.updateId, error: `view ${ref}: ${e.message}` });
       continue;
     }
     const gate = mergeGateOk(view);
     if (!gate.ok) {
-      await io.reply(`❌ Not merging ${ref}: ${gate.reason}. (Your “merge” is approval, not a bypass — fix the gate and re-approve.)`);
+      await io.reply(chat, `❌ Not merging ${ref}: ${gate.reason}. (Your “merge” is approval, not a bypass — fix the gate and re-approve.)`);
       actions.push({ updateId: d.updateId, refused: gate.reason });
       continue;
     }
     try {
       await io.mergePr(repo, pr);
-      await io.reply(`✅ Merged ${ref} on your approval.`);
+      await io.reply(chat, `✅ Merged ${ref} on your approval.`);
       actions.push({ updateId: d.updateId, merged: ref });
     } catch (e) {
-      await io.reply(`⚠️ Merge of ${ref} failed: ${e.message}`);
+      await io.reply(chat, `⚠️ Merge of ${ref} failed: ${e.message}`);
       actions.push({ updateId: d.updateId, error: `merge ${ref}: ${e.message}` });
     }
   }
@@ -77,30 +80,35 @@ function writeOffset(file, offset) {
   writeFileSync(file, JSON.stringify({ offset }), 'utf8');
 }
 
-async function tgGetUpdates(botToken, offset) {
-  const res = await fetch(`${TG}/bot${botToken}/getUpdates?timeout=0&offset=${offset}&allowed_updates=${encodeURIComponent('["message"]')}`,
-    { signal: AbortSignal.timeout(20_000) });
-  if (!res.ok) throw new Error(`getUpdates ${res.status}: ${(await res.text().catch(() => '')).slice(0, 200)}`);
+async function tgGet(botToken, method, query = '') {
+  const res = await fetch(`${TG}/bot${botToken}/${method}${query}`, { signal: AbortSignal.timeout(20_000) });
+  if (!res.ok) throw new Error(`${method} ${res.status}: ${(await res.text().catch(() => '')).slice(0, 200)}`);
   const j = await res.json();
-  if (!j.ok) throw new Error(`getUpdates not ok: ${JSON.stringify(j).slice(0, 200)}`);
-  return j.result || [];
+  if (!j.ok) throw new Error(`${method} not ok: ${JSON.stringify(j).slice(0, 200)}`);
+  return j.result;
 }
+const tgGetUpdates = (botToken, offset) =>
+  tgGet(botToken, 'getUpdates', `?timeout=0&offset=${offset}&allowed_updates=${encodeURIComponent('["message"]')}`);
 
-function makeRealIO(botToken, chatId, mergeToken) {
+function makeRealIO(botToken, mergeToken) {
   const gh = (args) => execFileSync('gh', args, { encoding: 'utf8', env: { ...process.env, GH_TOKEN: mergeToken }, stdio: ['ignore', 'pipe', 'pipe'] });
   return {
     viewPr(repo, pr) {
-      const out = gh(['pr', 'view', String(pr), '-R', repo, '--json', 'state,mergeable,reviewDecision,labels,isDraft']);
+      // statusCheckRollup is fetched so mergeGateOk can refuse a FAILING/pending check
+      // rather than --admin-bypassing it (cage-match #122, Carnot HIGH).
+      const out = gh(['pr', 'view', String(pr), '-R', repo, '--json', 'state,mergeable,reviewDecision,labels,isDraft,statusCheckRollup']);
       return JSON.parse(out);
     },
     mergePr(repo, pr) {
       const view = JSON.parse(gh(['pr', 'view', String(pr), '-R', repo, '--json', 'isDraft']));
       if (view.isDraft) gh(['pr', 'ready', String(pr), '-R', repo]); // un-draft before merge
-      // --admin: branch protection requires CI checks that never run (GHA out of
-      // minutes); the human approval + cage-matched + APPROVED are the real gate.
+      // --admin bypasses the ABSENT required check (GHA is out of minutes); mergeGateOk
+      // has already refused any check that EXISTS and isn't passing, and required an
+      // APPROVED + cage-matched PR — so --admin never bypasses a real signal.
       gh(['pr', 'merge', String(pr), '-R', repo, '--squash', '--admin', '--delete-branch']);
     },
-    async reply(text) {
+    async reply(chatId, text) {
+      if (!chatId) { process.stderr.write('[approve] reply skipped (no chat id)\n'); return; }
       const res = await fetch(`${TG}/bot${botToken}/sendMessage`, {
         method: 'POST', headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ chat_id: chatId, text }), signal: AbortSignal.timeout(15_000),
@@ -122,20 +130,31 @@ async function main() {
     process.stderr.write(`[approve] refusing to run — unprovisioned: ${missing.join(', ')}\n`);
     process.exit(2);
   }
-  const offsetFile = process.env.HEALER_APPROVE_OFFSET_FILE
-    || `${process.env.HEALER_STATE_DIR || `${process.env.HOME}/.self-healer`}/approve-offset.json`;
-  const cfg = { nickUserId, defaultRepo: process.env.HEALER_APPROVE_DEFAULT_REPO };
+  const stateDir = process.env.HEALER_STATE_DIR || `${process.env.HOME}/.self-healer`;
+  const offsetFile = process.env.HEALER_APPROVE_OFFSET_FILE || `${stateDir}/approve-offset.json`;
 
-  const offset = readOffset(offsetFile);
-  const updates = await tgGetUpdates(botToken, offset);
-  if (!updates.length) { process.stdout.write('[approve] no new updates\n'); return; }
+  // Single-instance lock so a cron overlap can't double-process a merge approval
+  // (cage-match #122, both adversaries). mkdir is atomic; a stale lock is cleared in
+  // finally. If another poller holds it, this run exits quietly.
+  const lockDir = `${stateDir}/approve.lock`;
+  mkdirSync(stateDir, { recursive: true });
+  try { mkdirSync(lockDir); } catch { process.stdout.write('[approve] another poller holds the lock — skipping\n'); return; }
+  try {
+    // The bot's own user id, so a reply-to only resolves a PR from the BOT's ping.
+    const me = await tgGet(botToken, 'getMe');
+    const cfg = { nickUserId, botUserId: me?.id, defaultRepo: process.env.HEALER_APPROVE_DEFAULT_REPO };
 
-  // The reply chat is Nick's DM with the bot — derive it from the first update's chat
-  // so we answer where he wrote, and only ever to an authorized message's chat.
-  const io = makeRealIO(botToken, updates[0].message?.chat?.id, mergeToken);
-  const { newOffset, actions } = await runApproveCycle(updates, io, cfg);
-  if (newOffset !== null) writeOffset(offsetFile, newOffset);
-  for (const a of actions) process.stdout.write(`[approve] ${JSON.stringify(a)}\n`);
+    const offset = readOffset(offsetFile);
+    const updates = await tgGetUpdates(botToken, offset);
+    if (!updates.length) { process.stdout.write('[approve] no new updates\n'); return; }
+
+    const io = makeRealIO(botToken, mergeToken); // reply chat is per-update now
+    const { newOffset, actions } = await runApproveCycle(updates, io, cfg);
+    if (newOffset !== null) writeOffset(offsetFile, newOffset);
+    for (const a of actions) process.stdout.write(`[approve] ${JSON.stringify(a)}\n`);
+  } finally {
+    try { rmdirSync(lockDir); } catch { /* best-effort */ }
+  }
 }
 
 if (process.argv[1] && process.argv[1].endsWith('approve-poll.mjs')) {

--- a/self-healer/src/approve-poll.mjs
+++ b/self-healer/src/approve-poll.mjs
@@ -50,7 +50,7 @@ export async function runApproveCycle(updates, io, cfg) {
       actions.push({ updateId: d.updateId, error: `view ${ref}: ${e.message}` });
       continue;
     }
-    const gate = mergeGateOk(view);
+    const gate = mergeGateOk(view, cfg);
     if (!gate.ok) {
       await io.reply(chat, `❌ Not merging ${ref}: ${gate.reason}. (Your “merge” is approval, not a bypass — fix the gate and re-approve.)`);
       actions.push({ updateId: d.updateId, refused: gate.reason });
@@ -96,7 +96,7 @@ function makeRealIO(botToken, mergeToken) {
     viewPr(repo, pr) {
       // statusCheckRollup is fetched so mergeGateOk can refuse a FAILING/pending check
       // rather than --admin-bypassing it (cage-match #122, Carnot HIGH).
-      const out = gh(['pr', 'view', String(pr), '-R', repo, '--json', 'state,mergeable,reviewDecision,labels,isDraft,statusCheckRollup']);
+      const out = gh(['pr', 'view', String(pr), '-R', repo, '--json', 'state,mergeable,reviewDecision,labels,isDraft,statusCheckRollup,reviews']);
       return JSON.parse(out);
     },
     mergePr(repo, pr) {
@@ -142,7 +142,9 @@ async function main() {
   try {
     // The bot's own user id, so a reply-to only resolves a PR from the BOT's ping.
     const me = await tgGet(botToken, 'getMe');
-    const cfg = { nickUserId, botUserId: me?.id, defaultRepo: process.env.HEALER_APPROVE_DEFAULT_REPO };
+    const trustedReviewers = (process.env.HEALER_APPROVE_TRUSTED_REVIEWERS || '')
+      .split(',').map((s) => s.trim()).filter(Boolean);
+    const cfg = { nickUserId, botUserId: me?.id, defaultRepo: process.env.HEALER_APPROVE_DEFAULT_REPO, trustedReviewers };
 
     const offset = readOffset(offsetFile);
     const updates = await tgGetUpdates(botToken, offset);

--- a/self-healer/src/approve.mjs
+++ b/self-healer/src/approve.mjs
@@ -1,0 +1,89 @@
+// approve.mjs — the PURE decision core of the two-way Telegram merge-approval loop
+// (Increment C2). Given a Telegram `getUpdates` message and the config, it decides:
+// merge PR <repo#N>, or ignore (with a reason). The impure half — polling
+// getUpdates, re-checking the PR is green, running `gh pr merge`, replying — lives
+// in approve-poll.mjs. Keeping the decision pure means the THREE security gates the
+// task mandates are unit-tested exhaustively without a network:
+//
+//   1. AUTHENTICATE THE APPROVER — the message must come from Nick's SPECIFIC
+//      Telegram user id (from.id), not "anyone in the chat". A group the bot is in
+//      could contain others; only Nick's id may approve.
+//   2. UNAMBIGUOUS PR REFERENCE — the approval must name exactly which PR, either by
+//      a full GitHub PR URL in the text, or by replying to the bot's PR ping (whose
+//      text carries the URL). A bare "#N" without a repo is refused (green-auto spans
+//      repos — an unqualified number is ambiguous, so fail closed).
+//   3. The decision here is APPROVAL INTENT ONLY. Whether the PR is actually green
+//      (mergeable + cage-matched + reviewed) is re-checked live by the poller before
+//      it merges — the "yes" is human approval, never a gate bypass.
+//
+// Fail-closed everywhere: anything not unambiguously "Nick said merge THIS pr" → ignore.
+
+/** A full GitHub PR URL → {repo: "owner/name", pr: N}, or null. Tightened to the
+ * exact host + /pull/ shape so a lookalike (evil-github.com, /pulls/) can't match. */
+export function parsePrUrl(text) {
+  const m = /https:\/\/github\.com\/([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)\/pull\/(\d+)\b/.exec(String(text || ''));
+  return m ? { repo: m[1], pr: Number(m[2]) } : null;
+}
+
+/** True iff `text` carries an explicit approval verb. Deliberately strict: the word
+ * "merge" or "approve" must be present — a bare "yes"/"ok" is NOT enough (too easy to
+ * fire by accident in a chat). Case-insensitive, allows a leading "yes ,". */
+export function isApprovalText(text) {
+  return /\b(merge|approve)\b/i.test(String(text || ''));
+}
+
+/**
+ * Decide what to do with one Telegram update. PURE.
+ * @param {object} update  a Telegram getUpdates result item
+ * @param {{nickUserId: number, defaultRepo?: string}} cfg
+ *   nickUserId — the ONLY user id allowed to approve (gate 1).
+ *   defaultRepo — optional "owner/name" to resolve a bare "#N" against; omit to
+ *     REQUIRE a URL/reply (the safe default for a multi-repo healer).
+ * @returns {{merge: {repo: string, pr: number}, updateId: number}
+ *          | {ignore: string, updateId: number}}
+ */
+export function approvalDecision(update, cfg = {}) {
+  const updateId = update?.update_id;
+  const msg = update?.message;
+  if (!msg) return { ignore: 'no message in update', updateId };
+
+  // Gate 1: the approver MUST be Nick's specific user id.
+  if (!cfg.nickUserId || msg.from?.id !== cfg.nickUserId) {
+    return { ignore: `sender ${msg.from?.id ?? '?'} is not the authorized approver`, updateId };
+  }
+
+  // Must carry an explicit approval verb.
+  if (!isApprovalText(msg.text)) return { ignore: 'no approval verb (need "merge"/"approve")', updateId };
+
+  // Gate 2: resolve WHICH PR. Prefer a URL in the approval text, then the quoted
+  // ping's text (reply-to), then a bare #N against a configured default repo.
+  const fromText = parsePrUrl(msg.text);
+  const fromReply = parsePrUrl(msg.reply_to_message?.text);
+  let target = fromText || fromReply;
+  if (!target) {
+    const bare = /(?:^|\s)#?(\d{1,7})\b/.exec(String(msg.text || ''));
+    if (bare && cfg.defaultRepo) target = { repo: cfg.defaultRepo, pr: Number(bare[1]) };
+  }
+  if (!target) return { ignore: 'approval did not unambiguously reference a PR (need a PR URL or a reply to the ping)', updateId };
+
+  return { merge: target, updateId };
+}
+
+/**
+ * The LIVE merge gate, evaluated by the poller against `gh pr view` JSON before it
+ * merges — the "your yes is approval, not a bypass" rule. PURE so it's exhaustively
+ * tested. Requires the PR to be OPEN, not conflicting, reviewer-APPROVED, AND carry
+ * the `cage-matched` label (the signal that the adversarial review passed). A draft
+ * is allowed (the poller marks it ready first) — draftness is not a block, an
+ * un-reviewed or un-cage-matched PR is.
+ * @param {{state?: string, mergeable?: string, reviewDecision?: string, labels?: Array<{name?:string}|string>}} pr
+ * @returns {{ok: true} | {ok: false, reason: string}}
+ */
+export function mergeGateOk(pr) {
+  if (!pr || pr.state !== 'OPEN') return { ok: false, reason: `PR is not open (state=${pr?.state ?? '?'})` };
+  if (pr.mergeable === 'CONFLICTING') return { ok: false, reason: 'PR has merge conflicts' };
+  if (pr.reviewDecision !== 'APPROVED') return { ok: false, reason: `PR is not approved (reviewDecision=${pr.reviewDecision || 'none'})` };
+  const labels = (pr.labels || []).map((l) => (typeof l === 'string' ? l : l?.name));
+  if (!labels.includes('cage-matched')) return { ok: false, reason: 'PR is not cage-matched (missing the cage-matched label)' };
+  return { ok: true };
+}

--- a/self-healer/src/approve.mjs
+++ b/self-healer/src/approve.mjs
@@ -83,10 +83,14 @@ export function approvalDecision(update, cfg = {}) {
  * the `cage-matched` label (the signal that the adversarial review passed). A draft
  * is allowed (the poller marks it ready first) — draftness is not a block, an
  * un-reviewed or un-cage-matched PR is.
- * @param {{state?: string, mergeable?: string, reviewDecision?: string, labels?: Array<{name?:string}|string>, statusCheckRollup?: Array<object>}} pr
+ * @param {{state?: string, mergeable?: string, reviewDecision?: string, labels?: Array<{name?:string}|string>, statusCheckRollup?: Array<object>, reviews?: Array<{state?: string, author?: {login?: string}}>}} pr
+ * @param {{trustedReviewers?: string[]}} [cfg]  when non-empty, an APPROVE must come
+ *   from one of these logins (provenance pin, cage-match #122). Unset → the named
+ *   tradeoff: reviewDecision===APPROVED already excludes the PR author, so the
+ *   green-auto bot can't self-approve; Nick's explicit Telegram "merge" is gate 1.
  * @returns {{ok: true} | {ok: false, reason: string}}
  */
-export function mergeGateOk(pr) {
+export function mergeGateOk(pr, cfg = {}) {
   if (!pr || pr.state !== 'OPEN') return { ok: false, reason: `PR is not open (state=${pr?.state ?? '?'})` };
   // WHITELIST, not blacklist: only an explicitly MERGEABLE PR. GitHub's UNKNOWN /
   // null is "not yet computed" and must NOT slip through to an --admin merge
@@ -97,6 +101,14 @@ export function mergeGateOk(pr) {
   if (!labels.includes('cage-matched')) return { ok: false, reason: 'PR is not cage-matched (missing the cage-matched label)' };
   const badCheck = failingCheck(pr.statusCheckRollup);
   if (badCheck) return { ok: false, reason: `a status check is not passing: ${badCheck}` };
+  // Provenance pin (opt-in): when a trusted-reviewer allowlist is configured, require
+  // an APPROVE from one of those logins, so an APPROVED PR can't ride a review from an
+  // unexpected identity into an --admin merge (cage-match #122, Carnot HIGH).
+  const trusted = cfg.trustedReviewers;
+  if (trusted && trusted.length) {
+    const byTrusted = (pr.reviews || []).some((r) => r?.state === 'APPROVED' && trusted.includes(r?.author?.login));
+    if (!byTrusted) return { ok: false, reason: `no APPROVE from a trusted reviewer (${trusted.join(', ')})` };
+  }
   return { ok: true };
 }
 

--- a/self-healer/src/approve.mjs
+++ b/self-healer/src/approve.mjs
@@ -35,38 +35,45 @@ export function isApprovalText(text) {
 /**
  * Decide what to do with one Telegram update. PURE.
  * @param {object} update  a Telegram getUpdates result item
- * @param {{nickUserId: number, defaultRepo?: string}} cfg
+ * @param {{nickUserId: number, botUserId?: number, defaultRepo?: string}} cfg
  *   nickUserId — the ONLY user id allowed to approve (gate 1).
+ *   botUserId — the notify bot's own user id; a reply-to only resolves the PR when
+ *     the replied-to message is the BOT's ping (cage-match #122, Carnot MEDIUM — else
+ *     an attacker in a group could plant a PR URL for Nick to reply to).
  *   defaultRepo — optional "owner/name" to resolve a bare "#N" against; omit to
  *     REQUIRE a URL/reply (the safe default for a multi-repo healer).
- * @returns {{merge: {repo: string, pr: number}, updateId: number}
- *          | {ignore: string, updateId: number}}
+ * @returns {{merge: {repo: string, pr: number}, updateId: number, chatId: number}
+ *          | {ignore: string, updateId: number, chatId: number}}
  */
 export function approvalDecision(update, cfg = {}) {
   const updateId = update?.update_id;
   const msg = update?.message;
-  if (!msg) return { ignore: 'no message in update', updateId };
+  if (!msg) return { ignore: 'no message in update', updateId, chatId: undefined };
+  const chatId = msg.chat?.id; // the chat to answer in — carried per update (cage-match #122)
 
   // Gate 1: the approver MUST be Nick's specific user id.
   if (!cfg.nickUserId || msg.from?.id !== cfg.nickUserId) {
-    return { ignore: `sender ${msg.from?.id ?? '?'} is not the authorized approver`, updateId };
+    return { ignore: `sender ${msg.from?.id ?? '?'} is not the authorized approver`, updateId, chatId };
   }
 
   // Must carry an explicit approval verb.
-  if (!isApprovalText(msg.text)) return { ignore: 'no approval verb (need "merge"/"approve")', updateId };
+  if (!isApprovalText(msg.text)) return { ignore: 'no approval verb (need "merge"/"approve")', updateId, chatId };
 
-  // Gate 2: resolve WHICH PR. Prefer a URL in the approval text, then the quoted
-  // ping's text (reply-to), then a bare #N against a configured default repo.
+  // Gate 2: resolve WHICH PR. Prefer a URL in the approval text; then the quoted
+  // ping's text — but ONLY when the replied-to message is the BOT's own ping (so a
+  // planted group message can't supply the target); then a bare #N against a
+  // configured default repo.
   const fromText = parsePrUrl(msg.text);
-  const fromReply = parsePrUrl(msg.reply_to_message?.text);
+  const replyIsBotPing = cfg.botUserId && msg.reply_to_message?.from?.id === cfg.botUserId;
+  const fromReply = replyIsBotPing ? parsePrUrl(msg.reply_to_message?.text) : null;
   let target = fromText || fromReply;
   if (!target) {
     const bare = /(?:^|\s)#?(\d{1,7})\b/.exec(String(msg.text || ''));
     if (bare && cfg.defaultRepo) target = { repo: cfg.defaultRepo, pr: Number(bare[1]) };
   }
-  if (!target) return { ignore: 'approval did not unambiguously reference a PR (need a PR URL or a reply to the ping)', updateId };
+  if (!target) return { ignore: 'approval did not unambiguously reference a PR (need a PR URL, or a reply to the bot ping)', updateId, chatId };
 
-  return { merge: target, updateId };
+  return { merge: target, updateId, chatId };
 }
 
 /**
@@ -76,14 +83,36 @@ export function approvalDecision(update, cfg = {}) {
  * the `cage-matched` label (the signal that the adversarial review passed). A draft
  * is allowed (the poller marks it ready first) — draftness is not a block, an
  * un-reviewed or un-cage-matched PR is.
- * @param {{state?: string, mergeable?: string, reviewDecision?: string, labels?: Array<{name?:string}|string>}} pr
+ * @param {{state?: string, mergeable?: string, reviewDecision?: string, labels?: Array<{name?:string}|string>, statusCheckRollup?: Array<object>}} pr
  * @returns {{ok: true} | {ok: false, reason: string}}
  */
 export function mergeGateOk(pr) {
   if (!pr || pr.state !== 'OPEN') return { ok: false, reason: `PR is not open (state=${pr?.state ?? '?'})` };
-  if (pr.mergeable === 'CONFLICTING') return { ok: false, reason: 'PR has merge conflicts' };
+  // WHITELIST, not blacklist: only an explicitly MERGEABLE PR. GitHub's UNKNOWN /
+  // null is "not yet computed" and must NOT slip through to an --admin merge
+  // (cage-match #122, both adversaries).
+  if (pr.mergeable !== 'MERGEABLE') return { ok: false, reason: `PR is not mergeable (mergeable=${pr.mergeable || 'unknown'})` };
   if (pr.reviewDecision !== 'APPROVED') return { ok: false, reason: `PR is not approved (reviewDecision=${pr.reviewDecision || 'none'})` };
   const labels = (pr.labels || []).map((l) => (typeof l === 'string' ? l : l?.name));
   if (!labels.includes('cage-matched')) return { ok: false, reason: 'PR is not cage-matched (missing the cage-matched label)' };
+  const badCheck = failingCheck(pr.statusCheckRollup);
+  if (badCheck) return { ok: false, reason: `a status check is not passing: ${badCheck}` };
   return { ok: true };
+}
+
+/** The name of the first status check that is NOT terminally passing (failing OR
+ * still running), or null if every check passes. An EMPTY/absent rollup → null: with
+ * GHA permanently out of minutes there are no checks, and `--admin` merges past the
+ * *absent required* check — but a check that EXISTS and is failing/pending blocks the
+ * merge here, so --admin never bypasses a real signal (cage-match #122, Carnot HIGH).
+ * Pass states: a CheckRun conclusion of SUCCESS/NEUTRAL/SKIPPED, or a StatusContext
+ * state of SUCCESS. Everything else (FAILURE/ERROR/PENDING/IN_PROGRESS/…) blocks. */
+export function failingCheck(rollup) {
+  for (const c of rollup || []) {
+    const concl = c?.conclusion; // CheckRun
+    const state = c?.state; // StatusContext
+    const passes = ['SUCCESS', 'NEUTRAL', 'SKIPPED'].includes(concl) || state === 'SUCCESS';
+    if (!passes) return c?.name || c?.context || concl || state || 'unknown check';
+  }
+  return null;
 }

--- a/self-healer/src/auto.mjs
+++ b/self-healer/src/auto.mjs
@@ -88,6 +88,29 @@ export function actionForExit(exitCode, fp) {
   return { action: AUTO_ACTIONS.FAILED, detail: `cage exited ${exitCode}` };
 }
 
+/** PURE: the PR number from a GitHub PR URL, or null. */
+export function prNumberFromUrl(url) {
+  const m = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/.exec(String(url || ''));
+  return m ? Number(m[1]) : null;
+}
+
+/** PURE: the Telegram lifecycle message for one green-auto outcome, or null when
+ * the outcome doesn't warrant pinging Nick (deduped / skipped / no-fix / refused are
+ * quiet — only an actual PR or a stumble is news). The CAGED ping carries the PR link
+ * + the finding signature + the exact "merge #N" reply that the approve listener
+ * (Increment C2) accepts; the FAILED ping flags that the monster stumbled. HTML. */
+export function formatAutoOutcome(o) {
+  if (o.action === AUTO_ACTIONS.CAGED) {
+    const n = prNumberFromUrl(o.prUrl);
+    const mergeHint = n ? `reply <b>“merge #${n}”</b>` : 'reply <b>“merge #&lt;PR&gt;”</b>';
+    return `🤖 <b>green-auto opened a draft PR</b>\n${o.prUrl || '(no url captured)'}\n<code>${o.container}</code>: ${o.signature || o.detail || ''}\n\nReview, then ${mergeHint} to merge (CI + cage-match must still be green — your “merge” is approval, not a bypass).`;
+  }
+  if (o.action === AUTO_ACTIONS.FAILED) {
+    return `⚠️ <b>green-auto stumbled</b> on <code>${o.container}</code>: ${o.detail || 'unknown error'} — no PR opened. Check the healer logs.`;
+  }
+  return null; // deduped / skipped / no-fix / refused → quiet
+}
+
 /** EVERY broad host token currently in the env (the healer's own GH-API creds,
  * any of the three names draft.mjs accepts). The bound green-auto token must
  * equal NONE of them — checking only the first (a `A || B || C` short-circuit)
@@ -285,14 +308,27 @@ function cleanupWorkdir(dir) {
   try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort; see note */ }
 }
 
-/** Spawn `node run-cage.mjs -- <agentCmd>` for one finding; resolve its exit code.
- * stdio inherited so the caged agent's output reaches the healer's logs. */
+/** Spawn `node run-cage.mjs -- <agentCmd>` for one finding; resolve {exitCode,
+ * stdout}. stderr is INHERITED (the agent's log() chatter streams to the healer's
+ * logs live); stdout is CAPTURED because the agent entrypoint prints ONLY the PR
+ * URL there — so the orchestrator can ping Nick with the link (Increment C). */
 function spawnCage({ bin, argv, env }) {
   return new Promise((resolve, reject) => {
-    const proc = spawn(bin, argv, { stdio: 'inherit', env: { ...process.env, ...env } });
+    const proc = spawn(bin, argv, { stdio: ['ignore', 'pipe', 'inherit'], env: { ...process.env, ...env } });
+    let stdout = '';
+    proc.stdout.on('data', (d) => { stdout += d; });
     proc.on('error', reject);
-    proc.on('exit', (code, signal) => resolve(signal ? `signal:${signal}` : (code ?? -1)));
+    proc.on('exit', (code, signal) => resolve({ exitCode: signal ? `signal:${signal}` : (code ?? -1), stdout }));
   });
+}
+
+/** The PR URL the agent printed on stdout (last non-blank line; the entrypoint
+ * writes ONLY the URL there). Returns '' if absent. A light guard that it looks
+ * like a GitHub PR URL so a stray stdout line doesn't masquerade as one. */
+export function prUrlFromStdout(stdout) {
+  const lines = String(stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+  const last = lines[lines.length - 1] || '';
+  return /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(last) ? last : '';
 }
 
 /**
@@ -356,12 +392,15 @@ export async function autoFixIfActionable(verdict, env = process.env) {
     try {
       workdirHost = await prepareWorkdir(repo, auth.token);
       const spawnSpec = buildRunCageSpawn({ finding: f, repo, workdirHost, token: auth.token, substrate: sub });
-      const exitCode = await spawnCage(spawnSpec);
+      const { exitCode, stdout } = await spawnCage(spawnSpec);
       const { action, detail } = actionForExit(exitCode, fp);
+      const prUrl = action === AUTO_ACTIONS.CAGED ? prUrlFromStdout(stdout) : '';
       outcomes.push({
         container: f.container,
         action,
         detail,
+        signature: f.signature, // for the lifecycle Telegram ping (Increment C)
+        prUrl,
         workdir: workdirHost,
         exitCode,
       });

--- a/self-healer/src/auto.mjs
+++ b/self-healer/src/auto.mjs
@@ -49,7 +49,7 @@ import { dirname, join } from 'node:path';
 import { actionableFindings, findingFingerprint, acquireDraftLock, releaseDraftLock } from './draft.mjs';
 import { repoForContainer } from './repos.mjs';
 import { runOnHostScript, isOnBox } from './host.mjs';
-import { scrubSecrets } from './notify.mjs';
+import { scrubSecrets, esc } from './notify.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 /** The one spawn door. green-auto and the escape probe share it so the
@@ -100,13 +100,16 @@ export function prNumberFromUrl(url) {
  * + the finding signature + the exact "merge #N" reply that the approve listener
  * (Increment C2) accepts; the FAILED ping flags that the monster stumbled. HTML. */
 export function formatAutoOutcome(o) {
+  // The container/signature/detail are log-derived = attacker-influenceable, and this
+  // renders under Telegram HTML parse_mode → escape every dynamic field (cage-match
+  // #122, Carnot). The PR URL is validated GitHub shape, but escape it too for safety.
   if (o.action === AUTO_ACTIONS.CAGED) {
     const n = prNumberFromUrl(o.prUrl);
     const mergeHint = n ? `reply <b>“merge #${n}”</b>` : 'reply <b>“merge #&lt;PR&gt;”</b>';
-    return `🤖 <b>green-auto opened a draft PR</b>\n${o.prUrl || '(no url captured)'}\n<code>${o.container}</code>: ${o.signature || o.detail || ''}\n\nReview, then ${mergeHint} to merge (CI + cage-match must still be green — your “merge” is approval, not a bypass).`;
+    return `🤖 <b>green-auto opened a draft PR</b>\n${esc(o.prUrl || '(no url captured)')}\n<code>${esc(o.container)}</code>: ${esc(o.signature || o.detail || '')}\n\nReview, then ${mergeHint} to merge (it must still be mergeable + cage-matched + approved — your “merge” is approval, not a bypass).`;
   }
   if (o.action === AUTO_ACTIONS.FAILED) {
-    return `⚠️ <b>green-auto stumbled</b> on <code>${o.container}</code>: ${o.detail || 'unknown error'} — no PR opened. Check the healer logs.`;
+    return `⚠️ <b>green-auto stumbled</b> on <code>${esc(o.container)}</code>: ${esc(o.detail || 'unknown error')} — no PR opened. Check the healer logs.`;
   }
   return null; // deduped / skipped / no-fix / refused → quiet
 }
@@ -328,7 +331,10 @@ function spawnCage({ bin, argv, env }) {
 export function prUrlFromStdout(stdout) {
   const lines = String(stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
   const last = lines[lines.length - 1] || '';
-  return /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(last) ? last : '';
+  // Extract JUST the URL (anchored at start), so a trailing "…/pull/42 DO-NOT-MERGE"
+  // can't ride along as part of the "url" (cage-match #122, Kelvin).
+  const m = /^(https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+)\b/.exec(last);
+  return m ? m[1] : '';
 }
 
 /**

--- a/self-healer/src/healer.mjs
+++ b/self-healer/src/healer.mjs
@@ -16,9 +16,9 @@ import { gatherSignals, assertValidContainerName } from './sensor.mjs';
 import { diagnose } from './diagnose.mjs';
 import { isOnBox } from './host.mjs';
 import { tierExitCode } from './tiers.mjs';
-import { pingIfNoteworthy } from './notify.mjs';
+import { pingIfNoteworthy, sendNotify } from './notify.mjs';
 import { draftIfActionable } from './draft.mjs';
-import { autoFixIfActionable } from './auto.mjs';
+import { autoFixIfActionable, formatAutoOutcome } from './auto.mjs';
 
 /**
  * Load + validate the watch list. Fails CLOSED on a malformed config so a bad
@@ -133,6 +133,16 @@ async function main() {
     const outcomes = await autoFixIfActionable(verdict);
     for (const o of outcomes) {
       process.stderr.write(`[healer] green-auto ${o.action}: ${o.container}${o.workdir ? ` [${o.workdir}]` : ''}${o.detail ? ` (${o.detail})` : ''}\n`);
+      // Lifecycle ping (Increment C): "PR opened" carries the link + the exact
+      // "merge #N" reply the approve listener accepts; a stumble flags for a look.
+      // The orchestrator (NOT the caged agent — it has no egress to notify) sends it.
+      // A notify failure must never change the diagnostic exit code, so each send is
+      // isolated: an error here is logged, not thrown.
+      const msg = formatAutoOutcome(o);
+      if (msg) {
+        try { await sendNotify(msg); }
+        catch (e) { process.stderr.write(`[healer] green-auto notify failed (non-fatal): ${e.message}\n`); }
+      }
     }
   } catch (err) {
     process.stderr.write(`[healer] green-auto FAILED (verdict still stands): ${err.message}\n`);

--- a/self-healer/src/notify.mjs
+++ b/self-healer/src/notify.mjs
@@ -162,23 +162,38 @@ export function passesCooldown(verdict, nowMs) {
 export async function pingIfNoteworthy(verdict, nowMs = Date.now()) {
   if (verdict.overallTier === 'green') return { pinged: false, reason: 'green — nothing to report' };
   if (process.env.HEALER_NO_PING === '1') return { pinged: false, reason: 'disabled via HEALER_NO_PING' };
-
-  const apiKey = process.env.NOTIFY_API_KEY;
-  if (!apiKey) return { pinged: false, reason: 'no NOTIFY_API_KEY configured' };
-
+  if (!process.env.NOTIFY_API_KEY) return { pinged: false, reason: 'no NOTIFY_API_KEY configured' };
   if (!passesCooldown(verdict, nowMs)) return { pinged: false, reason: 'cooldown — same problem set recently pinged' };
 
-  const url = resolveNotifyUrl();
-  const message = formatVerdict(verdict);
-  const res = await fetch(url, {
+  const { sent, reason } = await sendNotify(formatVerdict(verdict));
+  return sent ? { pinged: true } : { pinged: false, reason };
+}
+
+/**
+ * Send a raw message to Nick via the notify proxy. Scrubs secrets + caps to
+ * Telegram's length limit. A SILENT no-op (sent:false) when NOTIFY_API_KEY is
+ * unset, so a dev run never errors and an unconfigured box never throws. Used for
+ * green-auto lifecycle pings (PR opened / failed) where there is no verdict —
+ * `pingIfNoteworthy` delegates its actual POST here too. Respects HEALER_NO_PING.
+ * @param {string} message  may contain attacker-influenceable diagnosis text → scrubbed
+ * @param {{parseMode?: string}} [opts]
+ * @returns {Promise<{sent: boolean, reason?: string}>}
+ */
+export async function sendNotify(message, { parseMode = 'HTML' } = {}) {
+  if (process.env.HEALER_NO_PING === '1') return { sent: false, reason: 'disabled via HEALER_NO_PING' };
+  const apiKey = process.env.NOTIFY_API_KEY;
+  if (!apiKey) return { sent: false, reason: 'no NOTIFY_API_KEY configured' };
+
+  const safe = scrubSecrets(String(message ?? '')).slice(0, TELEGRAM_MAX);
+  const res = await fetch(resolveNotifyUrl(), {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({ message, parse_mode: 'HTML' }),
+    body: JSON.stringify({ message: safe, parse_mode: parseMode }),
     signal: AbortSignal.timeout(15_000),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     throw new Error(`notify /send failed (${res.status}): ${body.slice(0, 200)}`);
   }
-  return { pinged: true };
+  return { sent: true };
 }

--- a/self-healer/src/notify.mjs
+++ b/self-healer/src/notify.mjs
@@ -75,7 +75,7 @@ export function scrubSecrets(text) {
 /** Escape the five HTML metacharacters so dynamic text can't break out of (or
  * inject into) the Telegram HTML parse_mode — including quotes, so the markup
  * stays safe if an attribute-bearing tag is ever added. */
-function esc(text) {
+export function esc(text) {
   return String(text ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/self-healer/src/notify.mjs
+++ b/self-healer/src/notify.mjs
@@ -30,17 +30,21 @@ const TELEGRAM_MAX = 4096; // Telegram's hard message-length limit.
 // Known secret PREFIXES — the first line of defence (cheap, precise). NOT the
 // only line: the generic rules below catch the shapes a prefix list can't.
 const KNOWN_SECRET_PATTERNS = [
-  [/\bsk-ant-[a-zA-Z0-9_-]{6,}/g, '<redacted:anthropic-key>'],
-  [/\b(?:github_pat|gh[posru])_[A-Za-z0-9_]{16,}/g, '<redacted:github-token>'],
-  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, '<redacted:slack-token>'],
-  [/\bAIza[A-Za-z0-9_-]{20,}/g, '<redacted:google-key>'],
-  [/\bsk-(?:proj-)?[A-Za-z0-9]{20,}/g, '<redacted:openai-key>'],
-  [/\bsk_(?:live|test)_[A-Za-z0-9]{16,}/g, '<redacted:stripe-key>'],
-  [/\bxkeysib-[A-Za-z0-9]{16,}/g, '<redacted:brevo-key>'],
-  [/\bAKIA[0-9A-Z]{16}\b/g, '<redacted:aws-key-id>'],
-  [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/g, '<redacted:bearer>'],
-  [/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}/g, '<redacted:jwt>'],
-  [/-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----/g, '<redacted:private-key>'],
+  // Markers use SQUARE brackets, not angle, so they are HTML-safe: scrubbing may run
+  // AFTER a field is HTML-escaped (sendNotify scrubs the final message), and an
+  // angle-bracket marker would reintroduce raw <…> and break Telegram HTML parse_mode
+  // (cage-match #122, Carnot).
+  [/\bsk-ant-[a-zA-Z0-9_-]{6,}/g, '[redacted:anthropic-key]'],
+  [/\b(?:github_pat|gh[posru])_[A-Za-z0-9_]{16,}/g, '[redacted:github-token]'],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, '[redacted:slack-token]'],
+  [/\bAIza[A-Za-z0-9_-]{20,}/g, '[redacted:google-key]'],
+  [/\bsk-(?:proj-)?[A-Za-z0-9]{20,}/g, '[redacted:openai-key]'],
+  [/\bsk_(?:live|test)_[A-Za-z0-9]{16,}/g, '[redacted:stripe-key]'],
+  [/\bxkeysib-[A-Za-z0-9]{16,}/g, '[redacted:brevo-key]'],
+  [/\bAKIA[0-9A-Z]{16}\b/g, '[redacted:aws-key-id]'],
+  [/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/g, '[redacted:bearer]'],
+  [/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}/g, '[redacted:jwt]'],
+  [/-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----/g, '[redacted:private-key]'],
 ];
 
 /**
@@ -65,10 +69,10 @@ export function scrubSecrets(text) {
   // 2. sensitive key=value / key: value (preserve the key name, redact value).
   out = out.replace(
     /\b(pass(?:word|wd)?|secret|api[_-]?key|apikey|client[_-]?secret|access[_-]?key|auth(?:orization)?|token)\b(\s*[=:]\s*)('?"?)[^\s'"]+/gi,
-    (_m, key, sep) => `${key}${sep}<redacted>`,
+    (_m, key, sep) => `${key}${sep}[redacted]`,
   );
   // 3. high-entropy catch-all: any 32+ char run of credential-alphabet chars.
-  out = out.replace(/\b[A-Za-z0-9+/_-]{32,}={0,2}\b/g, '<redacted:high-entropy>');
+  out = out.replace(/\b[A-Za-z0-9+/_-]{32,}={0,2}\b/g, '[redacted:high-entropy]');
   return out;
 }
 

--- a/self-healer/test/approve.test.mjs
+++ b/self-healer/test/approve.test.mjs
@@ -1,0 +1,145 @@
+// approve.test.mjs — the merge-approval loop's security gates (Increment C2).
+//
+// This decides whether a Telegram message MERGES a PR, so the gates get exhaustive,
+// adversarial coverage: only Nick's id may approve; the PR must be unambiguously
+// referenced; a non-green PR is refused even on a valid approval; the offset always
+// advances so a message isn't acted on twice. Every "merge" path is also re-gated by
+// a LIVE mergeGateOk in runApproveCycle — proven here with a fake that returns a
+// non-green PR and asserting NO merge fires.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parsePrUrl, isApprovalText, approvalDecision, mergeGateOk } from '../src/approve.mjs';
+import { runApproveCycle } from '../src/approve-poll.mjs';
+
+const NICK = 12345;
+const ping = (n) => `🤖 green-auto opened a draft PR\nhttps://github.com/imagineering-cc/x/pull/${n}\nfoo`;
+const msg = (over = {}) => ({ update_id: 1, message: { from: { id: NICK }, text: 'merge', chat: { id: 999 }, ...over } });
+
+// ── parsing ──────────────────────────────────────────────────────────────────
+
+test('parsePrUrl: exact github PR URL only', () => {
+  assert.deepEqual(parsePrUrl('see https://github.com/o/r/pull/42 now'), { repo: 'o/r', pr: 42 });
+  assert.equal(parsePrUrl('https://evil-github.com/o/r/pull/42'), null); // lookalike host
+  assert.equal(parsePrUrl('https://github.com/o/r/pulls/42'), null); // wrong path
+  assert.equal(parsePrUrl('https://github.com/o/r/issues/42'), null);
+});
+
+test('isApprovalText: requires the word merge/approve, not a bare yes', () => {
+  assert.ok(isApprovalText('merge #42'));
+  assert.ok(isApprovalText('yes, merge it'));
+  assert.ok(isApprovalText('APPROVE'));
+  assert.equal(isApprovalText('yes'), false); // too weak to fire a merge
+  assert.equal(isApprovalText('ok'), false);
+  assert.equal(isApprovalText(''), false);
+});
+
+// ── gate 1: authentication ─────────────────────────────────────────────────────
+
+test('approvalDecision: a message from anyone but Nick is IGNORED', () => {
+  const d = approvalDecision(msg({ from: { id: 99999 }, text: `merge ${ping(42)}` }), { nickUserId: NICK });
+  assert.ok(d.ignore);
+  assert.match(d.ignore, /not the authorized approver/);
+});
+
+test('approvalDecision: nickUserId unset → never authorizes (fail closed)', () => {
+  const d = approvalDecision(msg({ text: 'merge https://github.com/o/r/pull/1' }), {});
+  assert.ok(d.ignore);
+});
+
+// ── gate 2: unambiguous PR reference ───────────────────────────────────────────
+
+test('approvalDecision: URL in the approval text → merge that exact repo+pr', () => {
+  const d = approvalDecision(msg({ text: 'merge https://github.com/o/r/pull/7' }), { nickUserId: NICK });
+  assert.deepEqual(d.merge, { repo: 'o/r', pr: 7 });
+});
+
+test('approvalDecision: reply to the ping → PR resolved from the QUOTED text', () => {
+  const d = approvalDecision(msg({ text: 'merge', reply_to_message: { text: ping(55) } }), { nickUserId: NICK });
+  assert.deepEqual(d.merge, { repo: 'imagineering-cc/x', pr: 55 });
+});
+
+test('approvalDecision: bare "#N" with NO repo context is refused (multi-repo ambiguity)', () => {
+  const d = approvalDecision(msg({ text: 'merge #42' }), { nickUserId: NICK });
+  assert.ok(d.ignore);
+  assert.match(d.ignore, /unambiguously reference/);
+});
+
+test('approvalDecision: bare "#N" resolves ONLY against a configured defaultRepo', () => {
+  const d = approvalDecision(msg({ text: 'merge #42' }), { nickUserId: NICK, defaultRepo: 'o/r' });
+  assert.deepEqual(d.merge, { repo: 'o/r', pr: 42 });
+});
+
+test('approvalDecision: approval verb but no PR anywhere → ignore', () => {
+  assert.ok(approvalDecision(msg({ text: 'merge it please' }), { nickUserId: NICK }).ignore);
+});
+
+test('approvalDecision: a non-approval message from Nick → ignore (not every message merges)', () => {
+  assert.ok(approvalDecision(msg({ text: 'thanks!' }), { nickUserId: NICK }).ignore);
+});
+
+// ── gate 3: the live green gate ─────────────────────────────────────────────────
+
+test('mergeGateOk: passes only an OPEN, non-conflicting, APPROVED, cage-matched PR', () => {
+  assert.deepEqual(mergeGateOk({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] }), { ok: true });
+});
+
+test('mergeGateOk: refuses each missing condition', () => {
+  assert.match(mergeGateOk({ state: 'MERGED', labels: [] }).reason, /not open/);
+  assert.match(mergeGateOk({ state: 'OPEN', mergeable: 'CONFLICTING', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] }).reason, /conflict/);
+  assert.match(mergeGateOk({ state: 'OPEN', reviewDecision: 'REVIEW_REQUIRED', labels: [{ name: 'cage-matched' }] }).reason, /not approved/);
+  assert.match(mergeGateOk({ state: 'OPEN', reviewDecision: 'APPROVED', labels: [] }).reason, /not cage-matched/);
+});
+
+// ── runApproveCycle: orchestration over injected IO ─────────────────────────────
+
+function fakeIO(prView) {
+  const calls = { merged: [], replies: [] };
+  return {
+    calls,
+    viewPr: async () => prView,
+    mergePr: async (repo, pr) => { calls.merged.push(`${repo}#${pr}`); },
+    reply: async (t) => { calls.replies.push(t); },
+  };
+}
+
+test('runApproveCycle: a valid approval of a GREEN PR merges + confirms + advances offset', async () => {
+  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] });
+  const updates = [{ update_id: 10, message: { from: { id: NICK }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(7) } } }];
+  const { newOffset, actions } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  assert.deepEqual(io.calls.merged, ['imagineering-cc/x#7']);
+  assert.match(io.calls.replies[0], /Merged/);
+  assert.equal(newOffset, 11); // offset advances past the processed update
+  assert.equal(actions[0].merged, 'imagineering-cc/x#7');
+});
+
+test('runApproveCycle: a valid approval of a NON-GREEN PR does NOT merge (the live gate holds)', async () => {
+  const io = fakeIO({ state: 'OPEN', reviewDecision: 'REVIEW_REQUIRED', labels: [] });
+  const updates = [{ update_id: 5, message: { from: { id: NICK }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(7) } } }];
+  const { newOffset, actions } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  assert.deepEqual(io.calls.merged, [], 'must NOT merge an un-approved PR even on a valid "merge"');
+  assert.match(io.calls.replies[0], /Not merging/);
+  assert.equal(newOffset, 6); // still advances so it isn't re-tried forever
+  assert.equal(actions[0].refused !== undefined, true);
+});
+
+test('runApproveCycle: an impostor message merges nothing but still advances the offset', async () => {
+  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] });
+  const updates = [{ update_id: 8, message: { from: { id: 666 }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(7) } } }];
+  const { newOffset, actions } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  assert.deepEqual(io.calls.merged, []);
+  assert.deepEqual(io.calls.replies, []); // we don't even reply to an impostor
+  assert.equal(newOffset, 9);
+  assert.ok(actions[0].ignored);
+});
+
+test('runApproveCycle: processes a batch in update_id order; offset = max+1', async () => {
+  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: ['cage-matched'] });
+  const updates = [
+    { update_id: 30, message: { from: { id: NICK }, text: 'hi', chat: { id: 1 } } },
+    { update_id: 31, message: { from: { id: NICK }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(9) } } },
+  ];
+  const { newOffset } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  assert.deepEqual(io.calls.merged, ['imagineering-cc/x#9']);
+  assert.equal(newOffset, 32);
+});

--- a/self-healer/test/approve.test.mjs
+++ b/self-healer/test/approve.test.mjs
@@ -119,6 +119,19 @@ test('mergeGateOk: a FAILING or still-running check blocks the merge (no --admin
   assert.match(mergeGateOk({ ...GREEN, statusCheckRollup: [{ name: 'ci', status: 'IN_PROGRESS', conclusion: null }] }).reason, /not passing/);
 });
 
+test('mergeGateOk: trustedReviewers (opt-in) requires an APPROVE from a trusted login', () => {
+  const withReviews = { ...GREEN, reviews: [{ state: 'APPROVED', author: { login: 'nick' } }] };
+  // unset → named tradeoff, passes on reviewDecision alone
+  assert.deepEqual(mergeGateOk(withReviews), { ok: true });
+  // configured + a trusted approver present → ok
+  assert.deepEqual(mergeGateOk(withReviews, { trustedReviewers: ['nick', 'maxwell'] }), { ok: true });
+  // configured but the approve came from an UNtrusted login → refused
+  const byStranger = { ...GREEN, reviews: [{ state: 'APPROVED', author: { login: 'randobot' } }] };
+  assert.match(mergeGateOk(byStranger, { trustedReviewers: ['nick'] }).reason, /trusted reviewer/);
+  // configured but NO approving review object present → refused
+  assert.match(mergeGateOk(GREEN, { trustedReviewers: ['nick'] }).reason, /trusted reviewer/);
+});
+
 test('failingCheck: passes SUCCESS/NEUTRAL/SKIPPED + StatusContext SUCCESS; absent → null', () => {
   assert.equal(failingCheck([]), null);
   assert.equal(failingCheck(undefined), null);

--- a/self-healer/test/approve.test.mjs
+++ b/self-healer/test/approve.test.mjs
@@ -9,12 +9,16 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parsePrUrl, isApprovalText, approvalDecision, mergeGateOk } from '../src/approve.mjs';
+import { parsePrUrl, isApprovalText, approvalDecision, mergeGateOk, failingCheck } from '../src/approve.mjs';
 import { runApproveCycle } from '../src/approve-poll.mjs';
 
 const NICK = 12345;
+const BOT = 555; // the notify bot's own user id
+const CFG = { nickUserId: NICK, botUserId: BOT };
 const ping = (n) => `🤖 green-auto opened a draft PR\nhttps://github.com/imagineering-cc/x/pull/${n}\nfoo`;
+const botPing = (n) => ({ text: ping(n), from: { id: BOT } }); // a reply-to that IS the bot's ping
 const msg = (over = {}) => ({ update_id: 1, message: { from: { id: NICK }, text: 'merge', chat: { id: 999 }, ...over } });
+const GREEN = { state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }], statusCheckRollup: [] };
 
 // ── parsing ──────────────────────────────────────────────────────────────────
 
@@ -37,7 +41,7 @@ test('isApprovalText: requires the word merge/approve, not a bare yes', () => {
 // ── gate 1: authentication ─────────────────────────────────────────────────────
 
 test('approvalDecision: a message from anyone but Nick is IGNORED', () => {
-  const d = approvalDecision(msg({ from: { id: 99999 }, text: `merge ${ping(42)}` }), { nickUserId: NICK });
+  const d = approvalDecision(msg({ from: { id: 99999 }, text: `merge ${ping(42)}` }), CFG);
   assert.ok(d.ignore);
   assert.match(d.ignore, /not the authorized approver/);
 });
@@ -49,46 +53,78 @@ test('approvalDecision: nickUserId unset → never authorizes (fail closed)', ()
 
 // ── gate 2: unambiguous PR reference ───────────────────────────────────────────
 
-test('approvalDecision: URL in the approval text → merge that exact repo+pr', () => {
-  const d = approvalDecision(msg({ text: 'merge https://github.com/o/r/pull/7' }), { nickUserId: NICK });
+test('approvalDecision: URL in the approval text → merge that exact repo+pr (+ carries chatId)', () => {
+  const d = approvalDecision(msg({ text: 'merge https://github.com/o/r/pull/7' }), CFG);
   assert.deepEqual(d.merge, { repo: 'o/r', pr: 7 });
+  assert.equal(d.chatId, 999); // the chat to answer in, carried per update
 });
 
-test('approvalDecision: reply to the ping → PR resolved from the QUOTED text', () => {
-  const d = approvalDecision(msg({ text: 'merge', reply_to_message: { text: ping(55) } }), { nickUserId: NICK });
+test('approvalDecision: reply to the BOT ping → PR resolved from the quoted text', () => {
+  const d = approvalDecision(msg({ text: 'merge', reply_to_message: botPing(55) }), CFG);
   assert.deepEqual(d.merge, { repo: 'imagineering-cc/x', pr: 55 });
 });
 
+test('approvalDecision: reply to a NON-bot message is NOT trusted (planted-URL defense, #122)', () => {
+  // An attacker in a group plants a message with a PR URL; Nick replies "merge".
+  // The replied-to message is not from the bot → its URL must NOT resolve the target.
+  const d = approvalDecision(msg({ text: 'merge', reply_to_message: { text: ping(999), from: { id: 99999 } } }), CFG);
+  assert.ok(d.ignore);
+  assert.match(d.ignore, /unambiguously reference/);
+});
+
+test('approvalDecision: reply-to ignored when botUserId is unset (fail closed)', () => {
+  const d = approvalDecision(msg({ text: 'merge', reply_to_message: botPing(55) }), { nickUserId: NICK });
+  assert.ok(d.ignore); // no botUserId → can't trust any reply-to
+});
+
 test('approvalDecision: bare "#N" with NO repo context is refused (multi-repo ambiguity)', () => {
-  const d = approvalDecision(msg({ text: 'merge #42' }), { nickUserId: NICK });
+  const d = approvalDecision(msg({ text: 'merge #42' }), CFG);
   assert.ok(d.ignore);
   assert.match(d.ignore, /unambiguously reference/);
 });
 
 test('approvalDecision: bare "#N" resolves ONLY against a configured defaultRepo', () => {
-  const d = approvalDecision(msg({ text: 'merge #42' }), { nickUserId: NICK, defaultRepo: 'o/r' });
+  const d = approvalDecision(msg({ text: 'merge #42' }), { ...CFG, defaultRepo: 'o/r' });
   assert.deepEqual(d.merge, { repo: 'o/r', pr: 42 });
 });
 
 test('approvalDecision: approval verb but no PR anywhere → ignore', () => {
-  assert.ok(approvalDecision(msg({ text: 'merge it please' }), { nickUserId: NICK }).ignore);
+  assert.ok(approvalDecision(msg({ text: 'merge it please' }), CFG).ignore);
 });
 
 test('approvalDecision: a non-approval message from Nick → ignore (not every message merges)', () => {
-  assert.ok(approvalDecision(msg({ text: 'thanks!' }), { nickUserId: NICK }).ignore);
+  assert.ok(approvalDecision(msg({ text: 'thanks!' }), CFG).ignore);
 });
 
 // ── gate 3: the live green gate ─────────────────────────────────────────────────
 
-test('mergeGateOk: passes only an OPEN, non-conflicting, APPROVED, cage-matched PR', () => {
-  assert.deepEqual(mergeGateOk({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] }), { ok: true });
+test('mergeGateOk: passes only an OPEN, MERGEABLE, APPROVED, cage-matched, checks-green PR', () => {
+  assert.deepEqual(mergeGateOk(GREEN), { ok: true });
+});
+
+test('mergeGateOk: a not-yet-computed mergeable (UNKNOWN/null) is REFUSED — whitelist, not blacklist (#122)', () => {
+  assert.match(mergeGateOk({ ...GREEN, mergeable: 'UNKNOWN' }).reason, /not mergeable/);
+  assert.match(mergeGateOk({ ...GREEN, mergeable: undefined }).reason, /not mergeable/);
+  assert.match(mergeGateOk({ ...GREEN, mergeable: 'CONFLICTING' }).reason, /not mergeable/);
 });
 
 test('mergeGateOk: refuses each missing condition', () => {
   assert.match(mergeGateOk({ state: 'MERGED', labels: [] }).reason, /not open/);
-  assert.match(mergeGateOk({ state: 'OPEN', mergeable: 'CONFLICTING', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] }).reason, /conflict/);
-  assert.match(mergeGateOk({ state: 'OPEN', reviewDecision: 'REVIEW_REQUIRED', labels: [{ name: 'cage-matched' }] }).reason, /not approved/);
-  assert.match(mergeGateOk({ state: 'OPEN', reviewDecision: 'APPROVED', labels: [] }).reason, /not cage-matched/);
+  assert.match(mergeGateOk({ ...GREEN, reviewDecision: 'REVIEW_REQUIRED' }).reason, /not approved/);
+  assert.match(mergeGateOk({ ...GREEN, labels: [] }).reason, /not cage-matched/);
+});
+
+test('mergeGateOk: a FAILING or still-running check blocks the merge (no --admin bypass of a real signal)', () => {
+  assert.match(mergeGateOk({ ...GREEN, statusCheckRollup: [{ name: 'ci', conclusion: 'FAILURE' }] }).reason, /not passing/);
+  assert.match(mergeGateOk({ ...GREEN, statusCheckRollup: [{ name: 'ci', status: 'IN_PROGRESS', conclusion: null }] }).reason, /not passing/);
+});
+
+test('failingCheck: passes SUCCESS/NEUTRAL/SKIPPED + StatusContext SUCCESS; absent → null', () => {
+  assert.equal(failingCheck([]), null);
+  assert.equal(failingCheck(undefined), null);
+  assert.equal(failingCheck([{ name: 'a', conclusion: 'SUCCESS' }, { name: 'b', conclusion: 'SKIPPED' }, { context: 'c', state: 'SUCCESS' }]), null);
+  assert.equal(failingCheck([{ name: 'x', conclusion: 'FAILURE' }]), 'x');
+  assert.equal(failingCheck([{ context: 'y', state: 'PENDING' }]), 'y');
 });
 
 // ── runApproveCycle: orchestration over injected IO ─────────────────────────────
@@ -99,47 +135,60 @@ function fakeIO(prView) {
     calls,
     viewPr: async () => prView,
     mergePr: async (repo, pr) => { calls.merged.push(`${repo}#${pr}`); },
-    reply: async (t) => { calls.replies.push(t); },
+    reply: async (chatId, t) => { calls.replies.push({ chatId, t }); },
   };
 }
+const nickMerge = (id, pr, chat = 1) => ({ update_id: id, message: { from: { id: NICK }, text: 'merge', chat: { id: chat }, reply_to_message: botPing(pr) } });
 
 test('runApproveCycle: a valid approval of a GREEN PR merges + confirms + advances offset', async () => {
-  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] });
-  const updates = [{ update_id: 10, message: { from: { id: NICK }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(7) } } }];
-  const { newOffset, actions } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  const io = fakeIO(GREEN);
+  const { newOffset, actions } = await runApproveCycle([nickMerge(10, 7)], io, CFG);
   assert.deepEqual(io.calls.merged, ['imagineering-cc/x#7']);
-  assert.match(io.calls.replies[0], /Merged/);
+  assert.match(io.calls.replies[0].t, /Merged/);
   assert.equal(newOffset, 11); // offset advances past the processed update
   assert.equal(actions[0].merged, 'imagineering-cc/x#7');
 });
 
 test('runApproveCycle: a valid approval of a NON-GREEN PR does NOT merge (the live gate holds)', async () => {
-  const io = fakeIO({ state: 'OPEN', reviewDecision: 'REVIEW_REQUIRED', labels: [] });
-  const updates = [{ update_id: 5, message: { from: { id: NICK }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(7) } } }];
-  const { newOffset, actions } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'REVIEW_REQUIRED', labels: [] });
+  const { newOffset, actions } = await runApproveCycle([nickMerge(5, 7)], io, CFG);
   assert.deepEqual(io.calls.merged, [], 'must NOT merge an un-approved PR even on a valid "merge"');
-  assert.match(io.calls.replies[0], /Not merging/);
+  assert.match(io.calls.replies[0].t, /Not merging/);
   assert.equal(newOffset, 6); // still advances so it isn't re-tried forever
   assert.equal(actions[0].refused !== undefined, true);
 });
 
-test('runApproveCycle: an impostor message merges nothing but still advances the offset', async () => {
-  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: [{ name: 'cage-matched' }] });
-  const updates = [{ update_id: 8, message: { from: { id: 666 }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(7) } } }];
-  const { newOffset, actions } = await runApproveCycle(updates, io, { nickUserId: NICK });
+test('runApproveCycle: an impostor message merges nothing AND gets no reply, but advances the offset', async () => {
+  const io = fakeIO(GREEN);
+  const updates = [{ update_id: 8, message: { from: { id: 666 }, text: 'merge', chat: { id: 1 }, reply_to_message: botPing(7) } }];
+  const { newOffset, actions } = await runApproveCycle(updates, io, CFG);
   assert.deepEqual(io.calls.merged, []);
   assert.deepEqual(io.calls.replies, []); // we don't even reply to an impostor
   assert.equal(newOffset, 9);
   assert.ok(actions[0].ignored);
 });
 
+test('runApproveCycle: the reply goes to the AUTHORIZED message chat, not the batch-first chat (#122)', async () => {
+  // update 30 is an impostor in a GROUP (chat 111); update 31 is Nick's valid
+  // approval in his DM (chat 222). The "Merged" reply must go to 222, never 111.
+  const io = fakeIO(GREEN);
+  const updates = [
+    { update_id: 30, message: { from: { id: 666 }, text: 'merge', chat: { id: 111 }, reply_to_message: botPing(9) } },
+    nickMerge(31, 9, 222),
+  ];
+  await runApproveCycle(updates, io, CFG);
+  assert.deepEqual(io.calls.merged, ['imagineering-cc/x#9']);
+  assert.equal(io.calls.replies.length, 1);
+  assert.equal(io.calls.replies[0].chatId, 222, 'reply must go to Nick’s chat, not the impostor group');
+});
+
 test('runApproveCycle: processes a batch in update_id order; offset = max+1', async () => {
-  const io = fakeIO({ state: 'OPEN', mergeable: 'MERGEABLE', reviewDecision: 'APPROVED', labels: ['cage-matched'] });
+  const io = fakeIO(GREEN);
   const updates = [
     { update_id: 30, message: { from: { id: NICK }, text: 'hi', chat: { id: 1 } } },
-    { update_id: 31, message: { from: { id: NICK }, text: 'merge', chat: { id: 1 }, reply_to_message: { text: ping(9) } } },
+    nickMerge(31, 9),
   ];
-  const { newOffset } = await runApproveCycle(updates, io, { nickUserId: NICK });
+  const { newOffset } = await runApproveCycle(updates, io, CFG);
   assert.deepEqual(io.calls.merged, ['imagineering-cc/x#9']);
   assert.equal(newOffset, 32);
 });

--- a/self-healer/test/auto.test.mjs
+++ b/self-healer/test/auto.test.mjs
@@ -18,6 +18,9 @@ import {
   buildRunCageSpawn,
   autoFixIfActionable,
   actionForExit,
+  prUrlFromStdout,
+  prNumberFromUrl,
+  formatAutoOutcome,
   AUTO_ACTIONS,
   RUN_CAGE_PATH,
   CLONE_SCRIPT,
@@ -134,6 +137,36 @@ test('actionForExit: NO_DIFF (exit 3) → NO_FIX, NOT FAILED (benign empty-diff 
 test('actionForExit: any other non-zero exit → FAILED', () => {
   for (const code of [1, 2, 4, 5, 6, 7, 'signal:SIGKILL']) {
     assert.equal(actionForExit(code, 'fp').action, AUTO_ACTIONS.FAILED, `exit ${code} should be FAILED`);
+  }
+});
+
+// ── lifecycle notify formatting (Increment C) ────────────────────────────────
+
+test('prUrlFromStdout: extracts a GitHub PR URL from the last stdout line, else ""', () => {
+  assert.equal(prUrlFromStdout('some log\nhttps://github.com/o/r/pull/42'), 'https://github.com/o/r/pull/42');
+  assert.equal(prUrlFromStdout('https://github.com/o/r/pull/42\n'), 'https://github.com/o/r/pull/42');
+  assert.equal(prUrlFromStdout('not a url'), ''); // a stray line must not masquerade as a PR url
+  assert.equal(prUrlFromStdout(''), '');
+});
+
+test('prNumberFromUrl: pulls the PR number, or null', () => {
+  assert.equal(prNumberFromUrl('https://github.com/o/r/pull/42'), 42);
+  assert.equal(prNumberFromUrl('https://github.com/o/r/issues/42'), null);
+  assert.equal(prNumberFromUrl(''), null);
+});
+
+test('formatAutoOutcome: CAGED → a ping with the link AND the exact "merge #N" reply', () => {
+  const msg = formatAutoOutcome({ action: AUTO_ACTIONS.CAGED, container: 'edf', signature: 'null deref', prUrl: 'https://github.com/o/r/pull/42' });
+  assert.match(msg, /draft PR/);
+  assert.match(msg, /pull\/42/);
+  assert.match(msg, /merge #42/); // the listener (C2) accepts exactly this
+  assert.match(msg, /null deref/);
+});
+
+test('formatAutoOutcome: FAILED → a stumble ping; benign outcomes are quiet (null)', () => {
+  assert.match(formatAutoOutcome({ action: AUTO_ACTIONS.FAILED, container: 'edf', detail: 'cage exited 5' }), /stumbled/);
+  for (const a of [AUTO_ACTIONS.DEDUPED, AUTO_ACTIONS.SKIPPED, AUTO_ACTIONS.NO_FIX, AUTO_ACTIONS.REFUSED]) {
+    assert.equal(formatAutoOutcome({ action: a, container: 'edf' }), null, `${a} must be a quiet (null) ping`);
   }
 });
 

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -111,21 +111,28 @@ test('draftIfActionable: enabled but no token ⇒ skipped, no network', async ()
 });
 
 test('scrubSecrets: redacts known token prefixes', () => {
-  assert.match(scrubSecrets('token sk-ant-oat01-abc123DEF_xyz here'), /<redacted:anthropic-key>/);
-  assert.match(scrubSecrets('ghs_AAAABBBBCCCCDDDD1111'), /<redacted:github-token>/);
-  assert.match(scrubSecrets('github_pat_11ABCDEFG_longtailwithunderscores0000'), /<redacted:github-token>/);
+  assert.match(scrubSecrets('token sk-ant-oat01-abc123DEF_xyz here'), /\[redacted:anthropic-key\]/);
+  assert.match(scrubSecrets('ghs_AAAABBBBCCCCDDDD1111'), /\[redacted:github-token\]/);
+  assert.match(scrubSecrets('github_pat_11ABCDEFG_longtailwithunderscores0000'), /\[redacted:github-token\]/);
   assert.doesNotMatch(scrubSecrets('Authorization: Bearer abcdef1234567890'), /abcdef1234567890/);
   assert.equal(scrubSecrets('nothing secret here'), 'nothing secret here');
 });
 
+test('scrubSecrets: redaction markers are HTML-safe (no angle brackets — cage-match #122)', () => {
+  // The markers must not contain < or >, so scrubbing an already-HTML-escaped string
+  // (sendNotify scrubs the final message) can't reintroduce raw markup.
+  const out = scrubSecrets('sk-ant-oat01-abc123DEF_xyz and ghs_AAAABBBBCCCCDDDD1111');
+  assert.doesNotMatch(out, /[<>]/);
+});
+
 test('scrubSecrets: catches the shapes a prefix list misses (cage-match PR #101)', () => {
   // AWS *secret* key (40-char base64, no prefix) → high-entropy catch-all.
-  assert.match(scrubSecrets('aws wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1'), /<redacted/);
+  assert.match(scrubSecrets('aws wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY1'), /\[redacted/);
   // k=v with a sensitive key name and an unknown token format.
-  assert.match(scrubSecrets('password=hunter2supersecret'), /password=<redacted>/);
-  assert.match(scrubSecrets('client_secret: abc.def.ghi'), /client_secret:\s*<redacted>/);
+  assert.match(scrubSecrets('password=hunter2supersecret'), /password=\[redacted\]/);
+  assert.match(scrubSecrets('client_secret: abc.def.ghi'), /client_secret:\s*\[redacted\]/);
   // PEM private key block.
-  assert.match(scrubSecrets('-----BEGIN PRIVATE KEY-----\nMIIabc\n-----END PRIVATE KEY-----'), /<redacted:private-key>/);
+  assert.match(scrubSecrets('-----BEGIN PRIVATE KEY-----\nMIIabc\n-----END PRIVATE KEY-----'), /\[redacted:private-key\]/);
 });
 
 test('scrubSecrets: preserves short diagnostic IDs (LiveKit nodeIds ~24 chars)', () => {


### PR DESCRIPTION
The human-in-the-loop half of the green-auto monster (#571), on top of the merged agent (#121). green-auto **tells Nick when it acts**, and Nick can **approve the merge from his phone** — the merge gate stays human, the "yes" is approval not a bypass.

Ships **inert**: notify no-ops without `NOTIFY_API_KEY`; the poller refuses to start unprovisioned and isn't cron-wired until on-box (Increment D).

## C1 — lifecycle notify (one-way)
The **orchestrator** sends it (the caged agent has no egress to `notify` — allowlist is github+anthropic only). `spawnCage` captures the agent's stdout (it prints only the PR URL); each draft PR → a ping with the link + the exact `merge #N` reply; a stumble → a warning. `sendNotify` reuses the existing `notify` proxy (scrubs secrets, silent no-op without a key).

## C2 — two-way approve (`approve.mjs` + `approve-poll.mjs`)
Poller reads the notify bot's `getUpdates`, merges on Nick's "merge". **Three fail-closed gates**, exhaustively tested:
1. **Auth** — sender must be `NICK_TELEGRAM_USER_ID` (his specific id, not anyone in the chat).
2. **Unambiguous PR** — a URL, or a reply to the ping (whose text carries the URL); a bare `#N` without a default repo is refused.
3. **Live green gate** — re-check OPEN + mergeable + reviewer-APPROVED + `cage-matched` label before merge. A test proves a valid "merge" of a *non-green* PR merges **nothing**.

The merge token is **separate** from the bot token (bot only reads/replies). `runApproveCycle` is IO-injected → orchestration tested with fakes (merge happy-path, refuse-non-green, ignore-impostor, monotonic offset).

## Tests
150 pass (+16). The merge-trigger's entire decision surface is covered without a network.

## Merge gate
Trust boundary (a Telegram message → a merge) → **cage-match by law**. Provisioning runbook in `cage/README.md`; the cron + tokens land in Increment D (on-box, your hands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)