### PR TITLE
feat(secrets): SOPS backup of the enspyr island JWT secret (#1577)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@
 
 creation_rules:
   # Match secret yaml files in service and provider directories
-  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway)/.*\.yaml$
+  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway|aiko-chat-gateway-enspyr)/.*\.yaml$
     age: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks

--- a/aiko-chat-gateway-enspyr/secrets.yaml
+++ b/aiko-chat-gateway-enspyr/secrets.yaml
@@ -1,0 +1,21 @@
+#ENC[AES256_GCM,data:ULBid0ObMjfJLGypAf31AszYOAjBW6O+GQXZyiA15ENc4RzVhAlo0AXwZkQZ5/uKlWJxIkRr+Sghth6i3h7MfRyVqa4yaZlGBJLfJi0rzgbGGCzlc2K37Q==,iv:OzfDp7rSJJojaP+KyMXMXRVbbI97757l9jAApfvdWAU=,tag:3gxQ2s815n5aRdWF3RfoOg==,type:comment]
+#ENC[AES256_GCM,data:fFIKFpGy4XdlgUA1whNbMRB0d0PpaZvy/ts5Tv7wzaysT85EOJYjxwjTeXiKaluDFbQIS/XX48jDCWi2JVV6KAyhFn/5O4PI6g==,iv:CTCJWHuQn31BrzD7iJUWAEofUmq3NfXuznU16BZjwFk=,tag:Ltp+qY2II37j4PgIGSLfiA==,type:comment]
+#ENC[AES256_GCM,data:cqhaz0WAaJW9kfD+EvC5sy+/dCpNL2mn7Z+wHNEofNfWxCU64nt2RL24eSj0MBi80tDYFiugOtwyvXBdb9B5+sCGr3pk3pPq/h5l5/4h,iv:J0D2uA6BF5tzRNvnMFyStcr1Ofqg0hK6JutAJKe7Uyc=,tag:vOGONhcS8XjEyETVK5GK5w==,type:comment]
+#ENC[AES256_GCM,data:4K4VbOLt3zLvanMJkyb27LDMROykjoit9xhNPwilY+sfCWAKw+dp6j3bXSivHXHoTGbo+Y0RqlflQDGra+9ZqvjwpucawVt9tcA1sA==,iv:CI3t1wVtSrhT5H0vm3G1WS5w2C9UyWJqAV8KpS96cA0=,tag:ZsDbSZFkDd6aC8E0q5mV6w==,type:comment]
+#ENC[AES256_GCM,data:vHRz1LxRw9jvmU0UjLIUA+24CNVaiVL36tbX4Ad1mD1mgKrvU3k7+0CoSGE1gcDpOJfSTfiRZcIxgHValHIIpS9pEcgjRgmACyTGYUtN+9E=,iv:OKnhVJBVMcjD2PR/3lk2wMJdiTEc0nn09z9MfWk7zmc=,tag:dvhMGR2evLrRw/0czpn+lA==,type:comment]
+jwt_secret: ENC[AES256_GCM,data:XUyrwLYTXtr+eXxfEpu8whGLxeTUsGWC9Hs5pBheyJKvMoBeD4ND+tqD2AFVUfW2,iv:QurwhUwcHqd7kjypw7C97Y8DEY0hBkUigmMrNbIlXVE=,tag:r8NONIFAdV+wJmQipCnwrA==,type:str]
+sops:
+    age:
+        - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPaERldEtDTUNzOWk0Z0F1
+            OE9NSkp2VFlRcDJjNzhVcWZYZ282SnJjdTJrCkc2ZjByRWtwZXc2UHJMWHFGZ1Nq
+            aklqWGZMZ0JsbUxrRWw1bmxHOXZuUmsKLS0tIGVqU2s4Q0t2UEM2anpZT3FyekJv
+            bzhFaXl3cy9NaW9Nc3M2Z0tjVXIwY1EKTMW+aDYZxmC0EvFYHF6MtYz0y3dFAbVK
+            PdQ7TUyL9wUDMKzpmzZ1A859dzpYDdFAJnCIO/rIv+7DdW0sEPIRvA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-06T04:38:44Z"
+    mac: ENC[AES256_GCM,data:v3VI7ImYdZA1KS4p9sXDD3TGGYWb2Ox7TCzvJw2ySNe0puDAalPqR2n4xxw8tpy+OtsNAUDFGzVPXk8MDYowMyYNu330rtB+mQNwjPkPd7UoeQHzTYsQjRSRu7qzWzdyPm8QIhHyuTm77TNwV5FPjJ0vQThB7T1mHetI3ffssQY=,iv:NXjEBnVQ7HouKOqi3W3oUAdo6Aaw2x/bnGBGOE77RYo=,tag:TXSIB/BsWfWSIzCMwWrJ/g==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/aiko-chat-gateway-enspyr/secrets.yaml.example
+++ b/aiko-chat-gateway-enspyr/secrets.yaml.example
@@ -1,0 +1,3 @@
+# Copy to secrets.yaml and `sops -e -i secrets.yaml`. jwt_secret must be >=32 chars.
+# ENSPYR island (chat.enspyr.co). See #1577.
+jwt_secret: REPLACE_WITH_32+_CHAR_SECRET


### PR DESCRIPTION
Closes the unbacked single-point-of-failure for chat.enspyr.co's JWT_SECRET (previously box-only on the Melbourne OCI box). Mirrors the existing `aiko-chat-gateway/secrets.yaml` pattern under `aiko-chat-gateway-enspyr/`, age-encrypted via SOPS.

**Verified**: sops-decrypt fingerprint matches the live box value (sha256 `9b7f3462…6290`). Stored as ciphertext — no plaintext in the diff.

Note: I observed a second box-only secret on that box, `GITHUB_CLIENT_SECRET`, which also appears unbacked (on both islands) — flagged as a follow-up, not included here to keep this scoped to the named #1577 gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)