### PR TITLE
fix(backup): auto-detect live aiko-gateway volume (ghost-volume bug)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@
 
 creation_rules:
   # Match secret yaml files in service and provider directories
-  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway)/.*\.yaml$
+  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway|aiko-chat-gateway-enspyr)/.*\.yaml$
     age: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks

--- a/aiko-chat-gateway-enspyr/secrets.yaml
+++ b/aiko-chat-gateway-enspyr/secrets.yaml
@@ -1,0 +1,21 @@
+#ENC[AES256_GCM,data:ULBid0ObMjfJLGypAf31AszYOAjBW6O+GQXZyiA15ENc4RzVhAlo0AXwZkQZ5/uKlWJxIkRr+Sghth6i3h7MfRyVqa4yaZlGBJLfJi0rzgbGGCzlc2K37Q==,iv:OzfDp7rSJJojaP+KyMXMXRVbbI97757l9jAApfvdWAU=,tag:3gxQ2s815n5aRdWF3RfoOg==,type:comment]
+#ENC[AES256_GCM,data:fFIKFpGy4XdlgUA1whNbMRB0d0PpaZvy/ts5Tv7wzaysT85EOJYjxwjTeXiKaluDFbQIS/XX48jDCWi2JVV6KAyhFn/5O4PI6g==,iv:CTCJWHuQn31BrzD7iJUWAEofUmq3NfXuznU16BZjwFk=,tag:Ltp+qY2II37j4PgIGSLfiA==,type:comment]
+#ENC[AES256_GCM,data:cqhaz0WAaJW9kfD+EvC5sy+/dCpNL2mn7Z+wHNEofNfWxCU64nt2RL24eSj0MBi80tDYFiugOtwyvXBdb9B5+sCGr3pk3pPq/h5l5/4h,iv:J0D2uA6BF5tzRNvnMFyStcr1Ofqg0hK6JutAJKe7Uyc=,tag:vOGONhcS8XjEyETVK5GK5w==,type:comment]
+#ENC[AES256_GCM,data:4K4VbOLt3zLvanMJkyb27LDMROykjoit9xhNPwilY+sfCWAKw+dp6j3bXSivHXHoTGbo+Y0RqlflQDGra+9ZqvjwpucawVt9tcA1sA==,iv:CI3t1wVtSrhT5H0vm3G1WS5w2C9UyWJqAV8KpS96cA0=,tag:ZsDbSZFkDd6aC8E0q5mV6w==,type:comment]
+#ENC[AES256_GCM,data:vHRz1LxRw9jvmU0UjLIUA+24CNVaiVL36tbX4Ad1mD1mgKrvU3k7+0CoSGE1gcDpOJfSTfiRZcIxgHValHIIpS9pEcgjRgmACyTGYUtN+9E=,iv:OKnhVJBVMcjD2PR/3lk2wMJdiTEc0nn09z9MfWk7zmc=,tag:dvhMGR2evLrRw/0czpn+lA==,type:comment]
+jwt_secret: ENC[AES256_GCM,data:XUyrwLYTXtr+eXxfEpu8whGLxeTUsGWC9Hs5pBheyJKvMoBeD4ND+tqD2AFVUfW2,iv:QurwhUwcHqd7kjypw7C97Y8DEY0hBkUigmMrNbIlXVE=,tag:r8NONIFAdV+wJmQipCnwrA==,type:str]
+sops:
+    age:
+        - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPaERldEtDTUNzOWk0Z0F1
+            OE9NSkp2VFlRcDJjNzhVcWZYZ282SnJjdTJrCkc2ZjByRWtwZXc2UHJMWHFGZ1Nq
+            aklqWGZMZ0JsbUxrRWw1bmxHOXZuUmsKLS0tIGVqU2s4Q0t2UEM2anpZT3FyekJv
+            bzhFaXl3cy9NaW9Nc3M2Z0tjVXIwY1EKTMW+aDYZxmC0EvFYHF6MtYz0y3dFAbVK
+            PdQ7TUyL9wUDMKzpmzZ1A859dzpYDdFAJnCIO/rIv+7DdW0sEPIRvA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-06T04:38:44Z"
+    mac: ENC[AES256_GCM,data:v3VI7ImYdZA1KS4p9sXDD3TGGYWb2Ox7TCzvJw2ySNe0puDAalPqR2n4xxw8tpy+OtsNAUDFGzVPXk8MDYowMyYNu330rtB+mQNwjPkPd7UoeQHzTYsQjRSRu7qzWzdyPm8QIhHyuTm77TNwV5FPjJ0vQThB7T1mHetI3ffssQY=,iv:NXjEBnVQ7HouKOqi3W3oUAdo6Aaw2x/bnGBGOE77RYo=,tag:TXSIB/BsWfWSIzCMwWrJ/g==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/aiko-chat-gateway-enspyr/secrets.yaml.example
+++ b/aiko-chat-gateway-enspyr/secrets.yaml.example
@@ -1,0 +1,3 @@
+# Copy to secrets.yaml and `sops -e -i secrets.yaml`. jwt_secret must be >=32 chars.
+# ENSPYR island (chat.enspyr.co). See #1577.
+jwt_secret: REPLACE_WITH_32+_CHAR_SECRET

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -207,7 +207,30 @@ backup_aiko_gateway() {
   # to gzip would mask it behind gzip's status (and a gzip of empty input is
   # still a non-empty container, so an `-s` size check on the .gz lies). Capture
   # stderr for the error message (a WAL-locked read fails loudly, not silently).
-  if ! docker run --rm -v "aiko-chat-gateway_aiko_gateway_data:/data:ro" sqlite-dumper:latest \
+  # Derive the live gateway volume from the RUNNING container rather than
+  # hardcoding it. The island cutover (project aiko-chat-gateway + volume
+  # aiko-chat-gateway_aiko_gateway_data -> project aiko + external volume
+  # aiko_data) silently ORPHANED the old volume, so a hardcoded name backed up
+  # a frozen ghost for days (caught 2026-07-07: Sydney's daily dump had
+  # passkey_credentials=0 while the live DB had 1). Auto-detect removes that
+  # drift class and works on BOTH islands regardless of cutover state (Melbourne
+  # still runs the pre-cutover volume name).
+  local gw_cid gw_vol
+  gw_cid=$(docker ps --format '{{.Names}}\t{{.Image}}' \
+    | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
+  if [ -z "$gw_cid" ]; then
+    error "aiko-gateway: no running gateway container (image aiko-chat-island|gateway:*)"
+    return 1
+  fi
+  gw_vol=$(docker inspect "$gw_cid" \
+    --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+  if [ -z "$gw_vol" ]; then
+    error "aiko-gateway: container $gw_cid has no /data volume mount"
+    return 1
+  fi
+  log "  live gateway volume: $gw_vol (container $gw_cid)"
+
+  if ! docker run --rm -v "${gw_vol}:/data:ro" sqlite-dumper:latest \
        sqlite3 -cmd '.timeout 5000' /data/aiko.db .dump > "$tmp" 2>"$err"; then
     error "aiko-gateway sqlite3 .dump failed: $(tr '\n' ' ' < "$err")"
     rm -f "$tmp" "$err"


### PR DESCRIPTION
backup_aiko_gateway hardcoded `aiko-chat-gateway_aiko_gateway_data`. The island cutover moved the live gateway to the external `aiko_data` volume, orphaning the old one — so the daily backup silently dumped a **frozen pre-cutover copy** for ~3 days (pushed dump had passkey_credentials=0 while the live DB had 1; near-identical daily byte sizes were the canary).

Fix: derive the volume from the running gateway container's /data mount. Kills the drift class; works on both islands regardless of cutover state. **Verified against both live boxes** (Sydney→aiko_data, Melbourne→aiko-chat-gateway_aiko_gateway_data) and by running the deployed script (log: `live gateway volume: aiko_data`, artifact passkeys=1).

Already deployed to the Sydney box (backup ~/backup.sh.bak-preghostfix) to protect tonight's cron. Emergency manual backups of both islands' live DBs already pushed to imagineering-backups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)