### PR TITLE
feat(backup): recurring DB-backup rig for the enspyr/Melbourne island (#1577)

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@
 
 creation_rules:
   # Match secret yaml files in service and provider directories
-  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway)/.*\.yaml$
+  - path_regex: (backups|outline|kanbn|dreamfinder|embodied-dreamfinder|familiars-server|livekit|radicale|matrix|imagineering-contact-us|claudius|lugh|youtube-rag|tech-world-bots|notify|cd-bus|claude-shim|aiko-chat-gateway|aiko-chat-gateway-enspyr)/.*\.yaml$
     age: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks

--- a/aiko-chat-gateway-enspyr/secrets.yaml
+++ b/aiko-chat-gateway-enspyr/secrets.yaml
@@ -1,0 +1,21 @@
+#ENC[AES256_GCM,data:ULBid0ObMjfJLGypAf31AszYOAjBW6O+GQXZyiA15ENc4RzVhAlo0AXwZkQZ5/uKlWJxIkRr+Sghth6i3h7MfRyVqa4yaZlGBJLfJi0rzgbGGCzlc2K37Q==,iv:OzfDp7rSJJojaP+KyMXMXRVbbI97757l9jAApfvdWAU=,tag:3gxQ2s815n5aRdWF3RfoOg==,type:comment]
+#ENC[AES256_GCM,data:fFIKFpGy4XdlgUA1whNbMRB0d0PpaZvy/ts5Tv7wzaysT85EOJYjxwjTeXiKaluDFbQIS/XX48jDCWi2JVV6KAyhFn/5O4PI6g==,iv:CTCJWHuQn31BrzD7iJUWAEofUmq3NfXuznU16BZjwFk=,tag:Ltp+qY2II37j4PgIGSLfiA==,type:comment]
+#ENC[AES256_GCM,data:cqhaz0WAaJW9kfD+EvC5sy+/dCpNL2mn7Z+wHNEofNfWxCU64nt2RL24eSj0MBi80tDYFiugOtwyvXBdb9B5+sCGr3pk3pPq/h5l5/4h,iv:J0D2uA6BF5tzRNvnMFyStcr1Ofqg0hK6JutAJKe7Uyc=,tag:vOGONhcS8XjEyETVK5GK5w==,type:comment]
+#ENC[AES256_GCM,data:4K4VbOLt3zLvanMJkyb27LDMROykjoit9xhNPwilY+sfCWAKw+dp6j3bXSivHXHoTGbo+Y0RqlflQDGra+9ZqvjwpucawVt9tcA1sA==,iv:CI3t1wVtSrhT5H0vm3G1WS5w2C9UyWJqAV8KpS96cA0=,tag:ZsDbSZFkDd6aC8E0q5mV6w==,type:comment]
+#ENC[AES256_GCM,data:vHRz1LxRw9jvmU0UjLIUA+24CNVaiVL36tbX4Ad1mD1mgKrvU3k7+0CoSGE1gcDpOJfSTfiRZcIxgHValHIIpS9pEcgjRgmACyTGYUtN+9E=,iv:OKnhVJBVMcjD2PR/3lk2wMJdiTEc0nn09z9MfWk7zmc=,tag:dvhMGR2evLrRw/0czpn+lA==,type:comment]
+jwt_secret: ENC[AES256_GCM,data:XUyrwLYTXtr+eXxfEpu8whGLxeTUsGWC9Hs5pBheyJKvMoBeD4ND+tqD2AFVUfW2,iv:QurwhUwcHqd7kjypw7C97Y8DEY0hBkUigmMrNbIlXVE=,tag:r8NONIFAdV+wJmQipCnwrA==,type:str]
+sops:
+    age:
+        - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPaERldEtDTUNzOWk0Z0F1
+            OE9NSkp2VFlRcDJjNzhVcWZYZ282SnJjdTJrCkc2ZjByRWtwZXc2UHJMWHFGZ1Nq
+            aklqWGZMZ0JsbUxrRWw1bmxHOXZuUmsKLS0tIGVqU2s4Q0t2UEM2anpZT3FyekJv
+            bzhFaXl3cy9NaW9Nc3M2Z0tjVXIwY1EKTMW+aDYZxmC0EvFYHF6MtYz0y3dFAbVK
+            PdQ7TUyL9wUDMKzpmzZ1A859dzpYDdFAJnCIO/rIv+7DdW0sEPIRvA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-06T04:38:44Z"
+    mac: ENC[AES256_GCM,data:v3VI7ImYdZA1KS4p9sXDD3TGGYWb2Ox7TCzvJw2ySNe0puDAalPqR2n4xxw8tpy+OtsNAUDFGzVPXk8MDYowMyYNu330rtB+mQNwjPkPd7UoeQHzTYsQjRSRu7qzWzdyPm8QIhHyuTm77TNwV5FPjJ0vQThB7T1mHetI3ffssQY=,iv:NXjEBnVQ7HouKOqi3W3oUAdo6Aaw2x/bnGBGOE77RYo=,tag:TXSIB/BsWfWSIzCMwWrJ/g==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/aiko-chat-gateway-enspyr/secrets.yaml.example
+++ b/aiko-chat-gateway-enspyr/secrets.yaml.example
@@ -1,0 +1,3 @@
+# Copy to secrets.yaml and `sops -e -i secrets.yaml`. jwt_secret must be >=32 chars.
+# ENSPYR island (chat.enspyr.co). See #1577.
+jwt_secret: REPLACE_WITH_32+_CHAR_SECRET

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -11,7 +11,18 @@ All services backup to **GitHub** (imagineering-cc/imagineering-backups).
 | Radicale | CalDAV/CardDAV collections | Daily 4 AM | 7 days |
 | Dreamfinder | SQLite database | Daily 4 AM | 7 days |
 | Claudius | Agent state files | Daily 4 AM | 7 days |
-| aiko-chat-gateway | SQLite (messages + auth + ACL — the sole copy) | Daily 4 AM | 7 days |
+| aiko-chat-gateway (Sydney / imagineering) | SQLite (messages + auth + ACL — the sole copy) | Daily 4 AM | 7 days |
+| aiko-chat-gateway (Melbourne / enspyr) | SQLite (`aiko-gateway-enspyr.sql`) | Daily 4:20 AM | 7 days |
+
+> **Two islands, one repo.** Each island's gateway backs up its own DB under a
+> distinct slug so they never clobber one file: Sydney → `aiko-gateway.sql`
+> (fleet `backup.sh` on the imagineering box), Melbourne → `aiko-gateway-enspyr.sql`
+> (standalone `backup-aiko-gateway-standalone.sh` on nick-mel, own on-box deploy
+> key, root cron 4:20 AM staggered from Sydney's 4 AM to avoid a push race).
+> Both auto-detect the live gateway volume from the running container — a
+> hardcoded name silently backs up an orphaned volume after an island cutover
+> (fixed 2026-07-07; see PR #124). **Follow-up:** Melbourne has no backup-recency
+> watcher yet (Sydney does) — a silent failure there would go unnoticed.
 
 ## Manual Operations
 

--- a/scripts/backup-aiko-gateway-standalone.sh
+++ b/scripts/backup-aiko-gateway-standalone.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Standalone aiko-chat-gateway DB backup for a SINGLE-SERVICE island box
+# (e.g. the enspyr / Melbourne OCI box), which does NOT run the full fleet
+# backup.sh. Dumps the gateway's SQLite DB and pushes it to the shared backup
+# repo (imagineering-cc/imagineering-backups) under a per-island slug so two
+# islands never clobber one file.
+#
+# Usage:  backup-aiko-gateway-standalone.sh <slug>
+#   e.g.  backup-aiko-gateway-standalone.sh aiko-gateway-enspyr
+#
+# Requires: docker (run as root or a docker-group user), git, and a deploy key
+# with WRITE on the backup repo at ~/.ssh/imagineering-backups-deploy plus the
+# ssh host alias `github-imagineering-backups` (see the deploy notes / #1577).
+#
+# Mirrors the fleet backup.sh's aiko-gateway logic: auto-detect the live volume
+# (survives the island cutover), .dump to text SQL (git-diffable), validate the
+# dump ends in COMMIT; (a truncated dump is worse than none — restore replays it
+# over the SOLE live DB), then pull --rebase + push (staggered from the Sydney
+# 4am cron to avoid a push race on the shared repo).
+set -euo pipefail
+
+SLUG="${1:?usage: $0 <slug>  e.g. aiko-gateway-enspyr}"
+DATE=$(date +%Y-%m-%d)
+BACKUP_DIR="/tmp/backups"
+GITHUB_BACKUP_REPO="git@github-imagineering-backups:imagineering-cc/imagineering-backups.git"
+GITHUB_BACKUP_DIR="/tmp/imagineering-backups"
+mkdir -p "$BACKUP_DIR"
+
+log()   { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
+fail()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1" >&2; exit 1; }
+
+# --- Locate the LIVE gateway volume from the running container -----------------
+# Hardcoding the volume name silently backs up a ghost after a compose/project
+# cutover renames it (that bug bit Sydney — see fleet backup.sh). Derive it.
+GW_CID=$(docker ps --format '{{.Names}}\t{{.Image}}' \
+  | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
+[ -n "$GW_CID" ] || fail "no running gateway container (image aiko-chat-island|gateway:*)"
+GW_VOL=$(docker inspect "$GW_CID" \
+  --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+[ -n "$GW_VOL" ] || fail "container $GW_CID has no /data volume mount"
+log "live gateway volume: $GW_VOL (container $GW_CID)"
+
+# --- Dump (online-safe: read-only mount, .dump reads a consistent snapshot) ----
+# The gateway image ships no sqlite3, so mount the volume read-only into a small
+# alpine+sqlite image. Build it once if absent (idempotent).
+if ! docker image inspect sqlite-dumper:latest >/dev/null 2>&1; then
+  log "building sqlite-dumper:latest (alpine + sqlite3)"
+  printf 'FROM alpine:3.20\nRUN apk add --no-cache sqlite\n' \
+    | docker build -q -t sqlite-dumper:latest - >/dev/null
+fi
+
+TMP="$BACKUP_DIR/${SLUG}-${DATE}.sql"
+ERR="$BACKUP_DIR/${SLUG}-${DATE}.err"
+if ! docker run --rm -v "${GW_VOL}:/data:ro" sqlite-dumper:latest \
+     sqlite3 -cmd '.timeout 5000' /data/aiko.db .dump > "$TMP" 2>"$ERR"; then
+  fail "sqlite3 .dump failed: $(tr '\n' ' ' < "$ERR")"
+fi
+# A COMPLETE .dump's LAST non-blank line is exactly COMMIT; (end-anchored — app
+# data can embed a line starting 'COMMIT;', which a whole-file grep would accept).
+LAST=$(grep -ve '^[[:space:]]*$' "$TMP" | tail -n1)
+[ "$LAST" = "COMMIT;" ] || fail "dump invalid (last line '$LAST', not COMMIT; — truncated): $(tr '\n' ' ' < "$ERR")"
+rm -f "$ERR"
+log "dump OK ($(wc -l < "$TMP") lines)"
+
+# --- Push to the shared backup repo (git-diffable plaintext SQL) ---------------
+[ -f "$HOME/.ssh/imagineering-backups-deploy" ] || fail "deploy key missing at ~/.ssh/imagineering-backups-deploy"
+if [ -d "$GITHUB_BACKUP_DIR/.git" ]; then
+  git -C "$GITHUB_BACKUP_DIR" pull --rebase 2>/dev/null || {
+    rm -rf "$GITHUB_BACKUP_DIR"; git clone --depth 1 "$GITHUB_BACKUP_REPO" "$GITHUB_BACKUP_DIR"; }
+else
+  rm -rf "$GITHUB_BACKUP_DIR"
+  git clone --depth 1 "$GITHUB_BACKUP_REPO" "$GITHUB_BACKUP_DIR"
+fi
+cp "$TMP" "$GITHUB_BACKUP_DIR/${SLUG}.sql"
+git -C "$GITHUB_BACKUP_DIR" add -A
+if git -C "$GITHUB_BACKUP_DIR" diff --cached --quiet; then
+  log "no changes to push"
+else
+  git -C "$GITHUB_BACKUP_DIR" -c user.name="imagineering-backup" -c user.email="backup@imagineering.cc" \
+    commit -q -m "backup ${SLUG} ${DATE}"
+  # One rebase-retry on a race with the Sydney cron pushing concurrently.
+  git -C "$GITHUB_BACKUP_DIR" push origin HEAD 2>/dev/null || {
+    git -C "$GITHUB_BACKUP_DIR" pull --rebase && git -C "$GITHUB_BACKUP_DIR" push origin HEAD; }
+  log "pushed ${SLUG}.sql to GitHub"
+fi
+
+# Local retention: keep 7 days of dated dumps.
+find "$BACKUP_DIR" -name "${SLUG}-*.sql" -mtime +7 -delete 2>/dev/null || true
+log "backup complete: ${SLUG}"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -207,7 +207,30 @@ backup_aiko_gateway() {
   # to gzip would mask it behind gzip's status (and a gzip of empty input is
   # still a non-empty container, so an `-s` size check on the .gz lies). Capture
   # stderr for the error message (a WAL-locked read fails loudly, not silently).
-  if ! docker run --rm -v "aiko-chat-gateway_aiko_gateway_data:/data:ro" sqlite-dumper:latest \
+  # Derive the live gateway volume from the RUNNING container rather than
+  # hardcoding it. The island cutover (project aiko-chat-gateway + volume
+  # aiko-chat-gateway_aiko_gateway_data -> project aiko + external volume
+  # aiko_data) silently ORPHANED the old volume, so a hardcoded name backed up
+  # a frozen ghost for days (caught 2026-07-07: Sydney's daily dump had
+  # passkey_credentials=0 while the live DB had 1). Auto-detect removes that
+  # drift class and works on BOTH islands regardless of cutover state (Melbourne
+  # still runs the pre-cutover volume name).
+  local gw_cid gw_vol
+  gw_cid=$(docker ps --format '{{.Names}}\t{{.Image}}' \
+    | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
+  if [ -z "$gw_cid" ]; then
+    error "aiko-gateway: no running gateway container (image aiko-chat-island|gateway:*)"
+    return 1
+  fi
+  gw_vol=$(docker inspect "$gw_cid" \
+    --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+  if [ -z "$gw_vol" ]; then
+    error "aiko-gateway: container $gw_cid has no /data volume mount"
+    return 1
+  fi
+  log "  live gateway volume: $gw_vol (container $gw_cid)"
+
+  if ! docker run --rm -v "${gw_vol}:/data:ro" sqlite-dumper:latest \
        sqlite3 -cmd '.timeout 5000' /data/aiko.db .dump > "$tmp" 2>"$err"; then
     error "aiko-gateway sqlite3 .dump failed: $(tr '\n' ' ' < "$err")"
     rm -f "$tmp" "$err"


### PR DESCRIPTION
Enspyr (chat.enspyr.co) had **no backup at all** — its gateway DB was one disk failure from gone. This adds durable daily backup, deployed and verified.

**What:** a lean, self-contained `backup-aiko-gateway-standalone.sh` (single-service island box; doesn't drag the full fleet backup.sh over). Auto-detects the live volume, `.dump` + COMMIT;-validate, pushes to imagineering-backups under `aiko-gateway-enspyr.sql` (distinct slug — never clobbers Sydney's `aiko-gateway.sql`). Pull-rebase + retry survives a push race with Sydney's 4 AM cron.

**Deployed to nick-mel (verified):**
- Deploy key minted **on the box** (private half never left it), registered write-only on the repo.
- Root cron 4:20 AM (staggered from Sydney 4 AM).
- Test run: auto-detected volume, dump 195 lines validated, pushed. GH `aiko-gateway-enspyr.sql` confirmed to hold live data (5 channels).

**Follow-up (noted in docs):** no backup-recency watcher on Melbourne yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)