### PR TITLE
feat(df): wire INTERNAL_SCOPE_KEY declaratively (activate ascend-scope trust boundary)

### DIFF
--- a/embodied-dreamfinder/docker-compose.yml
+++ b/embodied-dreamfinder/docker-compose.yml
@@ -59,6 +59,10 @@ services:
       # Second password scoping a session to "ascend" — unlocks the DF that knows last night
       # (AUTH_PASSWORD alone gives plain "base" DF, blind to it). See server.js /auth/login.
       - ASCEND_PASSWORD=${ASCEND_PASSWORD:-}
+      # Shared secret letting the in-container LiveKit voice agent request ascend-scoped
+      # context over localhost (server.js localhost override). Server + agent share this
+      # container env, so one value serves both. <16 chars → override disabled (fail-closed).
+      - INTERNAL_SCOPE_KEY=${INTERNAL_SCOPE_KEY:-}
     volumes:
       - embodied-dreamfinder-data:/data
       - /home/nick/whisper.cpp/build/bin:/opt/whisper/bin:ro

--- a/embodied-dreamfinder/secrets.yaml
+++ b/embodied-dreamfinder/secrets.yaml
@@ -21,6 +21,7 @@ lyra_ssh_key: ENC[AES256_GCM,data:LVW4AAVJGdUB0Trdpv1STs13/Gj4,iv:0kQRpOo71ooQc+
 claude_code_oauth_token: ENC[AES256_GCM,data:RZ5KofRdsuORdcqTwL2djLSn1Ak0jjI3qhdhzikHULUZ9exq6qUNFy65X0YUaOVWKBDO/jB4F0UacZ6jaUCkShlP8YqswQDR6nfN3r2EPQB7WJOl2mX3MNu8ArGFQ5+Jbww18usz8+yYKU0e,iv:I2t4ueYF3DbR0RwV7QLrB2i3SAWYMPjblhmOc5g7XBo=,tag:9AHSAQkvD1n7VSSajs+IKw==,type:str]
 ascend_ingest_key: ENC[AES256_GCM,data:CC5X+YK7hZqEjTgRs2+jzBMSAkY6uGYiGtSfLaY8x0frdufw+19ZV3G64qVjSeUYn9Ffq9WnS2Ii/NHiBhJ2gw==,iv:SeWwwxzGiftfemiJ5aibeOMXDU/zkyupAWDdJuj4Ty4=,tag:CEcRKElyld4fZPyxjRfONg==,type:str]
 ascend_password: ENC[AES256_GCM,data:qzc7+8jf,iv:XIxOGdxDhTDa+3MCB3hxSAhDgi9mWvr/sWSCg+dN+kY=,tag:wOQeFXAM8HDQs2yka36Wcg==,type:str]
+internal_scope_key: ENC[AES256_GCM,data:xA8iNFrKYTv7cwjQFnLzsK5fteKpAzWwlPuZSKAAkn6JfZ8MKJGh2mkXpXqsiVcc2d3mX1DjH+1YimhH5sRC1Q==,iv:r+Y9Q9FpH6L4o+KWXikgQVrMAHOqx8/r9jSfeek08TE=,tag:WISgVjQ+haTXZFIeicRkMQ==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -32,7 +33,7 @@ sops:
             aTliSGZZNTJWeTVCeTJUTWI1QTBtZ2sKKS8eDR70HQgZ4vXcuUkaqhD3xH+AKsgM
             ZlT0Knz3kFt3ENRgOB9xPlN6WfpGwtcor2UCfTXAZpCWEqC51Ht3bg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-03T01:30:00Z"
-    mac: ENC[AES256_GCM,data:Euy8YAQj4NBHzWB+bqPMXvbAHoH0ycbP/gPnLgngsVqtx6h9M2d4Tkleg0bZCpfja29ufrq2Bb0AcAIYcp1suS0hqTDzOddevALqnr257Uhc1RPLQwOvt+UJuWIQkovUyGcJ1pI4PXiqcqhqhT/l2AgKmKzhevwWC3cQF05zRgA=,iv:IDp/9CaeoEWs3npmms4nwB97PLdnsz5U1n33mTs00Ro=,tag:n7g1DcX/Kkg4LAvyRYS6aQ==,type:str]
+    lastmodified: "2026-07-09T02:10:56Z"
+    mac: ENC[AES256_GCM,data:+mucOPLh+gTMGofu6LDZh/5xnUk1zROmhgFnmP/L4bvsPL0sZqdZbF7KksIXDEN/5SwL32HiF/SgiJgG8bnmoPUv98tYcoWbgDuFDXbrvSXkuXfLGLCKc4KwpRsDGenLXNH3iv2OcR4GrwGsu9WzLrAC6H3Mh8kXEd0VmRe1SYU=,iv:oVvNhFE0IVqLLjVGfhDPb8IGL77LroF56MO+2mOdfRo=,tag:uuWFESKRsq8qsbyHaQku+w==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/embodied-dreamfinder/secrets.yaml.example
+++ b/embodied-dreamfinder/secrets.yaml.example
@@ -30,3 +30,14 @@ dreamfinder_api_key: ""
 livekit_url: "wss://livekit.imagineering.cc"
 livekit_api_key: ""
 livekit_api_secret: ""
+
+# Ascend night scoping
+# ascend_password: a SECOND sign-in password that unlocks the DF who knows last night
+#   (plain auth_password gives "base" DF, blind to it).
+# ascend_ingest_key: bearer the ascend night-loop presents on POST /api/ascend/night.
+# internal_scope_key: shared secret (>=16 chars; generate with `openssl rand -hex 32`)
+#   letting the in-container LiveKit voice agent request ascend-scoped context over
+#   localhost. Server + agent share the container env, so one value serves both.
+ascend_password: ""
+ascend_ingest_key: ""
+internal_scope_key: ""

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -799,6 +799,12 @@ deploy_embodied_dreamfinder() {
         printf 'ASCEND_INGEST_KEY=%s\n'     "$(dotenv_quote "$(edf_field '.ascend_ingest_key')")"
         # Second password scoping a session to "ascend" (unlocks the DF that knows last night).
         printf 'ASCEND_PASSWORD=%s\n'       "$(dotenv_quote "$(edf_field '.ascend_password')")"
+        # Shared secret proving a localhost caller is the trusted in-container voice agent
+        # (not the public-embeddable renderer): lets it request ascend-scoped context over
+        # 127.0.0.1 so the local LiveKit pipeline gets the night. Server + agent run in the
+        # same container, so this one value reaches both. <16 chars → server disables the
+        # override (fail-closed). See embodied-dreamfinder server.js localhost branch.
+        printf 'INTERNAL_SCOPE_KEY=%s\n'    "$(dotenv_quote "$(edf_field '.internal_scope_key')")"
     } > "$REPO_ROOT/embodied-dreamfinder/.env"
 
     # Compose-file selection: only apply the lyra-live override (which mounts the


### PR DESCRIPTION
Activates embodied-dreamfinder PR #74's dormant ascend-scope path by wiring INTERNAL_SCOPE_KEY through the declarative secret pipeline (SOPS secrets.yaml → deploy-to.sh .env-gen → compose env). Server + in-container voice agent share the key. Fail-closed: <16-char key disables the override, so a mis-wire leaves bug 2 dormant rather than elevating. Encrypted value only — no plaintext in the diff. Will deploy from this branch + verify the in-container localhost override returns ascend before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)