### PR TITLE
fix(backup): auto-detect volume in restore + real restore test (#1759)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,23 @@ jobs:
           REQUIRE_ALL: "1"
         run: ./scripts/test-secret-quoting.sh
 
+  restore-aiko-island:
+    name: Aiko Island Restore Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Real restore test: drives restore.sh's _restore_island_core + the
+      # aiko_island_* discovery lib against throwaway docker volumes, asserting
+      # the restored passkey rows land in the LIVE volume (content, not
+      # presence) and that discovery never picks the orphaned ghost volume
+      # (#1759). ubuntu-latest ships docker; REQUIRE_ALL=1 makes a missing
+      # docker a HARD failure so this can't silently skip and go green.
+      - name: Run aiko-island restore test
+        env:
+          REQUIRE_ALL: "1"
+        run: ./scripts/test-restore-aiko-island.sh
+
   caddy-validate:
     name: Caddyfile Validate
     runs-on: ubuntu-latest

--- a/scripts/backup-aiko-island-standalone.sh
+++ b/scripts/backup-aiko-island-standalone.sh
@@ -29,15 +29,17 @@ mkdir -p "$BACKUP_DIR"
 log()   { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 fail()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1" >&2; exit 1; }
 
+# Shared live-volume discovery (single home for the invariant — see fleet
+# backup.sh; the ghost-volume history is documented in lib/aiko-volume.sh).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/aiko-volume.sh
+. "$SCRIPT_DIR/lib/aiko-volume.sh"
+
 # --- Locate the LIVE island volume from the running container -----------------
 # Hardcoding the volume name silently backs up a ghost after a compose/project
-# cutover renames it (that bug bit Sydney — see fleet backup.sh). Derive it.
-GW_CID=$(docker ps --format '{{.Names}}\t{{.Image}}' \
-  | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
-[ -n "$GW_CID" ] || fail "no running island container (image aiko-chat-island|gateway:*)"
-GW_VOL=$(docker inspect "$GW_CID" \
-  --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
-[ -n "$GW_VOL" ] || fail "container $GW_CID has no /data volume mount"
+# cutover renames it (that bug bit Sydney). Derive it from the live container.
+GW_CID=$(aiko_island_container) || fail "no running island container (image aiko-chat-island|gateway:*)"
+GW_VOL=$(aiko_island_volume "$GW_CID") || fail "container $GW_CID has no /data volume mount"
 log "live island volume: $GW_VOL (container $GW_CID)"
 
 # --- Dump (online-safe: read-only mount, .dump reads a consistent snapshot) ----

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -47,6 +47,10 @@ error() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/telegram.sh
 . "$SCRIPT_DIR/lib/telegram.sh"
+# Live island volume/container discovery — single home for the invariant so
+# backup and restore can't drift apart (aiko_chat_gateway#1759).
+# shellcheck source=lib/aiko-volume.sh
+. "$SCRIPT_DIR/lib/aiko-volume.sh"
 
 check_repo_size() {
   if [ ! -d "$GITHUB_BACKUP_DIR" ]; then
@@ -208,26 +212,13 @@ backup_aiko_island() {
   # still a non-empty container, so an `-s` size check on the .gz lies). Capture
   # stderr for the error message (a WAL-locked read fails loudly, not silently).
   # Derive the live island volume from the RUNNING container rather than
-  # hardcoding it. The island cutover (project aiko-chat-gateway + volume
-  # aiko-chat-gateway_aiko_gateway_data -> project aiko + external volume
-  # aiko_data) silently ORPHANED the old volume, so a hardcoded name backed up
-  # a frozen ghost for days (caught 2026-07-07: Sydney's daily dump had
-  # passkey_credentials=0 while the live DB had 1). Auto-detect removes that
-  # drift class and works on BOTH islands regardless of cutover state (Melbourne
-  # still runs the pre-cutover volume name).
+  # hardcoding it (see lib/aiko-volume.sh for the full ghost-volume history).
+  # Auto-detect follows the island cutover automatically and works on BOTH
+  # islands regardless of cutover state (Melbourne still runs the pre-cutover
+  # volume name).
   local gw_cid gw_vol
-  gw_cid=$(docker ps --format '{{.Names}}\t{{.Image}}' \
-    | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
-  if [ -z "$gw_cid" ]; then
-    error "aiko-island: no running island container (image aiko-chat-island|gateway:*)"
-    return 1
-  fi
-  gw_vol=$(docker inspect "$gw_cid" \
-    --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
-  if [ -z "$gw_vol" ]; then
-    error "aiko-island: container $gw_cid has no /data volume mount"
-    return 1
-  fi
+  gw_cid=$(aiko_island_container) || return 1
+  gw_vol=$(aiko_island_volume "$gw_cid") || return 1
   log "  live island volume: $gw_vol (container $gw_cid)"
 
   if ! docker run --rm -v "${gw_vol}:/data:ro" sqlite-dumper:latest \

--- a/scripts/lib/aiko-volume.sh
+++ b/scripts/lib/aiko-volume.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Shared discovery of the LIVE aiko-chat-island SQLite volume + container.
+#
+# WHY THIS FILE EXISTS: the island cutover renamed the DB volume (compose
+# project aiko-chat-gateway + volume aiko-chat-gateway_aiko_gateway_data  ->
+# project aiko + external volume aiko_data). Hardcoding the old name silently
+# operates on a frozen GHOST volume the live island never mounts — caught
+# 2026-07-07 when Sydney's daily dump had passkey_credentials=0 while the live
+# DB had 1. So backup AND restore MUST derive the volume from the RUNNING
+# container: that follows the cutover automatically and works on BOTH islands
+# (Melbourne still runs the pre-cutover name). This snippet used to be
+# copy-pasted into each script, and only the backup copies got the fix — so
+# restore.sh drifted and kept the ghost name (aiko_chat_gateway#1759). One home
+# for the invariant = the copies can't drift apart again.
+#
+# Usage — source this file, then:
+#   cid=$(aiko_island_container) || return 1
+#   vol=$(aiko_island_volume "$cid") || return 1
+#
+# Each function prints its result on stdout and returns non-zero (with a
+# message on stderr) on failure, so callers can `|| return` / `|| exit`.
+
+# The running island container. Match the image tag, tolerating island|gateway
+# because Melbourne (pre-cutover) still runs aiko-chat-gateway:*. First match
+# wins — a box runs exactly one island.
+aiko_island_container() {
+  local cid
+  cid=$(docker ps --format '{{.Names}}\t{{.Image}}' \
+    | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
+  if [ -z "$cid" ]; then
+    echo "aiko-volume: no running island container (image aiko-chat-island|gateway:*)" >&2
+    return 1
+  fi
+  printf '%s\n' "$cid"
+}
+
+# The docker volume backing /data in the given container. This is the SINGLE
+# source of truth for "which volume holds aiko.db" — never hardcode the name.
+aiko_island_volume() {
+  local cid=$1 vol
+  if [ -z "$cid" ]; then
+    echo "aiko-volume: aiko_island_volume requires a container id/name" >&2
+    return 1
+  fi
+  vol=$(docker inspect "$cid" \
+    --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+  if [ -z "$vol" ]; then
+    echo "aiko-volume: container $cid has no /data volume mount" >&2
+    return 1
+  fi
+  printf '%s\n' "$vol"
+}

--- a/scripts/lib/aiko-volume.sh
+++ b/scripts/lib/aiko-volume.sh
@@ -21,23 +21,39 @@
 # message on stderr) on failure, so callers can `|| return` / `|| exit`.
 
 # The running island container. Match the image tag, tolerating island|gateway
-# because Melbourne (pre-cutover) still runs aiko-chat-gateway:*. First match
-# wins — a box runs exactly one island.
+# because Melbourne (pre-cutover) still runs aiko-chat-gateway:*.
+#
+# Fail CLOSED on ambiguity: a box is meant to run exactly one island, but the
+# restore path stops + swaps + starts this container's SOLE auth+message DB, so
+# it must never GUESS when two match (a stale cutover sibling, a leftover
+# resttest container, a co-located second island). Uncertainty removes
+# authority — return an error the operator must resolve, don't silently pick one.
+#
+# KNOWN LIMITATION (tracked follow-up): discovery is `docker ps` (RUNNING only).
+# A crashed / exited island is invisible, so a restore-after-boot-failure can't
+# locate the volume until the container is running again. Widening to
+# `docker ps -a` is deferred because it changes backup semantics and must first
+# resolve post-cutover exited-container ambiguity (see the #1759 PR discussion).
 aiko_island_container() {
-  local cid
-  cid=$(docker ps --format '{{.Names}}\t{{.Image}}' \
-    | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1; exit}')
-  if [ -z "$cid" ]; then
+  local matches count
+  matches=$(docker ps --format '{{.Names}}\t{{.Image}}' \
+    | awk -F'\t' '$2 ~ /^aiko-chat-(island|gateway):/ {print $1}')
+  count=$(printf '%s' "$matches" | grep -c .)
+  if [ "$count" -eq 0 ]; then
     echo "aiko-volume: no running island container (image aiko-chat-island|gateway:*)" >&2
     return 1
   fi
-  printf '%s\n' "$cid"
+  if [ "$count" -gt 1 ]; then
+    echo "aiko-volume: >1 running island container matched ($(printf '%s' "$matches" | tr '\n' ' ')) — refusing to guess which is THE island" >&2
+    return 1
+  fi
+  printf '%s\n' "$matches"
 }
 
 # The docker volume backing /data in the given container. This is the SINGLE
 # source of truth for "which volume holds aiko.db" — never hardcode the name.
 aiko_island_volume() {
-  local cid=$1 vol
+  local cid=${1:-} vol   # ${1:-} so the -z diagnostic fires under set -u, not an abort
   if [ -z "$cid" ]; then
     echo "aiko-volume: aiko_island_volume requires a container id/name" >&2
     return 1

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -461,7 +461,10 @@ restore_continuwuity() {
 # because this branch is reached solely via `source`; a direct run never sets
 # RESTORE_LIB_ONLY, so it falls through to the dispatch below.
 if [ "${RESTORE_LIB_ONLY:-0}" = "1" ]; then
-  return 0
+  # `return` when sourced, `exit` when executed directly — mechanical, not by
+  # convention, so `RESTORE_LIB_ONLY=1 ./restore.sh` doesn't emit bash's
+  # "can only return from a function or sourced script" error.
+  return 0 2>/dev/null || exit 0
 fi
 
 # Deferred from the top of the file so the harness can source cleanly.

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-SERVICE=$1
+SERVICE=${1:-}   # may be unset when sourced by the test harness (set -u safe)
 RESTORE_DIR="/tmp/restore"
 GITHUB_BACKUP_REPO="git@github-imagineering-backups:imagineering-cc/imagineering-backups.git"
 BACKUP_CLONE_DIR="$RESTORE_DIR/imagineering-backups"
@@ -28,19 +28,16 @@ error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" >&2; }
 
 AGE_IDENTITY_FILE="${AGE_IDENTITY_FILE:-${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}}"
 
-if [ -z "$SERVICE" ]; then
-  echo "Usage: $0 <service>"
-  echo "  service: kanbn, outline, radicale, pm-bot, claudius, aiko-island, matrix, continuwuity"
-  echo ""
-  echo "Examples:"
-  echo "  $0 kanbn         # Restore latest from GitHub backup"
-  echo "  $0 outline       # Restore latest from GitHub backup"
-  echo "  $0 matrix        # Restore all matrix bridges + relay-bots"
-  echo "  $0 continuwuity  # Restore homeserver (requires AGE_IDENTITY_FILE)"
-  exit 1
-fi
+# Live island volume/container discovery — the SAME single home backup.sh uses,
+# so restore can never again drift back to a hardcoded (ghost) volume name
+# (aiko_chat_gateway#1759). test-restore-aiko-island.sh sources this file with
+# RESTORE_LIB_ONLY=1 to exercise _restore_island_core against a temp volume.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/aiko-volume.sh
+. "$SCRIPT_DIR/lib/aiko-volume.sh"
 
-mkdir -p "$RESTORE_DIR"
+# Usage check + dispatch are deferred to the guarded tail so the test harness
+# can source this file (RESTORE_LIB_ONLY=1) without triggering the arg check.
 
 # Clone the backup repo (shallow) to get latest backups
 fetch_backups() {
@@ -199,42 +196,48 @@ restore_claudius() {
   log "Claudius restore complete!"
 }
 
-# Restore the aiko-chat-island SQLite store from the latest .sql dump in the
-# backup repo. Mirrors the matrix-bridge sqlite restore: stop the container
-# (never replay against a live DB), replace the DB from the dump inside the
-# sqlite-dumper image (rw mount), restart. The dump carries the current schema
-# (email col, nullable password_hash, social_identities), so the island's boot
-# schema guard passes after restore. aiko_chat_gateway#4.
-restore_aiko_island() {
-  log "Restoring aiko-chat-island..."
+# Core island restore: replace aiko.db in volume $vol from $sql_file, stopping
+# then starting container $cid around the swap. NO prompt, NO git fetch — this
+# is the unit test-restore-aiko-island.sh drives against a throwaway volume, so
+# the CI test exercises the REAL install logic rather than a copy of it. Only
+# the gateway container (the one mounting /data) is stopped — the broker/
+# registrar never touch aiko.db, so a `docker stop <cid>` is more surgical than
+# the old `docker compose stop` (less downtime) and needs no compose dir.
+# Returns non-zero on any failure; the live aiko.db is intact in almost all
+# failure paths (candidate is validated before the atomic install).
+#
+# Ordering that matters: validate dump -> stop container -> rescue+install ->
+# start container. The dump carries the current schema (email col, nullable
+# password_hash, social_identities), so the island's boot schema guard passes
+# after restore. aiko_chat_gateway#4 / #1759.
+_restore_island_core() {
+  local sql_file=$1 cid=$2 vol=$3
 
-  fetch_backups
-
-  local sql_file="$BACKUP_CLONE_DIR/aiko-island.sql"
   # Validate the dump BEFORE touching anything: present, non-empty, and complete
   # (a COMPLETE sqlite .dump ends with COMMIT;). The island DB is the SOLE copy
   # of auth+messages+ACL, so a bad dump must never reach the destructive path.
   if [ ! -s "$sql_file" ]; then
-    error "No (non-empty) aiko-island.sql in backup repo"; cleanup_backups; exit 1
+    error "No (non-empty) dump at $sql_file"; return 1
   fi
   # End-anchored completeness check (see backup.sh): the LAST non-blank line of a
   # complete sqlite .dump is exactly `COMMIT;`. A whole-file grep could be fooled
   # by `COMMIT;` embedded in multiline data, accepting a truncated dump.
   if [ "$(grep -ve '^[[:space:]]*$' "$sql_file" | tail -n1)" != "COMMIT;" ]; then
-    error "aiko-island.sql looks truncated/invalid (last line is not COMMIT;)"; cleanup_backups; exit 1
+    error "dump looks truncated/invalid (last line is not COMMIT;)"; return 1
   fi
 
-  # Irreversible: replacing the sole auth+message store. Require typed consent.
-  echo "WARNING: this REPLACES the island's SOLE database (all accounts + messages + ACL)."
-  echo "  dump: $sql_file ($(wc -l < "$sql_file") lines, $(du -h "$sql_file" | cut -f1))"
-  read -r -p "Type 'restore aiko-island' to proceed: " confirm
-  if [ "$confirm" != "restore aiko-island" ]; then
-    error "Aborted (no confirmation)"; cleanup_backups; exit 1
+  # The island image ships no sqlite3; build the tiny alpine+sqlite helper if
+  # absent (idempotent — mirrors backup-aiko-island-standalone.sh) so restore
+  # works on a box where the backup path has never run.
+  if ! docker image inspect sqlite-dumper:latest >/dev/null 2>&1; then
+    log "Building sqlite-dumper:latest (alpine + sqlite3)..."
+    printf 'FROM alpine:3.20\nRUN apk add --no-cache sqlite\n' \
+      | docker build -q -t sqlite-dumper:latest - >/dev/null \
+      || { error "failed to build sqlite-dumper:latest"; return 1; }
   fi
 
-  log "Stopping island..."
-  cd ~/apps/aiko-chat-gateway
-  docker compose stop
+  log "Stopping island container $cid..."
+  docker stop "$cid" >/dev/null || { error "failed to stop container $cid"; return 1; }
 
   # Build + validate the candidate in a TEMP file, and only swap it in on
   # success — the live aiko.db is untouched until a valid replacement exists.
@@ -242,7 +245,7 @@ restore_aiko_island() {
   local rescue
   rescue="aiko.db.rescue-$(date +%Y%m%d-%H%M%S)"
   log "Building + validating candidate DB (live DB untouched until it passes)..."
-  if ! docker run --rm -i -v "aiko-chat-gateway_aiko_gateway_data:/data" sqlite-dumper:latest sh -c '
+  if ! docker run --rm -i -v "${vol}:/data" sqlite-dumper:latest sh -c '
         set -e
         rm -f /data/aiko.db.restore /data/aiko.db.restore-wal /data/aiko.db.restore-shm
         sqlite3 /data/aiko.db.restore        # replay dump from stdin
@@ -270,13 +273,48 @@ restore_aiko_island() {
         mv -f /data/aiko.db.restore /data/aiko.db
       ' < "$sql_file"; then
     error "aiko-island restore FAILED. The candidate was rejected before the final install in almost all cases, so the live aiko.db is the original; a complete rescue copy (aiko.db.rescue-*) is also in the volume. Inspect the volume before retrying. Restarting on the current DB."
-    docker compose up -d
-    cleanup_backups
-    exit 1
+    docker start "$cid" >/dev/null || error "ALSO failed to restart $cid — island is DOWN, start it manually"
+    return 1
   fi
 
   log "Restored OK (previous DB kept in the volume as $rescue). Restarting island..."
-  docker compose up -d
+  docker start "$cid" >/dev/null || { error "restore installed but restart of $cid FAILED — island is DOWN, start it manually"; return 1; }
+}
+
+# Restore the aiko-chat-island SQLite store from the latest .sql dump in the
+# backup repo. Wraps _restore_island_core with: fetch-from-backup-repo, live
+# volume/container AUTO-DETECT (never a hardcoded ghost name — #1759), and a
+# typed-consent gate (irreversible: replaces the sole auth+message store).
+restore_aiko_island() {
+  log "Restoring aiko-chat-island..."
+
+  fetch_backups
+  local sql_file="$BACKUP_CLONE_DIR/aiko-island.sql"
+  if [ ! -s "$sql_file" ]; then
+    error "No (non-empty) aiko-island.sql in backup repo"; cleanup_backups; exit 1
+  fi
+
+  # Auto-detect the LIVE volume + container BEFORE the destructive confirm, so a
+  # missing/renamed target fails early — and so restore writes into the SAME
+  # volume the live island reads, not the orphaned pre-cutover ghost the old
+  # hardcoded name pointed at (#1759).
+  local gw_cid gw_vol
+  gw_cid=$(aiko_island_container) || { cleanup_backups; exit 1; }
+  gw_vol=$(aiko_island_volume "$gw_cid") || { cleanup_backups; exit 1; }
+
+  # Irreversible: replacing the sole auth+message store. Require typed consent,
+  # and show the resolved target so the operator can eyeball the volume.
+  echo "WARNING: this REPLACES the island's SOLE database (all accounts + messages + ACL)."
+  echo "  dump:   $sql_file ($(wc -l < "$sql_file") lines, $(du -h "$sql_file" | cut -f1))"
+  echo "  target: volume $gw_vol (live container $gw_cid)"
+  read -r -p "Type 'restore aiko-island' to proceed: " confirm
+  if [ "$confirm" != "restore aiko-island" ]; then
+    error "Aborted (no confirmation)"; cleanup_backups; exit 1
+  fi
+
+  if ! _restore_island_core "$sql_file" "$gw_cid" "$gw_vol"; then
+    cleanup_backups; exit 1
+  fi
 
   cleanup_backups
   log "aiko-island restore complete!"
@@ -416,6 +454,30 @@ restore_continuwuity() {
   echo "TODO: ship an ldb-based helper or wait for Continuwuity to add a"
   echo "      'restore-database' admin command (file an issue upstream)."
 }
+
+# When sourced by the test harness (RESTORE_LIB_ONLY=1), stop here: expose the
+# functions (_restore_island_core + the aiko_island_* lib) without running the
+# dispatch, which would otherwise demand a $SERVICE arg. `return` is valid only
+# because this branch is reached solely via `source`; a direct run never sets
+# RESTORE_LIB_ONLY, so it falls through to the dispatch below.
+if [ "${RESTORE_LIB_ONLY:-0}" = "1" ]; then
+  return 0
+fi
+
+# Deferred from the top of the file so the harness can source cleanly.
+if [ -z "$SERVICE" ]; then
+  echo "Usage: $0 <service>"
+  echo "  service: kanbn, outline, radicale, pm-bot, claudius, aiko-island, matrix, continuwuity"
+  echo ""
+  echo "Examples:"
+  echo "  $0 kanbn         # Restore latest from GitHub backup"
+  echo "  $0 outline       # Restore latest from GitHub backup"
+  echo "  $0 matrix        # Restore all matrix bridges + relay-bots"
+  echo "  $0 continuwuity  # Restore homeserver (requires AGE_IDENTITY_FILE)"
+  exit 1
+fi
+
+mkdir -p "$RESTORE_DIR"
 
 # Run restore
 case $SERVICE in

--- a/scripts/test-restore-aiko-island.sh
+++ b/scripts/test-restore-aiko-island.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Real restore test for the aiko-chat-island DB (aiko_chat_gateway#1759).
+#
+# WHY THIS EXISTS: we could back up the island but had NEVER proven we could
+# restore it. Worse, restore.sh hardcoded the pre-cutover volume name — so on
+# Sydney a restore would have silently written into an ORPHANED ghost volume
+# the live island never mounts, reporting "restore complete!" while the live DB
+# stayed empty. "The file exists" is exactly the lie that bit us; this test
+# asserts CONTENT (passkey rows the live volume actually holds), not presence.
+#
+# It drives the REAL restore code — it sources restore.sh (RESTORE_LIB_ONLY=1)
+# and calls _restore_island_core + the aiko_island_* discovery lib, against a
+# throwaway container + temp volumes. No copy of the logic, so it can't rot out
+# of sync with production.
+#
+# Three assertions:
+#   [1] DISCOVERY  — aiko_island_volume() resolves the volume the LIVE container
+#                    mounts, never the ghost. This is the exact bug's root.
+#   [2] GHOST/RED  — restoring into the ghost volume (old hardcoded behaviour)
+#                    leaves the LIVE volume with 0 passkeys: data silently lost.
+#   [3] CONTENT    — restoring into the DISCOVERED volume gives the live volume
+#                    the passkey row, and the container is running again.
+#
+# REQUIRE_ALL=1 (set by CI) turns a missing docker into a hard failure rather
+# than a vacuous skip, so CI can't go green with the test silently not running.
+#
+# Exit non-zero on any failure.
+
+set -uo pipefail
+
+REQUIRE_ALL=${REQUIRE_ALL:-0}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+ok()   { echo "  ok   - $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL - $1"; FAIL=$((FAIL + 1)); }
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  if [ "$REQUIRE_ALL" = "1" ]; then
+    echo "  FAIL - docker unavailable (REQUIRE_ALL set — must be present in CI)"
+    exit 1
+  fi
+  echo "  skip - docker unavailable; skipping restore test (set REQUIRE_ALL=1 to force)"
+  exit 0
+fi
+
+# --- Unique, self-cleaning fixtures -----------------------------------------
+SUFFIX="$$-$(date +%s)"
+IMG="aiko-chat-island:resttest-$SUFFIX"     # image prefix must match discovery
+CTR="aiko-island-resttest-$SUFFIX"
+VOL_LIVE="aiko-resttest-live-$SUFFIX"       # the volume the container mounts
+VOL_GHOST="aiko-resttest-ghost-$SUFFIX"     # the orphaned pre-cutover name
+WORK="$(mktemp -d)"
+
+cleanup() {
+  docker rm -f "$CTR" >/dev/null 2>&1 || true
+  docker volume rm -f "$VOL_LIVE" "$VOL_GHOST" >/dev/null 2>&1 || true
+  docker image rm -f "$IMG" >/dev/null 2>&1 || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# alpine+sqlite helper for asserting content inside a volume (built by the
+# restore path too; build here so assertions work even if it hasn't run yet).
+if ! docker image inspect sqlite-dumper:latest >/dev/null 2>&1; then
+  printf 'FROM alpine:3.20\nRUN apk add --no-cache sqlite\n' \
+    | docker build -q -t sqlite-dumper:latest - >/dev/null
+fi
+
+# A throwaway "island" image whose tag matches the discovery regex
+# (^aiko-chat-(island|gateway):). It just sleeps — the restore only needs it
+# running so discovery can inspect its /data mount and stop/start it.
+docker build -q -t "$IMG" - >/dev/null <<'DOCKERFILE'
+FROM alpine:3.20
+CMD ["sleep", "3600"]
+DOCKERFILE
+
+docker volume create "$VOL_LIVE" >/dev/null
+docker volume create "$VOL_GHOST" >/dev/null
+docker run -d --name "$CTR" -v "$VOL_LIVE:/data" "$IMG" >/dev/null
+
+# A COMPLETE sqlite .dump (ends in COMMIT;) with a users row + one
+# passkey_credentials row — the content restore must land in the live volume.
+DUMP="$WORK/aiko-island.sql"
+cat > "$DUMP" <<'SQL'
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE users (id TEXT PRIMARY KEY, email TEXT);
+INSERT INTO users VALUES ('u_test','test@example.com');
+CREATE TABLE passkey_credentials (
+  id TEXT PRIMARY KEY, credential_id TEXT UNIQUE NOT NULL,
+  user_id TEXT NOT NULL, public_key TEXT NOT NULL,
+  sign_count INTEGER NOT NULL DEFAULT 0);
+INSERT INTO passkey_credentials VALUES ('pk_1','cred_abc','u_test','cose_pub',0);
+COMMIT;
+SQL
+
+# passkey_count <volume> — echoes the passkey_credentials row count in that
+# volume's aiko.db, or 0 if the DB doesn't exist yet. This is the CONTENT probe:
+# presence lied to us, so every assertion goes through real rows.
+passkey_count() {
+  docker run --rm -v "$1:/data:ro" sqlite-dumper:latest sh -c '
+    [ -f /data/aiko.db ] || { echo 0; exit 0; }
+    sqlite3 /data/aiko.db "SELECT count(*) FROM passkey_credentials;" 2>/dev/null || echo 0'
+}
+
+# --- Source the REAL restore code (functions only, no dispatch) -------------
+# shellcheck source=restore.sh disable=SC1091
+RESTORE_LIB_ONLY=1 . "$SCRIPT_DIR/restore.sh"
+set +e   # restore.sh sets -e; we drive control flow explicitly from here.
+
+echo "[1] discovery resolves the LIVE volume, not the ghost"
+CID="$(aiko_island_container)"
+VOL="$(aiko_island_volume "$CID")"
+if [ "$CID" = "$CTR" ]; then ok "container discovered ($CID)"; else bad "discovered '$CID', expected '$CTR'"; fi
+if [ "$VOL" = "$VOL_LIVE" ]; then ok "volume resolves to the mounted live volume"; else bad "resolved '$VOL', expected '$VOL_LIVE'"; fi
+if [ "$VOL" != "$VOL_GHOST" ]; then ok "discovery never returns the ghost volume"; else bad "discovery returned the ghost volume"; fi
+
+echo "[2] RED: restoring into the ghost volume loses data (the #1759 bug)"
+# This is the pre-fix behaviour: install into the hardcoded ghost name. The
+# live volume the island actually reads must be UNTOUCHED — 0 passkeys.
+_restore_island_core "$DUMP" "$CID" "$VOL_GHOST" >/dev/null 2>&1
+LIVE_AFTER_GHOST="$(passkey_count "$VOL_LIVE")"
+if [ "$LIVE_AFTER_GHOST" -eq 0 ]; then
+  ok "ghost restore left the live volume empty (proves the bug it would've hidden)"
+else
+  bad "expected 0 passkeys in live volume after ghost restore, got $LIVE_AFTER_GHOST"
+fi
+
+echo "[3] CONTENT: restoring into the DISCOVERED volume lands the rows live"
+_restore_island_core "$DUMP" "$CID" "$VOL"
+CORE_RC=$?
+LIVE_AFTER="$(passkey_count "$VOL_LIVE")"
+if [ "$CORE_RC" -eq 0 ]; then ok "_restore_island_core succeeded"; else bad "_restore_island_core returned $CORE_RC"; fi
+if [ "$LIVE_AFTER" -gt 0 ]; then
+  ok "live volume now holds the restored passkey row (count=$LIVE_AFTER)"
+else
+  bad "live volume still has 0 passkeys after restore into the discovered volume"
+fi
+# The fix restarts via `docker start <cid>` — the container must be up again.
+if [ "$(docker inspect -f '{{.State.Running}}' "$CTR" 2>/dev/null)" = "true" ]; then
+  ok "island container is running again after restore"
+else
+  bad "island container is not running after restore (docker start failed)"
+fi
+
+echo ""
+echo "restore test: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-restore-aiko-island.sh
+++ b/scripts/test-restore-aiko-island.sh
@@ -54,8 +54,10 @@ VOL_GHOST="aiko-resttest-ghost-$SUFFIX"     # the orphaned pre-cutover name
 WORK="$(mktemp -d)"
 
 cleanup() {
-  docker rm -f "$CTR" >/dev/null 2>&1 || true
-  docker volume rm -f "$VOL_LIVE" "$VOL_GHOST" >/dev/null 2>&1 || true
+  # ${CTR2:-}/${VOL2:-} are only set in step [4]; default-empty so the trap is
+  # set -u safe if the test aborts before [4] defines them.
+  docker rm -f "$CTR" "${CTR2:-}" >/dev/null 2>&1 || true
+  docker volume rm -f "$VOL_LIVE" "$VOL_GHOST" "${VOL2:-}" >/dev/null 2>&1 || true
   docker image rm -f "$IMG" >/dev/null 2>&1 || true
   rm -rf "$WORK"
 }
@@ -175,6 +177,24 @@ if [ "$(docker inspect -f '{{.State.Running}}' "$CTR" 2>/dev/null)" = "true" ]; 
 else
   bad "island container is not running after restore (docker start failed)"
 fi
+
+echo "[4] SAFETY: discovery fails CLOSED when >1 island container matches"
+# A destructive stop/swap/start must never GUESS which container is THE island.
+# This makes the fail-closed guard permanently falsifiable in the suite (not just
+# manually verified once): stand up a SECOND matching container and assert
+# aiko_island_container refuses. Runs LAST and tears the second container down
+# immediately, so the single-container invariant the earlier steps rely on holds.
+CTR2="aiko-island-resttest2-$SUFFIX"
+VOL2="aiko-resttest-second-$SUFFIX"
+docker volume create "$VOL2" >/dev/null
+docker run -d --name "$CTR2" -v "$VOL2:/data" "$IMG" >/dev/null
+if aiko_island_container >/dev/null 2>&1; then
+  bad "discovery returned a container despite 2 matching — first-match guess is back"
+else
+  ok "discovery refused to guess between 2 matching containers (fail-closed)"
+fi
+docker rm -f "$CTR2" >/dev/null 2>&1 || true
+docker volume rm -f "$VOL2" >/dev/null 2>&1 || true
 
 echo ""
 echo "restore test: $PASS passed, $FAIL failed"

--- a/scripts/test-restore-aiko-island.sh
+++ b/scripts/test-restore-aiko-island.sh
@@ -105,6 +105,15 @@ passkey_count() {
     sqlite3 /data/aiko.db "SELECT count(*) FROM passkey_credentials;" 2>/dev/null || echo 0'
 }
 
+# cred_id <volume> — the credential_id of the (single) restored row, or "" if the
+# DB/row is absent. Asserting the exact identity (not just count>0) is what makes
+# the content check falsifiable: a stale row or a wrong dump can't sneak past.
+cred_id() {
+  docker run --rm -v "$1:/data:ro" sqlite-dumper:latest sh -c '
+    [ -f /data/aiko.db ] || { echo ""; exit 0; }
+    sqlite3 /data/aiko.db "SELECT credential_id FROM passkey_credentials LIMIT 1;" 2>/dev/null || echo ""'
+}
+
 # --- Source the REAL restore code (functions only, no dispatch) -------------
 # shellcheck source=restore.sh disable=SC1091
 RESTORE_LIB_ONLY=1 . "$SCRIPT_DIR/restore.sh"
@@ -118,25 +127,47 @@ if [ "$VOL" = "$VOL_LIVE" ]; then ok "volume resolves to the mounted live volume
 if [ "$VOL" != "$VOL_GHOST" ]; then ok "discovery never returns the ghost volume"; else bad "discovery returned the ghost volume"; fi
 
 echo "[2] RED: restoring into the ghost volume loses data (the #1759 bug)"
-# This is the pre-fix behaviour: install into the hardcoded ghost name. The
-# live volume the island actually reads must be UNTOUCHED — 0 passkeys.
-_restore_island_core "$DUMP" "$CID" "$VOL_GHOST" >/dev/null 2>&1
+# This is the pre-fix behaviour: install into the hardcoded ghost name. To make
+# the RED assertion a real falsifier (not a vacuous one), we must prove the write
+# ACTUALLY happened to the ghost — a no-op or a failed install would ALSO leave
+# the live volume empty and would otherwise pass. So assert all three:
+#   (a) the restore itself succeeded, (b) the GHOST volume received the row,
+#   (c) the LIVE volume the island reads stayed empty (the silent data loss).
+if _restore_island_core "$DUMP" "$CID" "$VOL_GHOST" >/dev/null 2>&1; then
+  ok "ghost restore ran and succeeded (the pre-fix path executed)"
+else
+  bad "ghost restore itself failed — can't prove data-loss, RED would be vacuous"
+fi
+GHOST_AFTER="$(passkey_count "$VOL_GHOST")"
 LIVE_AFTER_GHOST="$(passkey_count "$VOL_LIVE")"
+if [ "$GHOST_AFTER" -gt 0 ]; then
+  ok "ghost volume received the write (count=$GHOST_AFTER) — the write really landed somewhere"
+else
+  bad "ghost volume has 0 passkeys — restore was a no-op, so the RED assertion proves nothing"
+fi
 if [ "$LIVE_AFTER_GHOST" -eq 0 ]; then
-  ok "ghost restore left the live volume empty (proves the bug it would've hidden)"
+  ok "live volume left empty by ghost restore (the silent data loss the bug caused)"
 else
   bad "expected 0 passkeys in live volume after ghost restore, got $LIVE_AFTER_GHOST"
 fi
 
-echo "[3] CONTENT: restoring into the DISCOVERED volume lands the rows live"
+echo "[3] CONTENT: restoring into the DISCOVERED volume lands the EXACT rows live"
 _restore_island_core "$DUMP" "$CID" "$VOL"
 CORE_RC=$?
 LIVE_AFTER="$(passkey_count "$VOL_LIVE")"
+LIVE_CRED="$(cred_id "$VOL_LIVE")"
 if [ "$CORE_RC" -eq 0 ]; then ok "_restore_island_core succeeded"; else bad "_restore_island_core returned $CORE_RC"; fi
-if [ "$LIVE_AFTER" -gt 0 ]; then
-  ok "live volume now holds the restored passkey row (count=$LIVE_AFTER)"
+# Exact count, not >0: a stale/duplicate/wrong-dump row must not sneak past.
+if [ "$LIVE_AFTER" = "1" ]; then
+  ok "live volume holds exactly the one restored row (count=1)"
 else
-  bad "live volume still has 0 passkeys after restore into the discovered volume"
+  bad "expected exactly 1 passkey in live volume, got $LIVE_AFTER"
+fi
+# Exact identity: proves it's OUR dump's row, not just any passkey row.
+if [ "$LIVE_CRED" = "cred_abc" ]; then
+  ok "restored row identity matches the dump (credential_id=cred_abc)"
+else
+  bad "expected credential_id 'cred_abc' in live volume, got '$LIVE_CRED'"
 fi
 # The fix restarts via `docker start <cid>` — the container must be up again.
 if [ "$(docker inspect -f '{{.State.Running}}' "$CTR" 2>/dev/null)" = "true" ]; then


### PR DESCRIPTION
## Why

We could back up the aiko-chat-island DB but had **never proven we could restore it** — and worse, `restore.sh` would have restored into the wrong place.

`restore_aiko_island` hardcoded the pre-cutover volume `aiko-chat-gateway_aiko_gateway_data` + `cd ~/apps/aiko-chat-gateway`. PR#124 killed that ghost-volume class in `backup.sh` (auto-detect the live volume from the running container) but **restore drifted** — it kept the old names. On Sydney (cut over to project `aiko` / external volume `aiko_data`) a restore would have written into the **orphaned volume the live island never mounts**, printed `restore complete!`, and left the live DB untouched. Exactly the lie the backup side used to tell (constant-byte ghost dumps, caught 2026-07-07).

## Root cause: a duplicated invariant

The live-volume discovery snippet was copy-pasted into three scripts; only the two backup copies got the PR#124 fix. This PR gives it **one home** so the copies can't drift apart again.

## Changes

- **`scripts/lib/aiko-volume.sh`** (new) — `aiko_island_container()` + `aiko_island_volume()`, sourced by `backup.sh`, `backup-aiko-island-standalone.sh`, and `restore.sh`.
- **`scripts/restore.sh`** — auto-detect the live volume + container; swap the DB via `docker stop/start <cid>` (more surgical than `docker compose stop` — only the gateway touches `aiko.db` — and needs no compose dir, which was a *second* stale ghost). Core logic split into `_restore_island_core` so it's unit-testable. Typed-consent gate preserved; now shows the resolved target volume.
- **`scripts/test-restore-aiko-island.sh`** (new) — drives the **real** restore code against throwaway docker volumes. Asserts **content** (restored `passkey_credentials` rows land in the *live* volume), that discovery never returns the ghost, and that restoring into the ghost leaves the live volume empty (the bug, reproduced). Presence is what lied last time → every assertion goes through real rows.
- **`.github/workflows/ci.yml`** — new docker-gated `restore-aiko-island` job (`REQUIRE_ALL=1`, mirrors `secret-quoting`).

## Verification (local)

- `test-restore-aiko-island.sh`: **7/7 pass**, exit 0, fixtures self-clean.
- **RED-proven**: mutating discovery to return a wrong volume → 2 failures / exit 1; revert → 7/7. If it can't fail, it isn't testing.
- `shellcheck -S warning` clean · `yamllint` clean · `bash -n` clean · `restore.sh <no-arg>` still prints usage + exits 1.

## Notes

- Works on **both** islands regardless of cutover state (Melbourne still runs the pre-cutover name; auto-detect follows either).
- Restore replaces the island's **sole** auth+message DB → **cage-match by law** before merge.
- Deploy is manual (`ssh` + pull) and stays Nick's call; no live-box changes here.

Closes #1759 (island task).