### PR TITLE
fix(self-healer): raise shim timeout chain 120→180 / 150→200 (nightly timeouts)

### DIFF
--- a/claude-shim/docker-compose.yml
+++ b/claude-shim/docker-compose.yml
@@ -21,11 +21,14 @@ services:
       # compose ${VAR} interpolation. The real OAuth token lives ONLY in the
       # encrypted secrets.yaml, never in git as plaintext.
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
-      # deploy-#49 floor: the self-healer's sonnet diagnoses take ~60-93s and
+      # deploy-#49 floor: the self-healer's sonnet diagnoses take ~60-96s and
       # time out against server.js's default 60000ms ceiling. Not a secret, so
       # versioned here as a literal (not in secrets.yaml). Keep below the
-      # healer's own SHIM_HTTP_TIMEOUT_MS=150000, which must sit above this.
-      - SHIM_TIMEOUT_MS=120000
+      # healer's own SHIM_HTTP_TIMEOUT_MS=200000, which must sit above this.
+      # 2026-07-13: raised 120000→180000 after back-to-back nightly timeouts
+      # (last success had <4s headroom); the healer curl ceiling moved 150→200
+      # in lockstep (self-healer/src/diagnose.mjs) so the chain stays monotonic.
+      - SHIM_TIMEOUT_MS=180000
     ports:
       - "127.0.0.1:8088:8088"   # host-local smoke tests; container callers use the network name
     networks:

--- a/self-healer/README.md
+++ b/self-healer/README.md
@@ -69,12 +69,15 @@ code encodes the worst tier: `0`=green, `1`=amber, `2`=red, `3`=healer error.
 | `SHIM_HTTP_TIMEOUT_MS` | `150000`               | curl `--max-time` for the shim call; outer SIGKILL is this + 10s |
 
 > **Timeout chain.** The ceilings are monotonic from the inside out —
-> `claude generation < shim (SHIM_TIMEOUT_MS, default 120s on the box) < curl
-> --max-time < runOnHost SIGKILL` — so a too-slow diagnosis fails on the shim
-> with a clean "claude timed out" rather than `curl exit 28` discarding an
-> answer the shim already produced. Keep `SHIM_HTTP_TIMEOUT_MS` above the shim's
-> `SHIM_TIMEOUT_MS`. (Observed live: a 93s sonnet verdict for 4 containers — the
-> old hardcoded 90s curl ceiling threw it away.)
+> `claude generation < shim (SHIM_TIMEOUT_MS, default 180s on the box) < curl
+> --max-time (SHIM_HTTP_TIMEOUT_MS, default 200s) < runOnHost SIGKILL (+10s)` —
+> so a too-slow diagnosis fails on the shim with a clean "claude timed out"
+> rather than `curl exit 28` discarding an answer the shim already produced.
+> Keep `SHIM_HTTP_TIMEOUT_MS` above the shim's `SHIM_TIMEOUT_MS`. (Observed live:
+> a 93s sonnet verdict for 4 containers — the old hardcoded 90s curl ceiling
+> threw it away; and on 2026-07-13 the whole chain moved 120→180 / 150→200 after
+> back-to-back nightly timeouts left the 4-container sonnet diagnosis, measured
+> at 96s, with under 4s of headroom against the old 120s wall.)
 
 ## The traffic-light leash
 
@@ -271,8 +274,13 @@ fail fast on misconfiguration.
 
 ## Known substrate facts (2026-06-22)
 
-- `claude-shim` lives at `~/apps/claude-shim` **on OCI only** — not checked in
-  anywhere (deployed by rsync). Versioning it is separate debt.
+- `claude-shim` is versioned in this repo at `claude-shim/` (source + Dockerfile
+  + compose + SOPS `secrets.yaml`) and deploys via
+  `./scripts/deploy-to.sh 149.118.69.221 claude-shim`, which rsyncs it to
+  `~/apps/claude-shim` on OCI and `docker compose build && up -d`. Non-secret
+  config (e.g. `SHIM_TIMEOUT_MS`) lives in the compose `environment:` block; only
+  the OAuth token is generated into `.env` from `secrets.yaml` at deploy time.
+  (This corrects an earlier note that claimed it was rsync-only / not in git.)
 - Observed live: `tw-gremlin` logged `level:50 "worker connection closed
   unexpectedly"` then re-registered under a new LiveKit node ~66ms later — a
   self-healed node rotation, the canonical "error that isn't a problem".

--- a/self-healer/src/diagnose.mjs
+++ b/self-healer/src/diagnose.mjs
@@ -15,10 +15,10 @@ const DIAGNOSE_MODEL = process.env.HEALER_MODEL || 'sonnet';
  * be monotonic from the inside out so the INNER layer fails first with a clean
  * error instead of an opaque outer kill:
  *
- *   claude generation  <  shim (SHIM_TIMEOUT_MS, default 120s on the box)
+ *   claude generation  <  shim (SHIM_TIMEOUT_MS, default 180s on the box)
  *                       <  curl --max-time  <  runOnHost hard SIGKILL
  *
- * The defaults (150s curl / 160s runOnHost) sit ABOVE the 120s shim ceiling, so
+ * The defaults (200s curl / 210s runOnHost) sit ABOVE the 180s shim ceiling, so
  * a too-slow diagnosis surfaces as the shim's own "claude timed out after …"
  * rather than `curl exit 28`. This is the deploy-#49 fix: a legitimate 93s
  * sonnet verdict was being thrown away by the old hardcoded 90s curl ceiling
@@ -26,20 +26,26 @@ const DIAGNOSE_MODEL = process.env.HEALER_MODEL || 'sonnet';
  * a shell string (it's a base64 positional arg now), but we still keep it an
  * integer for clean `--max-time` semantics.
  *
+ * 2026-07-13: the whole chain moved up 120→180 (shim) / 150→200 (curl) after
+ * back-to-back nightly timeouts — the sonnet 4-container diagnosis was brushing
+ * the old 120s wall with <4s headroom (measured 96s live once given room). The
+ * ceilings stay in lockstep (curl floor == shim ceiling) so the chain never
+ * inverts.
+ *
  * #50 FLOOR: the healer can't introspect the shim's OWN ceiling (SHIM_TIMEOUT_MS,
- * 120s on the box). A too-small SHIM_HTTP_TIMEOUT_MS would silently recreate the
+ * 180s on the box). A too-small SHIM_HTTP_TIMEOUT_MS would silently recreate the
  * deploy-#49 bug (curl killing the call before the shim can answer). So we CLAMP
- * the effective ms up to at least the shim's 120s ceiling and warn on stderr when
+ * the effective ms up to at least the shim's 180s ceiling and warn on stderr when
  * we do. This is monotonicity-preserving: runOnHostMs stays ms+10s, so the
  * existing curl<runOnHost invariant tests still hold for every input.
  *
  * @param {NodeJS.ProcessEnv} [env]
  * @returns {{curlMaxTimeSec: number, runOnHostMs: number}}
  */
-const SHIM_CEILING_MS = 120_000; // SHIM_TIMEOUT_MS on the box; the curl --max-time floor
+const SHIM_CEILING_MS = 180_000; // SHIM_TIMEOUT_MS on the box; the curl --max-time floor
 export function resolveHttpTimeouts(env = process.env) {
-  const raw = Number.parseInt(env.SHIM_HTTP_TIMEOUT_MS ?? '150000', 10);
-  const parsed = Number.isFinite(raw) && raw > 0 ? raw : 150_000;
+  const raw = Number.parseInt(env.SHIM_HTTP_TIMEOUT_MS ?? '200000', 10);
+  const parsed = Number.isFinite(raw) && raw > 0 ? raw : 200_000;
   const ms = Math.max(parsed, SHIM_CEILING_MS);
   if (ms !== parsed) {
     process.stderr.write(

--- a/self-healer/test/healer.test.mjs
+++ b/self-healer/test/healer.test.mjs
@@ -288,23 +288,23 @@ test('validateVerdict: coerces malformed finding fields to safe defaults', () =>
   assert.equal(f.diagnosis, ''); // non-string coerced
 });
 
-test('resolveHttpTimeouts: defaults sit above the 120s shim ceiling, monotonic (deploy #49)', () => {
+test('resolveHttpTimeouts: defaults sit above the 180s shim ceiling, monotonic (deploy #49)', () => {
   const { curlMaxTimeSec, runOnHostMs } = resolveHttpTimeouts({});
-  assert.equal(curlMaxTimeSec, 150);
-  assert.equal(runOnHostMs, 160_000);
+  assert.equal(curlMaxTimeSec, 200);
+  assert.equal(runOnHostMs, 210_000);
   // curl must kill BEFORE the outer hard SIGKILL...
   assert.ok(curlMaxTimeSec * 1000 < runOnHostMs);
-  // ...and AFTER the shim's own 120s ceiling, so the shim fails first (clean
+  // ...and AFTER the shim's own 180s ceiling, so the shim fails first (clean
   // "claude timed out") rather than curl exit 28 discarding a live answer.
-  assert.ok(curlMaxTimeSec * 1000 > 120_000);
+  assert.ok(curlMaxTimeSec * 1000 > 180_000);
 });
 
 test('resolveHttpTimeouts: honors SHIM_HTTP_TIMEOUT_MS, falls back on garbage/non-positive', () => {
   assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '200000' }).curlMaxTimeSec, 200);
   assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '200000' }).runOnHostMs, 210_000);
-  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: 'xyz' }).curlMaxTimeSec, 150); // unparseable ⇒ default
-  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '0' }).curlMaxTimeSec, 150);   // non-positive ⇒ default
-  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '-5' }).curlMaxTimeSec, 150);
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: 'xyz' }).curlMaxTimeSec, 200); // unparseable ⇒ default
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '0' }).curlMaxTimeSec, 200);   // non-positive ⇒ default
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '-5' }).curlMaxTimeSec, 200);
 });
 
 test('resolveHttpTimeouts: curlMaxTimeSec is an integer (shell-inert interpolation)', () => {
@@ -327,8 +327,9 @@ test('resolveHttpTimeouts: curl<runOnHost monotonicity + integer hold for ALL in
     assert.ok(curlMaxTimeSec * 1000 < runOnHostMs, `curl<runOnHost for ${JSON.stringify(v)}`);
   }
   // the injection string collapses to its leading integer (ms), never a shell
-  // token: '150000; rm -rf /' → parseInt 150000 ms → ceil(150000/1000) = 150s.
-  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '150000; rm -rf /' }).curlMaxTimeSec, 150);
+  // token: '150000; rm -rf /' → parseInt 150000 ms, which is below the 180s
+  // floor, so it clamps up → ceil(180000/1000) = 180s. The '; rm -rf /' is inert.
+  assert.equal(resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '150000; rm -rf /' }).curlMaxTimeSec, 180);
 });
 
 test('collapseRepeats: folds identical runs into ×N, leaves singletons alone (no timestamps)', () => {

--- a/self-healer/test/host_typed_argv.test.mjs
+++ b/self-healer/test/host_typed_argv.test.mjs
@@ -228,23 +228,23 @@ test('splitOnNonce: no nonce present => all head, empty logs (fail toward visibl
 
 // -- #50 timeout floor --------------------------------------------------------
 
-test('resolveHttpTimeouts: clamps a sub-floor SHIM_HTTP_TIMEOUT_MS up to >=120000', () => {
+test('resolveHttpTimeouts: clamps a sub-floor SHIM_HTTP_TIMEOUT_MS up to >=180000', () => {
   const { curlMaxTimeSec, runOnHostMs } = resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '30000' });
-  assert.ok(curlMaxTimeSec * 1000 >= 120_000, 'curl --max-time clamped to >= shim ceiling');
-  assert.equal(curlMaxTimeSec, 120);
-  assert.equal(runOnHostMs, 130_000);       // ms(120000) + 10s, monotonic above curl
+  assert.ok(curlMaxTimeSec * 1000 >= 180_000, 'curl --max-time clamped to >= shim ceiling');
+  assert.equal(curlMaxTimeSec, 180);
+  assert.equal(runOnHostMs, 190_000);       // ms(180000) + 10s, monotonic above curl
   assert.ok(curlMaxTimeSec * 1000 < runOnHostMs);
 });
 
 test('resolveHttpTimeouts: a value AT the floor passes through unchanged', () => {
-  const { curlMaxTimeSec } = resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '120000' });
-  assert.equal(curlMaxTimeSec, 120);
+  const { curlMaxTimeSec } = resolveHttpTimeouts({ SHIM_HTTP_TIMEOUT_MS: '180000' });
+  assert.equal(curlMaxTimeSec, 180);
 });
 
-test('resolveHttpTimeouts: default (150000) is above the floor and unchanged', () => {
+test('resolveHttpTimeouts: default (200000) is above the floor and unchanged', () => {
   const { curlMaxTimeSec, runOnHostMs } = resolveHttpTimeouts({});
-  assert.equal(curlMaxTimeSec, 150);
-  assert.equal(runOnHostMs, 160_000);
+  assert.equal(curlMaxTimeSec, 200);
+  assert.equal(runOnHostMs, 210_000);
 });
 
 test('resolveHttpTimeouts: an above-floor value is NOT clamped (floor only raises, never lowers)', () => {


### PR DESCRIPTION
## What
The self-healer's brain (`claude-shim`) has been hitting its **120s hard timeout** on the nightly 22:00 diagnosis. Two of the last four nights (2026-07-10, 2026-07-11) the run **exited 3 — the watchdog couldn't run at all**. The last success (07-09) finished at 117.6s, **<4s of headroom**. Confirmed live on 2026-07-13: a read-only re-run also timed out; once given room the full 4-container sonnet diagnosis measured **96s**.

## Fix
Move the whole **monotonic timeout chain** up in lockstep (curl floor == shim ceiling, so it never inverts):

```
claude gen  <  shim SHIM_TIMEOUT_MS (120→180)  <  curl SHIM_HTTP_TIMEOUT_MS
            (150→200, floor 120→180)  <  runOnHost SIGKILL (+10s)
```

- `claude-shim/docker-compose.yml` — `SHIM_TIMEOUT_MS` 120000→180000
- `self-healer/src/diagnose.mjs` — default `SHIM_HTTP_TIMEOUT_MS` 150000→200000, `SHIM_CEILING_MS` floor 120000→180000
- tests + README updated

**Why not haiku?** `diagnose.mjs` deliberately picks sonnet — tier accuracy matters more than latency, and red→green misclassification is the disaster case. This preserves the model and just gives it headroom. If latency creeps toward 150s later, trimming log tails is the next lever (noted, not done).

## Durability (the real point)
The box was **already fixed live** (shim `.env` + `self-healer.env`) and verified end-to-end (96s run). But that reverts on the next `deploy-to.sh claude-shim` because the versioned compose `environment:` block **overrides** `env_file:`. This PR makes the fix survive a redeploy. Also corrects a stale README claim that `claude-shim` is rsync-only / not in git — it **is** versioned here.

## Verification
- `node --test` → **158/158 pass**
- Live on box: shim recreated at 180s, `{"text":"OK"}` probe 6.7s, full healer run **exit 1 (amber), 96.3s**

🤖 Generated with [Claude Code](https://claude.com/claude-code)