### PR TITLE
chore: sweep imagineering-infra → enspyrco/infra references (repo rename)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# Imagineering Infrastructure
+# enspyrco/infra
 
-Monorepo for Imagineering infrastructure and self-hosted services.
+Monorepo for self-hosted infrastructure — imagineering.cc services, co-located xdeca, and enspyr.
+(Formerly `imagineering-cc/imagineering-infra`; renamed 2026-07-28. The `imagineering.cc` domain
+and its live services are unchanged — only the GitHub repo moved.)
 
 ## IMPORTANT: Production Server Safety
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,62 @@
+# Handoff: infra tab — pick up in the new home (2026-07-28)
+
+This repo was **`imagineering-cc/imagineering-infra`** until 2026-07-28. It is now
+**`enspyrco/infra`** at `~/git/orgs/enspyrco/infra`. This handoff is the pickup point.
+
+## Why the rename
+
+North star (was living only in Nick's head, now captured): **one place to manage all
+infra, and a single `nick@` user per box** — not the current `ubuntu@` + `nick@` split.
+`enspyrco/infra` becomes the one home; the boxes get normalised to `nick`-primary.
+
+## Migration status — both phases DONE (2026-07-28)
+
+**Phase 1 (local, reversible) ✓**
+- Local dir `orgs/imagineering/imagineering-infra` → `orgs/enspyrco/infra`
+- 3 git worktrees removed (2 open PRs captured as tasks; 1 was already merged)
+- Memory project dir → slug `-Users-nick-git-orgs-enspyrco-infra`; MEMORY.md live
+- 18 consolidation `memory-path.txt` repointed; wake-up protocol resolves the new home
+- Task label `project:imagineering-infra` → `project:infra` (20 issues followed)
+
+**Phase 2 (GitHub, irreversible) ✓**
+- Transferred + renamed → `enspyrco/infra`; local `origin` repointed; fetch verified
+- Preflight was clean: workflows use no secrets, no repo secrets/webhooks/deploy keys
+- **Deploys are pull-based** (cd-bus systemd timers `git pull` on the boxes). Old-URL
+  pulls keep working via GitHub's transfer redirect — so nothing broke — but the boxes'
+  remotes still say `imagineering-cc/imagineering-infra` until the sweep updates them.
+
+## First task = the sweep (find the stragglers)
+
+The rename left prose/path/remote references pointing at the old name in several places.
+See the "sweep" task. Scope:
+- **Boxes' git remotes** → `enspyrco/infra` (currently redirect-covered, not yet updated),
+  then verify a `cd-poll` actually fires (the terminal deploy observable).
+- **Repo-internal prose** (CLAUDE.md, READMEs, the GitHub description still say
+  "imagineering-infra"/"imagineering.cc") — now correct to rename since GitHub matches.
+- **Other repos' docs** referencing the old local path: xero, adventures-in/tech_world,
+  hardware-freedom/SUPERBRIDGE.md, imagineering/sessions. Cosmetic, cross-project.
+
+## Open workstreams (the rest of the north star — NOT yet planned)
+
+1. **enspyr `ubuntu@` → `nick@` migration** — grounded plan already exists at
+   `~/git/orgs/aiko/aiko-chat-island/HANDOFF-to-infra-tab.md`. Premises verified live
+   2026-07-28 (multi-tenant box, `echo` group shared, nick idle since Jun 3, etc.).
+   Two gates it names: (a) **fresh DB backup immediately pre-cutover** — latest is
+   `aiko.db.precutover-20260711-064747`, ~17 days old; (b) the **`echo` group work is
+   co-owned** by adarsha/meghana — a HUMAN coordination blocker, not a solo step.
+2. **xdeca decommission** (ensure backups fresh → stop) — colocated on the Sydney box
+   (149.118.69.221), shares caddy. Kill it *before* folding its infra in; its dir
+   becomes `archive/`, not a live subdir.
+3. **Other boxes' `nick@` status** — Sydney/imagineering already nick-primary (reference
+   end-state). enspyr in-flight (#1). Robin's box (`robins-oci`, 207.211.145.30) still
+   `ubuntu@`; ant colony untouched.
+
+## Decisions still open
+- **Label name coupling**: label is `project:infra` (forced by repo basename `infra`) —
+  generic. A distinctive `project:enspyrco-infra` would require basename `enspyrco-infra`.
+  Left as `project:infra`; flag if you want it changed (restore key = basename).
+
+## Do NOT touch
+- The `CANDEIRA` OCI profile / `oci_api_key_candeira.pem` is **intentional consented
+  break-glass** access to Javier's account — see `reference_oci_candeira_breakglass.md`.
+  Do not "helpfully" revoke it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# imagineering-infra
+# enspyrco/infra
 
-Infrastructure monorepo for self-hosted services.
+Infrastructure monorepo for self-hosted services (imagineering.cc, co-located xdeca, and enspyr).
+
+> Formerly `imagineering-cc/imagineering-infra` — renamed 2026-07-28. The `imagineering.cc`
+> domain and its services are unchanged; only the GitHub repo moved.
 
 ## Services
 

--- a/cd-bus/fleet/README.md
+++ b/cd-bus/fleet/README.md
@@ -37,7 +37,7 @@ All legs run the **same** `deploy.sh` under a **per-service flock**: legs of one
 
 ## One-time host setup
 
-**Prerequisites** (the units assume these): a `nick` group/user (units run as `User=nick`), and the shared Telegram helper at `/opt/scripts/lib/telegram.sh` (installed by imagineering-infra's `deploy_scripts` — without it the OnFailure *alerts* can't send, though deploys still work). `install-shared.sh` warns if either is missing.
+**Prerequisites** (the units assume these): a `nick` group/user (units run as `User=nick`), and the shared Telegram helper at `/opt/scripts/lib/telegram.sh` (installed by enspyrco/infra's `deploy_scripts` — without it the OnFailure *alerts* can't send, though deploys still work). `install-shared.sh` warns if either is missing.
 
 ```bash
 scp -r cd-bus/fleet nick@HOST:/tmp/cd-bus-fleet

--- a/cd-bus/fleet/install-shared.sh
+++ b/cd-bus/fleet/install-shared.sh
@@ -5,7 +5,7 @@
 # (and /etc/cd-bus/<svc>.env) is separate — see README.md.
 #
 # Run FROM this directory on the host (these repo files are hand-managed
-# mirrors of the host, like the rest of imagineering-infra's deploy artifacts):
+# mirrors of the host, like the rest of enspyrco/infra's deploy artifacts):
 #   scp -r cd-bus/fleet nick@host:/tmp/cd-bus-fleet && \
 #     ssh host 'cd /tmp/cd-bus-fleet && sudo ./install-shared.sh'
 set -euo pipefail
@@ -20,7 +20,7 @@ UNITS=/etc/systemd/system
 # the shared Telegram helper, and the unit files run as group nick. Warn rather
 # than fail — install the scripts/units regardless, but make a missing prereq loud.
 getent group nick >/dev/null || echo "WARN: group 'nick' not found — the units run as User=nick; create it or edit the units."
-[ -f /opt/scripts/lib/telegram.sh ] || echo "WARN: /opt/scripts/lib/telegram.sh missing — failure ALERTS will not send until imagineering-infra's deploy_scripts installs it."
+[ -f /opt/scripts/lib/telegram.sh ] || echo "WARN: /opt/scripts/lib/telegram.sh missing — failure ALERTS will not send until enspyrco/infra's deploy_scripts installs it."
 
 echo "installing shared scripts -> $OPT"
 install -d -o root -g root -m 0755 "$OPT"

--- a/cd-bus/fleet/systemd/cd-bus-recover@.service
+++ b/cd-bus/fleet/systemd/cd-bus-recover@.service
@@ -22,7 +22,7 @@
 # Install at /etc/systemd/system/cd-bus-recover@.service
 [Unit]
 Description=Auto-recover a failed cd-bus-subscriber@%i (bounded re-alert, no permanent death)
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 
 [Service]
 Type=oneshot

--- a/cd-bus/fleet/systemd/cd-bus-recover@.timer
+++ b/cd-bus/fleet/systemd/cd-bus-recover@.timer
@@ -12,7 +12,7 @@
 # Install at /etc/systemd/system/cd-bus-recover@.timer
 [Unit]
 Description=Periodic auto-recovery check for cd-bus-subscriber@%i
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 
 [Timer]
 # First check 5 min after boot (let the subscriber come up and, if the relay is

--- a/cd-bus/fleet/systemd/cd-bus-subscriber-alert@.service
+++ b/cd-bus/fleet/systemd/cd-bus-subscriber-alert@.service
@@ -6,7 +6,7 @@
 # Install at /etc/systemd/system/cd-bus-subscriber-alert@.service
 [Unit]
 Description=Telegram alert for cd-bus-subscriber@%i failure
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 
 [Service]
 Type=oneshot

--- a/cd-bus/fleet/systemd/cd-bus-subscriber@.service
+++ b/cd-bus/fleet/systemd/cd-bus-subscriber@.service
@@ -12,7 +12,7 @@
 # revives a `failed` unit so it can never die permanently silent.
 [Unit]
 Description=Deploy-bus SSE subscriber for %i
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 After=network-online.target docker.service
 Wants=network-online.target
 Requires=docker.service

--- a/cd-bus/fleet/systemd/cd-poll-alert@.service
+++ b/cd-bus/fleet/systemd/cd-poll-alert@.service
@@ -6,7 +6,7 @@
 # Install at /etc/systemd/system/cd-poll-alert@.service
 [Unit]
 Description=Telegram alert for cd-poll@%i failure
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 
 [Service]
 Type=oneshot

--- a/cd-bus/fleet/systemd/cd-poll@.service
+++ b/cd-bus/fleet/systemd/cd-poll@.service
@@ -4,7 +4,7 @@
 # Install at /etc/systemd/system/cd-poll@.service
 [Unit]
 Description=Deploy-bus CD pull backstop for %i
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 After=network-online.target docker.service
 Wants=network-online.target
 Requires=docker.service

--- a/cd-bus/fleet/systemd/cd-poll@.timer
+++ b/cd-bus/fleet/systemd/cd-poll@.timer
@@ -3,7 +3,7 @@
 # Install at /etc/systemd/system/cd-poll@.timer
 [Unit]
 Description=Trigger deploy-bus CD pull for %i every 5 min
-Documentation=https://github.com/imagineering-cc/imagineering-infra/blob/main/cd-bus/fleet/README.md
+Documentation=https://github.com/enspyrco/infra/blob/main/cd-bus/fleet/README.md
 
 [Timer]
 # First tick 2 min after boot (let Docker settle), then every 5 min.

--- a/claudius/docker-compose.yml
+++ b/claudius/docker-compose.yml
@@ -1,7 +1,7 @@
 # Claudius Maximus — headless email-polling Claude Code agent.
 #
 # Source is rsynced from ~/git/experiments/containerized-claude/claudius-maximus-container/
-# by deploy-to.sh. This file lives in imagineering-infra for consistent deployment.
+# by deploy-to.sh. This file lives in enspyrco/infra for consistent deployment.
 #
 # Deploy: ./scripts/deploy-to.sh 149.118.69.221 claudius
 

--- a/lugh/docker-compose.yml
+++ b/lugh/docker-compose.yml
@@ -1,7 +1,7 @@
 # Lugh — Lowell's AI historian pen pal.
 #
 # Source is rsynced from ~/git/individuals/lowell/lugh/
-# by deploy-to.sh. This file lives in imagineering-infra for consistent deployment.
+# by deploy-to.sh. This file lives in enspyrco/infra for consistent deployment.
 #
 # Deploy: ./scripts/deploy-to.sh 149.118.69.221 lugh
 

--- a/scripts/watchers/sudo-helpers/sudoers.watcher-diag
+++ b/scripts/watchers/sudo-helpers/sudoers.watcher-diag
@@ -3,7 +3,7 @@
 # script in /usr/local/bin/ — never a raw command. Wrappers take no
 # arguments to eliminate any "wrong flag passed" failure mode.
 #
-# Source of truth: scripts/watchers/sudo-helpers/ in imagineering-infra.
+# Source of truth: scripts/watchers/sudo-helpers/ in enspyrco/infra.
 # Re-install via the procedure in that directory's README.md when
 # adding/modifying wrappers.
 

--- a/self-healer/src/notify.mjs
+++ b/self-healer/src/notify.mjs
@@ -2,7 +2,7 @@
 // Telegram message via the existing `notify` proxy.
 //
 // TOPOLOGY: we do NOT hold a Telegram bot token or build a Telegram path. The
-// `notify` service (imagineering-infra/notify, https://notify.imagineering.cc)
+// `notify` service (enspyrco/infra/notify, https://notify.imagineering.cc)
 // already is the notification bus — it holds the bot token centrally and takes
 // a thin `POST /send` with a Bearer API key. Because notify is PUBLIC https
 // (unlike claude-shim's loopback bind), this is a plain `fetch` — no shell, no


### PR DESCRIPTION
Repo transferred+renamed `imagineering-cc/imagineering-infra` → `enspyrco/infra` on 2026-07-28. This lands the **repo-internal** half of the rename sweep (task #23).

## What changed (doc/comment-only, zero functional code)
- `README.md` / `CLAUDE.md` titles + a "Formerly …" note. **Every `*.imagineering.cc` URL and the `imagineering.cc` DNS/Cloudflare section is preserved** — only the GitHub repo moved, not the domain.
- 7 cd-bus systemd unit `Documentation=` URLs → `github.com/enspyrco/infra` (annotation only).
- Bare short-name comment refs in claudius/lugh compose, cd-bus fleet install/README, watcher sudoers, and `self-healer/src/notify.mjs`.

## Intentionally NOT renamed
- The migration record in `HANDOFF.md`.
- Every `imagineering-cc/{imagineering-backups,dreamfinder,dreamfinder-avatar,galaxy}` ref — those are **separate repos**, not part of this rename.

## Verified live during the sweep (not just repo-grep)
- **No box holds a CD-wired infra git checkout** — deploys are rsync-push + GHCR image-pull, not `git pull`. The one **inert** manual clone on Sydney (last fetched 2026-06-30, wired into no cron/systemd) had its remote repointed + fetch-verified.
- **No `ghcr.io/imagineering-cc` image paths exist** → the rename creates no stale-image breakage.
- `self-healer` `repoForContainer` maps no container to this repo → green-auto's PR path unaffected.

Secret-scanned pre-commit. Cross-project doc refs (other repos) are redirect-covered and handled opportunistically, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)