### PR TITLE
feat(oci): auto-detect per-tenancy A1 allotment (Oracle cut free grant to 2/12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Everything runs on Oracle Cloud's Always Free tier — no billing, no trial expi
 
 | Shape | OCPUs | RAM | Instances | Notes |
 |-------|-------|-----|-----------|-------|
-| VM.Standard.A1.Flex (Arm) | 4 total | 24 GB total | Up to 4 | Ampere Altra 3 GHz. OCPU/RAM ratio is flexible — allocate independently |
+| VM.Standard.A1.Flex (Arm) | 4 total¹ | 24 GB total¹ | Up to 4 | Ampere Altra 3 GHz. OCPU/RAM ratio is flexible — allocate independently. ¹Grandfathered accounts (our Sydney tenancy) get 4/24; **newer tenancies are now capped at 2 OCPU / 12 GB** (Oracle shrank the A1 grant). `scripts/oci-retry-provision.sh` auto-detects the real per-tenancy limit and adapts. |
 | VM.Standard.E2.1.Micro (AMD x86) | 1/8 each (burstable) | 1 GB each | Up to 2 | **Separate CPU budget** — does not eat into A1 allocation. Can burst above baseline |
 
 Total baseline: **4.25 OCPUs + 26 GB RAM** across up to 6 instances.

--- a/docs/oci-provisioning-guide.md
+++ b/docs/oci-provisioning-guide.md
@@ -1,8 +1,19 @@
 # Free Cloud Servers with OCI Always Free Tier
 
-This guide walks you through setting up an automated script that keeps trying to grab a free ARM server from Oracle Cloud until it works. These are legitimately powerful machines (4 CPU cores, 24GB RAM) and they're **free forever** on Oracle's Always Free tier.
+This guide walks you through setting up an automated script that keeps trying to grab a free ARM server from Oracle Cloud until it works. These are legitimately powerful machines (up to 4 CPU cores, 24GB RAM) and they're **free forever** on Oracle's Always Free tier.
 
 The catch? Everyone wants one, so they're almost always "out of capacity." Hence the retry script — it tries every 5 minutes until one slips through.
+
+> **⚠️ Heads up — Oracle has been shrinking the free A1 grant.** Older tenancies
+> (e.g. our Sydney box) got the full **4 OCPU / 24 GB**. Some **newer** tenancies
+> are now capped at **2 OCPU / 12 GB**. You can't tell from the marketing page —
+> you have to ask the API. The retry script now **auto-detects the tenancy's real
+> A1 allotment** (`limits resource-availability get` on `standard-a1-core-count`)
+> and caps its resize target to whatever the account actually allows, logging a
+> warning when it's below 4. So you always get the biggest box the tenancy permits,
+> and the loop still self-completes instead of grinding forever trying to reach a 4
+> it can't have. Once at target it resizes online — so if Oracle later raises your
+> limit, bump `full_ocpus` and it grows with no rebuild.
 
 ## What You're Getting
 
@@ -10,7 +21,8 @@ The catch? Everyone wants one, so they're almost always "out of capacity." Hence
 ┌─────────────────────────────────────────┐
 │  Oracle Cloud Always Free ARM Instance  │
 │                                         │
-│  • 4 OCPU (ARM cores) / 24GB RAM       │
+│  • Up to 4 OCPU / 24GB RAM (2/12 on    │
+│    some newer tenancies — auto-detected)│
 │  • Up to 200GB disk                     │
 │  • Ubuntu 24.04                         │
 │  • Public IP address                    │
@@ -26,7 +38,7 @@ But the ARM instance is just the headliner. The Always Free tier comes with a lo
 
 | Shape | CPUs | RAM | Max Instances | Notes |
 |-------|------|-----|---------------|-------|
-| VM.Standard.A1.Flex (Arm) | 4 OCPUs | 24 GB | 4 | Ampere Altra 3 GHz. Split OCPUs and RAM however you want across instances |
+| VM.Standard.A1.Flex (Arm) | 4 OCPUs* | 24 GB* | 4 | Ampere Altra 3 GHz. Split OCPUs and RAM however you want across instances. *Newer tenancies may be capped at 2 OCPU / 12 GB — the retry script auto-detects and adapts |
 | VM.Standard.E2.1.Micro (AMD x86) | 1/8 OCPU each | 1 GB each | 2 | **Independent CPU budget** — doesn't touch the Arm allocation. Burstable above baseline |
 
 The Micro instances are the sleeper pick. They run on completely different x86 hardware, so you're getting extra compute on top of the 4 Arm cores. Each gets its own public IP and 50 Mbps internet bandwidth. Good for monitoring, cron runners, small proxies, or a Tailscale exit node.

--- a/scripts/oci-retry-provision.sh
+++ b/scripts/oci-retry-provision.sh
@@ -1,25 +1,52 @@
 #!/bin/bash
-# OCI auto-provisioning — keeps trying until it gets an instance
+# OCI auto-provisioning — keeps retrying until it grabs an ARM (Ampere A1)
+# instance, then resizes it up to the target size.
+#
+# Lineage: reconciled 2026-07-28 to match the deployed (no-cloud-init) variant
+# that actually provisioned Robin's and Amanda's Melbourne boxes. Instances get
+# the OCI-default 'ubuntu' user; SSH keys come from $AUTHORIZED_KEYS_FILE
+# (one key per line). The older cloud-init/--user-data-file lineage was dropped
+# because it had already diverged from what runs in production.
 #
 # Strategy:
-#   1. Try small (1 OCPU/6GB) first — easier to get capacity
-#   2. Once small instance exists, resize to full (4 OCPU/24GB)
-#   3. Once at full size, disable the cron job (we're done!)
-#   4. Random jitter to avoid looking like a bot
+#   1. Detect the tenancy's ACTUAL A1 allotment. Oracle has reduced the Always
+#      Free A1 grant for some newer tenancies from 4 OCPU/24GB to 2 OCPU/12GB,
+#      so we never assume 4/24 — the target is capped to what the tenancy
+#      genuinely allows, and a warning is logged when that's below the request.
+#   2. Try small (1 OCPU/6GB) first — far easier to place when A1 hosts are tight.
+#   3. Once a small instance exists, resize it to the (capped) full target.
+#   4. When every account is at its full target, disable the cron job.
+#   5. Random jitter to avoid a predictable request pattern.
 
 LOG=~/oci-provision.log
 LOCK=/tmp/oci-provision.lock
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ACCOUNTS_FILE="$SCRIPT_DIR/accounts.yaml"
-SSH_KEY_PATH="$HOME/.ssh/id_ed25519.pub"
+AUTHORIZED_KEYS_FILE="$SCRIPT_DIR/authorized_keys"
 
-# What we're aiming for
+# What we aim for (per-account override via accounts.yaml full_ocpus/full_mem)
 SMALL_OCPUS=1
 SMALL_MEM=6
-FULL_OCPUS=4
-FULL_MEM=24
+DEFAULT_FULL_OCPUS=4
+A1_MEM_PER_OCPU=6   # Always Free ratio: 6 GB RAM per OCPU (memory tracks cores)
 
 log() { echo "$(date): $*" >> "$LOG"; }
+
+# Floor-integer count of A1 OCPUs still available in this tenancy/AD (limit
+# minus current usage). Region comes from the profile. Empty on query failure,
+# in which case callers fall back to the requested size (reactive handling below
+# still catches a LimitExceeded).
+a1_available_ocpus() {
+    local profile="$1" compartment="$2" ad="$3"
+    oci limits resource-availability get \
+        --profile "$profile" \
+        --service-name compute --limit-name standard-a1-core-count \
+        --compartment-id "$compartment" --availability-domain "$ad" 2>/dev/null \
+        | jq -r '.data.available // empty' | cut -d. -f1
+}
+
+# Smaller of two integers
+min() { if [ "$1" -le "$2" ]; then echo "$1"; else echo "$2"; fi; }
 
 # ── Prevent two copies running at once ──
 if [ -f "$LOCK" ]; then
@@ -32,35 +59,24 @@ fi
 echo $$ > "$LOCK"
 trap 'rm -f "$LOCK"' EXIT
 
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 
-# ── Random jitter: 0-90 seconds ──
-# This avoids a predictable request pattern (Oracle might rate-limit you)
+# ── Random jitter: 0-90 seconds (avoids a predictable request pattern) ──
 JITTER=$((RANDOM % 90))
 log "Sleeping ${JITTER}s jitter..."
 sleep "$JITTER"
 
-# ── Cloud-init: runs on the instance after first boot ──
-CLOUD_INIT=$(cat << 'CLOUDINIT'
-#!/bin/bash
-apt-get update && apt-get install -y htop curl docker.io docker-compose
-
-# Keep-alive task — prevents Oracle from reclaiming idle free instances
-cat > /opt/keep-alive.sh << 'KEEPALIVE'
-#!/bin/bash
-timeout 30 dd if=/dev/urandom bs=1M count=50 | md5sum > /dev/null 2>&1
-echo "$(date): keep-alive ping" >> /var/log/keep-alive.log
-KEEPALIVE
-chmod +x /opt/keep-alive.sh
-echo "0 */6 * * * root /opt/keep-alive.sh" > /etc/cron.d/keep-alive
-
-echo "Cloud-init complete" >> /var/log/cloud-init-output.log
-CLOUDINIT
-)
-
 # ── Check dependencies ──
 if ! command -v yq &> /dev/null; then
     log "ERROR: yq not installed. Run: pip3 install yq"
+    exit 1
+fi
+if ! command -v oci &> /dev/null; then
+    log "ERROR: oci CLI not on PATH (expected in ~/bin or ~/.local/bin)."
+    exit 1
+fi
+if [ ! -f "$AUTHORIZED_KEYS_FILE" ]; then
+    log "ERROR: authorized_keys file missing at $AUTHORIZED_KEYS_FILE"
     exit 1
 fi
 
@@ -75,15 +91,18 @@ for i in $(seq 0 $((NUM_ACCOUNTS - 1))); do
     IMAGE_ID=$(yq -r ".accounts[$i].image_id" "$ACCOUNTS_FILE")
     AVAILABILITY_DOMAIN=$(yq -r ".accounts[$i].availability_domain" "$ACCOUNTS_FILE")
     INSTANCE_NAME=$(yq -r ".accounts[$i].instance_name" "$ACCOUNTS_FILE")
+    FULL_OCPUS=$(yq -r ".accounts[$i].full_ocpus // $DEFAULT_FULL_OCPUS" "$ACCOUNTS_FILE")
 
     if [[ "$COMPARTMENT_ID" == *"REPLACE"* ]] || [[ "$COMPARTMENT_ID" == *"paste"* ]]; then
         log "[$NAME] Skipping - not configured yet"
         continue
     fi
 
+    # ── Detect the tenancy's real A1 allotment (available OCPUs right now) ──
+    AVAIL=$(a1_available_ocpus "$PROFILE" "$COMPARTMENT_ID" "$AVAILABILITY_DOMAIN")
+
     log "[$NAME] Checking for existing instance..."
 
-    # ── Check if we already have an instance ──
     INSTANCE_JSON=$(oci compute instance list \
         --profile "$PROFILE" \
         --compartment-id "$COMPARTMENT_ID" \
@@ -93,36 +112,49 @@ for i in $(seq 0 $((NUM_ACCOUNTS - 1))); do
         '[.data[] | select(.["lifecycle-state"] == "RUNNING" or .["lifecycle-state"] == "PROVISIONING")] | .[0].id // empty')
 
     if [ -n "$RUNNING_ID" ]; then
-        # ── Instance exists — check if it needs resizing ──
+        # ── Instance exists — decide whether it still needs resizing ──
         CURRENT_OCPUS=$(echo "$INSTANCE_JSON" | jq -r \
-            "[.data[] | select(.id == \"$RUNNING_ID\")] | .[0][\"shape-config\"].ocpus // 0")
+            "[.data[] | select(.id == \"$RUNNING_ID\")] | .[0][\"shape-config\"].ocpus // 0" | cut -d. -f1)
 
-        if [ "$(echo "$CURRENT_OCPUS >= $FULL_OCPUS" | bc -l)" = "1" ]; then
+        # Cap the target to what the tenancy allows: total = available + what
+        # this instance already uses. Fall back to the request if the quota
+        # query failed.
+        if [ -n "$AVAIL" ]; then
+            TOTAL_ALLOWED=$((AVAIL + CURRENT_OCPUS))
+            EFF_OCPUS=$(min "$FULL_OCPUS" "$TOTAL_ALLOWED")
+        else
+            EFF_OCPUS=$FULL_OCPUS
+        fi
+        EFF_MEM=$((EFF_OCPUS * A1_MEM_PER_OCPU))
+        if [ "$EFF_OCPUS" -lt "$FULL_OCPUS" ]; then
+            log "[$NAME] ⚠️ A1 allotment reduced: tenancy allows ${TOTAL_ALLOWED} OCPU (requested ${FULL_OCPUS}). Capping target to ${EFF_OCPUS}/${EFF_MEM}GB."
+        fi
+
+        if [ "$CURRENT_OCPUS" -ge "$EFF_OCPUS" ]; then
             IP=$(oci compute instance list-vnics \
                 --profile "$PROFILE" \
                 --instance-id "$RUNNING_ID" 2>/dev/null | jq -r '.data[0]["public-ip"] // "pending"')
-            log "[$NAME] ✅ Full instance running ($FULL_OCPUS OCPUs) at $IP — nothing to do!"
+            log "[$NAME] ✅ Instance running at target (${CURRENT_OCPUS} OCPU) at $IP — nothing to do!"
             continue
         fi
 
-        # Small instance exists — try to resize it
         LIFECYCLE=$(echo "$INSTANCE_JSON" | jq -r \
             "[.data[] | select(.id == \"$RUNNING_ID\")] | .[0][\"lifecycle-state\"]")
 
         if [ "$LIFECYCLE" = "RUNNING" ]; then
-            log "[$NAME] Small instance found ($CURRENT_OCPUS OCPUs). Resizing to $FULL_OCPUS/$FULL_MEM..."
+            log "[$NAME] Instance at ${CURRENT_OCPUS} OCPU. Resizing to ${EFF_OCPUS}/${EFF_MEM}GB..."
 
             RESIZE_OUTPUT=$(oci compute instance update \
                 --profile "$PROFILE" \
                 --instance-id "$RUNNING_ID" \
-                --shape-config "{\"ocpus\": $FULL_OCPUS, \"memoryInGBs\": $FULL_MEM}" \
+                --shape-config "{\"ocpus\": $EFF_OCPUS, \"memoryInGBs\": $EFF_MEM}" \
                 --force 2>&1)
 
             if echo "$RESIZE_OUTPUT" | grep -qi "error\|ServiceError"; then
                 log "[$NAME] Resize failed (probably still out of capacity). Will retry next cycle."
                 all_done=false
             else
-                log "[$NAME] 🎉 Resize initiated! Instance will reboot with $FULL_OCPUS OCPUs."
+                log "[$NAME] 🎉 Resize initiated! Instance will reboot with ${EFF_OCPUS} OCPU."
             fi
         else
             log "[$NAME] Instance in $LIFECYCLE state, waiting..."
@@ -131,12 +163,17 @@ for i in $(seq 0 $((NUM_ACCOUNTS - 1))); do
         continue
     fi
 
-    # ── No instance exists — try to create a small one ──
+    # ── No instance yet ──
     all_done=false
-    log "[$NAME] No instance found. Trying ${SMALL_OCPUS} OCPU / ${SMALL_MEM}GB..."
 
-    CLOUD_INIT_FILE=$(mktemp)
-    echo "$CLOUD_INIT" > "$CLOUD_INIT_FILE"
+    # If the tenancy can't even fit the small size, a retry loop is pointless —
+    # this is a quota problem, not a capacity one. Flag it and move on.
+    if [ -n "$AVAIL" ] && [ "$AVAIL" -lt "$SMALL_OCPUS" ]; then
+        log "[$NAME] A1 quota exhausted (available=${AVAIL} OCPU, need ${SMALL_OCPUS}). Request a limit increase in the OCI console (Limits, Quotas and Usage). Skipping."
+        continue
+    fi
+
+    log "[$NAME] No instance found. Trying ${SMALL_OCPUS} OCPU / ${SMALL_MEM}GB..."
 
     OUTPUT=$(SUPPRESS_LABEL_WARNING=True oci compute instance launch \
         --profile "$PROFILE" \
@@ -148,17 +185,16 @@ for i in $(seq 0 $((NUM_ACCOUNTS - 1))); do
         --image-id "$IMAGE_ID" \
         --display-name "$INSTANCE_NAME" \
         --assign-public-ip true \
-        --ssh-authorized-keys-file "$SSH_KEY_PATH" \
-        --user-data-file "$CLOUD_INIT_FILE" \
+        --ssh-authorized-keys-file "$AUTHORIZED_KEYS_FILE" \
         --boot-volume-size-in-gbs 50 2>&1)
-
-    rm -f "$CLOUD_INIT_FILE"
 
     if echo "$OUTPUT" | grep -qi "Out of capacity\|out of host capacity"; then
         log "[$NAME] Out of capacity — will retry in 5 minutes..."
     elif echo "$OUTPUT" | grep -qi "TooManyRequests"; then
         log "[$NAME] Rate limited (429) — backing off 60s..."
         sleep 60
+    elif echo "$OUTPUT" | grep -qi "LimitExceeded"; then
+        log "[$NAME] Service limit exceeded even at ${SMALL_OCPUS} OCPU — A1 quota is likely 0. Request a limit increase. Skipping."
     elif echo "$OUTPUT" | grep -qi "error\|failed\|ServiceError"; then
         ERROR_MSG=$(echo "$OUTPUT" | jq -r '.message // empty' 2>/dev/null || echo "$OUTPUT" | head -2)
         log "[$NAME] Error: $ERROR_MSG"
@@ -168,9 +204,9 @@ for i in $(seq 0 $((NUM_ACCOUNTS - 1))); do
     fi
 done
 
-# ── If everything is at full size, we're done — disable the cron ──
+# ── If everything is at its (capped) full target, we're done — disable cron ──
 if $all_done; then
-    log "All instances at full capacity! Disabling cron job. 🎊"
+    log "All instances at target size! Disabling cron job. 🎊"
     crontab -l | grep -v "retry-provision" | crontab -
 fi
 


### PR DESCRIPTION
## Why
While provisioning **Amanda's OCI Melbourne box** today, launches failed with `LimitExceeded` on `standard-a1-core-count`: her fresh tenancy's Always Free A1 grant is **2 OCPU / 12 GB**, not the 4/24 our older (Sydney) tenancy enjoys. Oracle has quietly halved the free ARM allotment for newer accounts, and you can't see it from the marketing page — only from the API.

## What
- **Adaptive limit detection** — before launching/resizing, the provisioner queries `limits resource-availability get` for `standard-a1-core-count` and **caps the resize target to what the tenancy actually allows**. Logs a `⚠️ A1 allotment reduced` warning when below 4, and self-completes at the real ceiling instead of looping forever chasing an unreachable 4/24. Memory tracks cores at the fixed 6:1 free-tier ratio.
- **Per-account `full_ocpus`** override in `accounts.yaml` (defaults to 4).
- **Drift reconciliation** — the repo copy of `oci-retry-provision.sh` had diverged to an older cloud-init / single-`id_ed25519.pub` lineage. The script that actually provisioned Robin's *and* Amanda's boxes is the no-cloud-init, `authorized_keys`-file variant. This makes the repo authoritative again (drops the stale cloud-init block; `ubuntu` default user + multi-key `authorized_keys`).
- **Docs** — provisioning guide + CLAUDE.md inventory note the reduced grant and the auto-detect behaviour. The Sydney box's genuine grandfathered 4/24 facts are left untouched (that instance really is 4/24).

## Verification
- `shellcheck scripts/oci-retry-provision.sh` — clean.
- Logic exercised live against Amanda's tenancy: quota query returns `available: 2`, launch correctly falls to 1/6 small-first and is now on the 5-min retry loop awaiting Melbourne A1 capacity (currently "out of host capacity").

## Gate
Branch protection on `main` requires 1 approving review — **awaiting review** before merge.
Server deploy of the reconciled script is a separate step (the running loop already has the equivalent hotfix, targeting 2/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)