### PR TITLE
fix(restore): validate-before-destroy on all non-matrix restore paths (#29 phase 1)

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -50,6 +50,27 @@ cleanup_backups() {
   rm -rf "$BACKUP_CLONE_DIR"
 }
 
+# Validate a plain-text pg_dump BEFORE any destructive restore step: non-empty,
+# complete (end-anchored '-- PostgreSQL database dump complete'), and not a
+# schemaless/empty DB (has CREATE TABLE). Returns non-zero so the caller can abort
+# with the LIVE database still intact. The old restore_kanbn/outline dropped the
+# live DB FIRST, then blind-loaded — a corrupt/truncated repo dump wiped live data.
+# (The full atomic restore-into-temp-DB-then-rename is Phase 2 of #29 — needs a
+# postgres test container; this guard already stops a bad dump reaching dropdb.)
+_validate_pg_dump() {
+  local svc="$1" f="$2"
+  if [ ! -s "$f" ]; then
+    error "$svc: dump $(basename "$f") is empty — refusing (live DB untouched)"; return 1
+  fi
+  if ! tail -n5 "$f" | grep -qxF -- '-- PostgreSQL database dump complete'; then
+    error "$svc: dump incomplete (no completion marker — truncated) — refusing (live DB untouched)"; return 1
+  fi
+  if ! grep -q 'CREATE TABLE' "$f"; then
+    error "$svc: dump has no CREATE TABLE (empty/wrong DB) — refusing (live DB untouched)"; return 1
+  fi
+  return 0
+}
+
 restore_kanbn() {
   log "Restoring Kan.bn..."
 
@@ -62,6 +83,9 @@ restore_kanbn() {
     cleanup_backups
     exit 1
   fi
+  # Validate BEFORE the destructive drop — a corrupt/truncated dump must never
+  # reach dropdb (the old code dropped first, then blind-loaded).
+  _validate_pg_dump kanbn "$BACKUP_FILE" || { cleanup_backups; exit 1; }
 
   # Ensure Kan.bn postgres is running
   cd ~/apps/kanbn
@@ -73,9 +97,15 @@ restore_kanbn() {
   log "Dropping existing database..."
   docker exec -i kanbn_postgres bash -c "psql -U kanbn -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'kanbn' AND pid <> pg_backend_pid();\" postgres && dropdb -U kanbn kanbn && createdb -U kanbn kanbn"
 
-  # Restore database
+  # Atomic load: --single-transaction + ON_ERROR_STOP so a replay error rolls the
+  # WHOLE load back instead of leaving a half-populated DB. (The DB was just
+  # dropped+recreated, so on failure it ends EMPTY — surfaced loudly below, not
+  # silently logged as success.)
   log "Restoring database..."
-  docker exec -i kanbn_postgres psql -U kanbn kanbn < "$BACKUP_FILE"
+  if ! docker exec -i kanbn_postgres psql -v ON_ERROR_STOP=1 --single-transaction -U kanbn kanbn < "$BACKUP_FILE"; then
+    error "Kan.bn psql restore FAILED and rolled back — DB is now EMPTY (dump passed syntactic validation but errored on replay). Investigate the dump before retrying; do NOT expect data after an app restart."
+    cleanup_backups; exit 1
+  fi
 
   log "Restarting Kan.bn..."
   docker compose restart
@@ -95,6 +125,8 @@ restore_outline() {
     cleanup_backups
     exit 1
   fi
+  # Validate BEFORE the destructive drop (see restore_kanbn).
+  _validate_pg_dump outline "$BACKUP_FILE" || { cleanup_backups; exit 1; }
 
   # Ensure Outline postgres is running
   cd ~/apps/outline
@@ -106,9 +138,12 @@ restore_outline() {
   log "Dropping existing database..."
   docker exec -i outline_postgres bash -c "psql -U outline -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'outline' AND pid <> pg_backend_pid();\" postgres && dropdb -U outline outline && createdb -U outline outline"
 
-  # Restore database
+  # Atomic load (see restore_kanbn): rolls back on any replay error.
   log "Restoring database..."
-  docker exec -i outline_postgres psql -U outline outline < "$BACKUP_FILE"
+  if ! docker exec -i outline_postgres psql -v ON_ERROR_STOP=1 --single-transaction -U outline outline < "$BACKUP_FILE"; then
+    error "Outline psql restore FAILED and rolled back — DB is now EMPTY (dump passed syntactic validation but errored on replay). Investigate the dump before retrying; do NOT expect data after an app restart."
+    cleanup_backups; exit 1
+  fi
 
   log "Restarting Outline..."
   docker compose restart
@@ -131,10 +166,21 @@ restore_pm_bot() {
 
   # Copy SQLite database into container volume
   log "Restoring database..."
+  # Validate before overwriting the live DB: non-empty AND a real SQLite file
+  # (magic header "SQLite format 3"). A truncated/empty/wrong backup must not
+  # clobber the live bot.db.
+  if [ ! -s "$BACKUP_FILE" ]; then
+    error "Dreamfinder restore: $BACKUP_FILE is empty — refusing (live DB untouched)"
+    cleanup_backups; exit 1
+  fi
+  if ! head -c 16 "$BACKUP_FILE" | grep -aq 'SQLite format 3'; then
+    error "Dreamfinder restore: $BACKUP_FILE is not a SQLite database (bad magic) — refusing (live DB untouched)"
+    cleanup_backups; exit 1
+  fi
+
   # Target /app/data/bot.db — the path the app actually reads and that backup_pm_bot
   # copies FROM. The old kan-bot.db target was a stale pre-rename path, so restore
-  # silently wrote a file the app ignores (a no-op restore). (#29 tracks adding a
-  # pre-overwrite validity/size check on the .db.)
+  # silently wrote a file the app ignores (a no-op restore).
   docker cp "$BACKUP_FILE" dreamfinder:/app/data/bot.db
 
   log "Restarting Dreamfinder..."
@@ -157,12 +203,20 @@ restore_radicale() {
     exit 1
   fi
 
+  # Validate the archive BEFORE the destructive rm — a truncated/corrupt tar must
+  # not reach `rm -rf /data/collections` (which would leave collections gone with
+  # nothing to extract). `tar tf` reads the whole archive, so truncation fails here.
+  if ! tar tf "$BACKUP_FILE" >/dev/null 2>&1; then
+    error "Radicale restore: $BACKUP_FILE is not a valid/complete tar — refusing (collections untouched)"
+    cleanup_backups; exit 1
+  fi
+
   # Stop Radicale
   log "Stopping Radicale..."
   cd ~/apps/radicale
   docker compose stop radicale
 
-  # Restore collections into the volume
+  # Restore collections into the volume. Validated above, so the rm is safe.
   log "Restoring collections..."
   docker compose run --rm --entrypoint sh -v "$BACKUP_FILE:/restore.tar:ro" radicale \
     -c "rm -rf /data/collections && tar xf /restore.tar -C /"
@@ -185,6 +239,13 @@ restore_claudius() {
     error "No claudius.tar found in backup repo"
     cleanup_backups
     exit 1
+  fi
+
+  # Validate the archive before extracting over live state (extract is additive,
+  # lower-risk than a rm, but a corrupt tar should still be refused loudly).
+  if ! tar tf "$BACKUP_FILE" >/dev/null 2>&1; then
+    error "Claudius restore: $BACKUP_FILE is not a valid/complete tar — refusing"
+    cleanup_backups; exit 1
   fi
 
   # Restore state files into container

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -258,7 +258,10 @@ restore_radicale() {
   #   2. Content sentinel: at least one member under data/collections (backup.sh
   #      tars `docker exec radicale tar czf - /data/collections`, so a real archive
   #      lists data/collections[/...]). An empty or wrong-tree tar fails here.
-  if ! printf '%s\n' "$radicale_members" | grep -q '^data/collections'; then
+  # Exact directory boundary (`(/|$)`) — a bare prefix would also match a wrong
+  # tree like data/collections-old / data/collections.bak, pass, then let the
+  # rm wipe the real collections (cage-match #138 round 2, Carnot).
+  if ! printf '%s\n' "$radicale_members" | grep -qE '^data/collections(/|$)'; then
     error "Radicale restore: $BACKUP_FILE has no data/collections members (empty/wrong-tree tar) — refusing (collections untouched)"
     cleanup_backups; exit 1
   fi
@@ -465,14 +468,10 @@ restore_matrix() {
     "matrix-relay-hf:matrix_relay_hf_data:relay.db"
   )
 
-  # Build the sqlite helper if absent — restore may run on a box where the
-  # backup path (which builds it) has never executed. Idempotent.
-  if ! docker image inspect sqlite-dumper:latest >/dev/null 2>&1; then
-    log "Building sqlite-dumper:latest (alpine + sqlite3)..."
-    printf 'FROM alpine:3.20\nRUN apk add --no-cache sqlite\n' \
-      | docker build -q -t sqlite-dumper:latest - >/dev/null \
-      || { error "failed to build sqlite-dumper:latest"; cleanup_backups; return 1; }
-  fi
+  # Build the sqlite helper if absent — restore may run on a box where the backup
+  # path (which builds it) has never executed. Shared _ensure_sqlite_dumper, same
+  # as island/pm_bot (cage-match #138 round 2, Kelvin: was an inline copy).
+  _ensure_sqlite_dumper || { cleanup_backups; return 1; }
 
   # Stop the matrix stack first so we don't write to live DBs.
   log "Stopping matrix stack..."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -71,6 +71,52 @@ _validate_pg_dump() {
   return 0
 }
 
+# Build the tiny alpine+sqlite helper image if absent (idempotent — mirrors
+# backup-aiko-island-standalone.sh) so a box where the backup path never ran can
+# still validate a SQLite candidate. Shared single door for _restore_island_core
+# and _validate_sqlite_db so both paths validate identically. Returns non-zero on
+# build failure so the caller can abort with live state intact.
+_ensure_sqlite_dumper() {
+  if ! docker image inspect sqlite-dumper:latest >/dev/null 2>&1; then
+    log "Building sqlite-dumper:latest (alpine + sqlite3)..."
+    printf 'FROM alpine:3.20\nRUN apk add --no-cache sqlite\n' \
+      | docker build -q -t sqlite-dumper:latest - >/dev/null \
+      || { error "failed to build sqlite-dumper:latest"; return 1; }
+  fi
+  return 0
+}
+
+# Validate a raw SQLite .db file BEFORE it overwrites live state. The 16-byte magic
+# header alone is NOT enough: a truncated/garbage file that keeps the header still
+# passes a magic check and then clobbers the live DB (cage-match #138: Carnot+Tesla).
+# So this runs the same PRAGMA integrity_check the island path uses (reads the whole
+# b-tree — truncation fails) PLUS a non-empty .tables check (rejects a schemaless/
+# wrong DB). Exact-byte header match first as a cheap pre-filter. Returns non-zero
+# so the caller aborts with the live DB untouched.
+_validate_sqlite_db() {
+  local svc="$1" f="$2"
+  if [ ! -s "$f" ]; then
+    error "$svc: $(basename "$f") is empty — refusing (live DB untouched)"; return 1
+  fi
+  # Exact 15-byte header ("SQLite format 3", the magic minus its trailing NUL) —
+  # an exact prefix match, not a substring grep that any 16 bytes containing the
+  # string would satisfy (cage-match #138: Carnot+Tesla).
+  if [ "$(head -c 15 "$f")" != "SQLite format 3" ]; then
+    error "$svc: $(basename "$f") is not a SQLite database (bad header) — refusing (live DB untouched)"; return 1
+  fi
+  _ensure_sqlite_dumper || { error "$svc: cannot validate SQLite candidate (no sqlite-dumper image) — refusing (live DB untouched)"; return 1; }
+  # integrity_check reads the entire file, so a truncated-but-header-valid DB fails
+  # here; the non-empty .tables check rejects a schemaless/wrong DB. Mount read-only.
+  if ! docker run --rm -v "$f:/candidate.db:ro" sqlite-dumper:latest sh -c '
+        integ=$(sqlite3 /candidate.db "PRAGMA integrity_check;" 2>&1) || { echo "sqlite3 failed: $integ" >&2; exit 1; }
+        [ "$integ" = "ok" ] || { echo "integrity_check failed: $integ" >&2; exit 1; }
+        [ -n "$(sqlite3 /candidate.db ".tables" 2>/dev/null)" ] || { echo "no tables (schemaless/wrong DB)" >&2; exit 1; }
+      '; then
+    error "$svc: $(basename "$f") failed SQLite integrity_check (truncated/corrupt/schemaless) — refusing (live DB untouched)"; return 1
+  fi
+  return 0
+}
+
 restore_kanbn() {
   log "Restoring Kan.bn..."
 
@@ -166,17 +212,11 @@ restore_pm_bot() {
 
   # Copy SQLite database into container volume
   log "Restoring database..."
-  # Validate before overwriting the live DB: non-empty AND a real SQLite file
-  # (magic header "SQLite format 3"). A truncated/empty/wrong backup must not
-  # clobber the live bot.db.
-  if [ ! -s "$BACKUP_FILE" ]; then
-    error "Dreamfinder restore: $BACKUP_FILE is empty — refusing (live DB untouched)"
-    cleanup_backups; exit 1
-  fi
-  if ! head -c 16 "$BACKUP_FILE" | grep -aq 'SQLite format 3'; then
-    error "Dreamfinder restore: $BACKUP_FILE is not a SQLite database (bad magic) — refusing (live DB untouched)"
-    cleanup_backups; exit 1
-  fi
+  # Validate before overwriting the live DB: non-empty, exact SQLite header, AND
+  # a full PRAGMA integrity_check + non-empty schema (see _validate_sqlite_db). A
+  # header-only check would let a truncated-but-header-valid backup clobber the live
+  # bot.db — the same content-sentinel the island/matrix paths already enforce.
+  _validate_sqlite_db "Dreamfinder restore" "$BACKUP_FILE" || { cleanup_backups; exit 1; }
 
   # Target /app/data/bot.db — the path the app actually reads and that backup_pm_bot
   # copies FROM. The old kan-bot.db target was a stale pre-rename path, so restore
@@ -205,9 +245,21 @@ restore_radicale() {
 
   # Validate the archive BEFORE the destructive rm — a truncated/corrupt tar must
   # not reach `rm -rf /data/collections` (which would leave collections gone with
-  # nothing to extract). `tar tf` reads the whole archive, so truncation fails here.
-  if ! tar tf "$BACKUP_FILE" >/dev/null 2>&1; then
+  # nothing to extract). Two gates, because `tar tf` checks the CARRIER not the
+  # PAYLOAD (cage-match #138, Tesla): a well-formed EMPTY tar, or a valid tar of the
+  # WRONG tree, lists fine and would still let the rm wipe collections with nothing
+  # useful to restore.
+  #   1. Readable/complete archive (truncation fails a full listing).
+  local radicale_members
+  if ! radicale_members=$(tar tf "$BACKUP_FILE" 2>/dev/null); then
     error "Radicale restore: $BACKUP_FILE is not a valid/complete tar — refusing (collections untouched)"
+    cleanup_backups; exit 1
+  fi
+  #   2. Content sentinel: at least one member under data/collections (backup.sh
+  #      tars `docker exec radicale tar czf - /data/collections`, so a real archive
+  #      lists data/collections[/...]). An empty or wrong-tree tar fails here.
+  if ! printf '%s\n' "$radicale_members" | grep -q '^data/collections'; then
+    error "Radicale restore: $BACKUP_FILE has no data/collections members (empty/wrong-tree tar) — refusing (collections untouched)"
     cleanup_backups; exit 1
   fi
 
@@ -216,7 +268,10 @@ restore_radicale() {
   cd ~/apps/radicale
   docker compose stop radicale
 
-  # Restore collections into the volume. Validated above, so the rm is safe.
+  # Restore collections into the volume. Content-validated above (readable tar with
+  # real collections members), so the rm won't wipe live data with nothing to
+  # restore. NOTE: the in-container extract itself is not yet atomic (a mid-extract
+  # failure after the rm leaves a partial tree) — stage-to-temp-then-swap is Phase 2.
   log "Restoring collections..."
   docker compose run --rm --entrypoint sh -v "$BACKUP_FILE:/restore.tar:ro" radicale \
     -c "rm -rf /data/collections && tar xf /restore.tar -C /"
@@ -241,10 +296,21 @@ restore_claudius() {
     exit 1
   fi
 
-  # Validate the archive before extracting over live state (extract is additive,
-  # lower-risk than a rm, but a corrupt tar should still be refused loudly).
-  if ! tar tf "$BACKUP_FILE" >/dev/null 2>&1; then
+  # Validate the archive before extracting over live state. Extract is additive
+  # (no rm), so the blast is lower than radicale — but an empty/wrong-tree tar
+  # would still "restore" nothing silently, exactly the no-op class this PR fights.
+  # So carrier + payload here too, symmetric with radicale (cage-match #138, Tesla):
+  #   1. Readable/complete archive.
+  local claudius_members
+  if ! claudius_members=$(tar tf "$BACKUP_FILE" 2>/dev/null); then
     error "Claudius restore: $BACKUP_FILE is not a valid/complete tar — refusing"
+    cleanup_backups; exit 1
+  fi
+  #   2. Content sentinel: at least one workspace/ member (backup.sh tars
+  #      /workspace/... paths). An empty/wrong-tree tar fails here rather than
+  #      extracting nothing and reporting success.
+  if ! printf '%s\n' "$claudius_members" | grep -q '^workspace/'; then
+    error "Claudius restore: $BACKUP_FILE has no workspace/ members (empty/wrong-tree tar) — refusing"
     cleanup_backups; exit 1
   fi
 
@@ -292,14 +358,9 @@ _restore_island_core() {
   fi
 
   # The island image ships no sqlite3; build the tiny alpine+sqlite helper if
-  # absent (idempotent — mirrors backup-aiko-island-standalone.sh) so restore
-  # works on a box where the backup path has never run.
-  if ! docker image inspect sqlite-dumper:latest >/dev/null 2>&1; then
-    log "Building sqlite-dumper:latest (alpine + sqlite3)..."
-    printf 'FROM alpine:3.20\nRUN apk add --no-cache sqlite\n' \
-      | docker build -q -t sqlite-dumper:latest - >/dev/null \
-      || { error "failed to build sqlite-dumper:latest"; return 1; }
-  fi
+  # absent (shared _ensure_sqlite_dumper, also used by _validate_sqlite_db) so
+  # restore works on a box where the backup path has never run.
+  _ensure_sqlite_dumper || return 1
 
   log "Stopping island container $cid..."
   docker stop "$cid" >/dev/null || { error "failed to stop container $cid"; return 1; }


### PR DESCRIPTION
## Why
Follow-up to #137. That PR hardened the **backup writers** + **matrix restore**; the cage-match flagged that the **non-matrix restore paths** still had the same rm/drop-before-validate class — a corrupt/truncated repo dump could wipe live data. Restore is manual DR (rare, human-present), so this is lower-urgency than the unattended backup class #137 closed, but it's a real foot-gun during the one moment it matters.

## Phase 1 (this PR) — strictly-safe guards, no destructive-semantics change
- **`restore_kanbn` / `restore_outline`**: a shared `_validate_pg_dump` (non-empty + end-anchored `-- PostgreSQL database dump complete` + `CREATE TABLE` sentinel) runs **before `dropdb`**, so a bad dump never reaches the drop. Load switched to `psql -v ON_ERROR_STOP=1 --single-transaction` → a replay error rolls back the whole load instead of leaving a half-populated DB.
- **`restore_radicale`**: `tar tf` validates the archive **before** `rm -rf /data/collections`.
- **`restore_claudius`**: `tar tf` validates before the (additive) extract.
- **`restore_pm_bot`**: non-empty + SQLite-magic (`SQLite format 3`) check before `docker cp` overwrites the live `bot.db`.

## Deferred to Phase 2 (#29 — wants a postgres test container)
- Full **atomic restore-into-temp-DB-then-rename** for postgres (so live is untouched even when a *validated* dump errors on replay — the analog of matrix's candidate-build). Phase 1 already stops a *corrupt* dump reaching the drop; the residual is a syntactically-valid dump that errors mid-replay, which now rolls back to an empty DB (surfaced loudly). The temp-DB swap closes that last window but needs real-postgres testing to author safely — I won't push blind destructive DDL.
- **continuwuity backup completeness** (BackupEngine `meta/`+`shared_checksum/` layout + min-size floor — signing keys, unattended, high stakes).
- **`backup_to_github`** decompress-exit checks.

## Verification
- `shellcheck -S warning` clean.
- Synthetic tests: SQLite-magic check accepts a real DB, rejects garbage/empty (**caught + fixed a `grep`-binary false-negative that would have refused valid restores**); `tar tf` rejects a truncated archive; the pg-dump validator predicates verified in #137.
- NOT run against live postgres/docker volumes (no container here) — the destructive paths want a real-container exercise, which is exactly why the atomic swap is deferred.

## Tier
State-lifecycle / destructive restore → **cage-match** before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)