### PR TITLE
feat(restore): atomic temp-DB swap for postgres restore (#29 Phase 2)

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -183,22 +183,28 @@ _restore_pg_atomic() {
   # leaning on `set -e` (cage-match #140 round 2: Carnot/Tesla/Wu all flagged bare
   # set -e commands with no recovery). _pgx runs a psql statement with ON_ERROR_STOP
   # and returns its status; _unfence best-effort re-enables connections on a DB.
+  # _pgx runs a CHECKED psql statement (ON_ERROR_STOP) — always used in `if !` so
+  # set -e never aborts on it. _unfence + _apprestart are BEST-EFFORT recovery: they
+  # end in `|| true` so a failure can never trip set -e and skip the recovery step
+  # that follows (cage-match #140 r3, Carnot+Tesla: "best-effort under set -e is a
+  # lie"). The critical path is the explicit `if !` checks, not set -e.
   _pgx() { docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "$1" >/dev/null 2>&1; }
-  _unfence() { docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$1\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1; }
+  _unfence() { docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$1\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1 || true; }
+  _apprestart() { docker compose up -d >/dev/null 2>&1 || true; }
 
   # 3. Stop the app so nothing holds a connection to the live DB (ALTER DATABASE
   #    RENAME needs zero connections), then bring ONLY postgres back for the swap.
   #    ASSERT readiness — a not-ready postgres must not proceed to fence/rename.
   log "$svc: stopping app for the atomic swap..."
-  docker compose stop >/dev/null 2>&1
+  docker compose stop >/dev/null 2>&1 || true
   if ! docker compose up -d postgres >/dev/null 2>&1; then
     error "$svc: postgres failed to restart for the swap — live $db UNTOUCHED, temp $temp left. Bringing app back up."
-    docker compose up -d >/dev/null 2>&1; return 1
+    _apprestart; return 1
   fi
   for _ in $(seq 1 30); do docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 && break; sleep 1; done
   if ! docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1; then
     error "$svc: postgres not ready after restart — live $db UNTOUCHED, temp $temp left. Bringing app back up."
-    docker compose up -d >/dev/null 2>&1; return 1
+    _apprestart; return 1
   fi
 
   # 4. Atomic swap. FENCE connections first (ALLOW_CONNECTIONS false) so an external
@@ -208,17 +214,17 @@ _restore_pg_atomic() {
   #    the live rename, live is still $db and UNTOUCHED — un-fence it and restart.
   if ! _pgx "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS false; ALTER DATABASE \"$temp\" WITH ALLOW_CONNECTIONS false;"; then
     error "$svc: could not fence connections — aborting, live $db UNTOUCHED, temp $temp left. Un-fencing + restarting app."
-    _unfence "$db"; docker compose up -d >/dev/null 2>&1; return 1
+    _unfence "$db"; _apprestart; return 1
   fi
   if ! _pgx "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('$db','$temp') AND pid <> pg_backend_pid();"; then
     error "$svc: could not terminate live connections — aborting, live $db UNTOUCHED, temp $temp left. Un-fencing + restarting app."
-    _unfence "$db"; docker compose up -d >/dev/null 2>&1; return 1
+    _unfence "$db"; _apprestart; return 1
   fi
   # Rename live->rescue, then temp->live. If the second rename fails, roll rescue
   # back so live is never lost.
   if ! _pgx "ALTER DATABASE \"$db\" RENAME TO \"$rescue\";"; then
     error "$svc: could not rename live $db -> rescue (connections still open?) — live UNTOUCHED, temp $temp left."
-    _unfence "$db"; docker compose up -d >/dev/null 2>&1; return 1
+    _unfence "$db"; _apprestart; return 1
   fi
   if ! _pgx "ALTER DATABASE \"$temp\" RENAME TO \"$db\";"; then
     error "$svc: rename temp -> live FAILED after live moved to rescue — rolling back rescue -> live."
@@ -226,26 +232,32 @@ _restore_pg_atomic() {
       _unfence "$db"
       error "$svc: rolled back — live $db is the original; temp $temp left for inspection."
     else
-      error "$svc: ROLLBACK ALSO FAILED — original live is under DB '$rescue', candidate under '$temp'. Manual recovery needed; app NOT restarted."
+      error "$svc: ROLLBACK ALSO FAILED — original live is under DB '$rescue' (run: ALTER DATABASE \"$rescue\" RENAME TO \"$db\"; ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;), candidate under '$temp'. Manual recovery needed; app NOT restarted."
       return 1
     fi
-    docker compose up -d >/dev/null 2>&1; return 1
+    _apprestart; return 1
   fi
 
   # 5. Un-fence the new live DB — CHECKED. It inherited ALLOW_CONNECTIONS false from
   #    the temp; if this fails, the app would come up against a DB that refuses
-  #    connections (a silent RC=0 false-success — Tesla). Error loudly instead.
+  #    connections (a silent RC=0 false-success — Tesla). Keep the app STOPPED and
+  #    error loudly (starting it against a fenced DB just crash-loops — Carnot r3).
   if ! _pgx "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;"; then
-    error "$svc: swap done but FAILED to re-enable connections on live $db — the app cannot connect. Run: ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true; then restart. Previous live kept as '$rescue'."
-    docker compose up -d >/dev/null 2>&1; return 1
+    error "$svc: swap succeeded but FAILED to re-enable connections on live $db — app kept STOPPED to avoid crash-looping. Run: ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true; then 'docker compose up -d'. Previous live kept as '$rescue'."
+    return 1
   fi
   # Re-enable the rescue DB too so operators can inspect it without a manual ALTER
-  # (it inherited the fence when it was still the live $db — Carnot :207).
+  # (it inherited the fence when it was still the live $db — Carnot :207). Best-effort.
   _unfence "$rescue"
 
-  # Success — previous live kept as $rescue (drop it manually once satisfied).
-  log "$svc: atomic swap complete. Previous live DB kept as '$rescue' (drop when satisfied). Bringing app up..."
-  docker compose up -d >/dev/null 2>&1
+  # Success — previous live kept as $rescue (drop it manually once satisfied). Check
+  # the app restart: the data swap already succeeded, so a restart failure is a warn
+  # (not a data-loss error), but don't print "complete" as if the service is up.
+  if docker compose up -d >/dev/null 2>&1; then
+    log "$svc: atomic swap complete. Previous live DB kept as '$rescue' (drop when satisfied). App restarted."
+    return 0
+  fi
+  warn "$svc: atomic swap complete and data is live, but 'docker compose up -d' failed to restart the app — run it manually. Previous live kept as '$rescue'."
   return 0
 }
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -68,13 +68,15 @@ _validate_pg_dump() {
   if ! grep -q 'CREATE TABLE' "$f"; then
     error "$svc: dump has no CREATE TABLE (empty/wrong DB) — refusing (live DB untouched)"; return 1
   fi
-  # Refuse dumps that can switch databases mid-replay: a `\connect`/`\c` meta-command
-  # or a `CREATE DATABASE` (as emitted by pg_dump --create / pg_dumpall) would make
-  # psql reconnect to the LIVE db and replay there, BEFORE the atomic swap — breaking
-  # the "temp DB only, live untouched" invariant (cage-match #140, Carnot). Our backups
-  # are plain `pg_dump <db>` (no --create), so a real backup never trips this.
-  if grep -qE '^[[:space:]]*(\\c|\\connect|CREATE DATABASE)\b' "$f"; then
-    error "$svc: dump contains \\connect / CREATE DATABASE (could reconnect to the live DB mid-replay) — refusing. Expected a plain 'pg_dump <db>' dump."; return 1
+  # Refuse dumps that can escape the temp DB mid-replay: a `\connect`/`\c` reconnects
+  # to another DB (incl. the LIVE one), and cluster-level `CREATE DATABASE` /
+  # `DROP DATABASE` act on OTHER databases regardless of the current connection — any
+  # of these replays against live BEFORE the atomic swap, breaking the "temp DB only,
+  # live untouched" invariant (cage-match #140, Carnot r1 + Wu r2). Case-insensitive
+  # so lowercase SQL keywords don't slip past. Our backups are plain `pg_dump <db>`,
+  # so a real backup never trips this.
+  if grep -qiE '^[[:space:]]*(\\c|\\connect|create database|drop database)\b' "$f"; then
+    error "$svc: dump contains \\connect / CREATE DATABASE / DROP DATABASE (could act on the LIVE db mid-replay) — refusing. Expected a plain 'pg_dump <db>' dump."; return 1
   fi
   return 0
 }
@@ -165,7 +167,9 @@ _restore_pg_atomic() {
 
   # 2. Integrity gate: the candidate must have loaded at least one public table.
   local ntables
-  ntables=$(docker exec "$container" psql -U "$user" -d "$temp" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';" 2>/dev/null)
+  # `|| true` so a hard docker/psql failure doesn't trip set -e on the assignment
+  # (leaving temp undropped) — the numeric guard below treats empty as a failed gate.
+  ntables=$(docker exec "$container" psql -U "$user" -d "$temp" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';" 2>/dev/null || true)
   # Validate ntables is actually a number before the -ge (a failed docker exec /
   # psql can emit a non-numeric error line, which would make `[ -ge ]` itself
   # error — treat any non-digit result as a failed gate, live untouched).
@@ -175,45 +179,71 @@ _restore_pg_atomic() {
     return 1
   fi
 
+  # Small helpers for the swap phase — every step is explicitly checked rather than
+  # leaning on `set -e` (cage-match #140 round 2: Carnot/Tesla/Wu all flagged bare
+  # set -e commands with no recovery). _pgx runs a psql statement with ON_ERROR_STOP
+  # and returns its status; _unfence best-effort re-enables connections on a DB.
+  _pgx() { docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "$1" >/dev/null 2>&1; }
+  _unfence() { docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$1\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1; }
+
   # 3. Stop the app so nothing holds a connection to the live DB (ALTER DATABASE
   #    RENAME needs zero connections), then bring ONLY postgres back for the swap.
+  #    ASSERT readiness — a not-ready postgres must not proceed to fence/rename.
   log "$svc: stopping app for the atomic swap..."
   docker compose stop >/dev/null 2>&1
-  docker compose up -d postgres >/dev/null 2>&1
-  for _ in $(seq 1 30); do docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 && break; sleep 1; done
-
-  # 4. Atomic swap: rename live->rescue then temp->live. FENCE connections first —
-  #    ALLOW_CONNECTIONS false blocks new connects, so an external client/supervisor
-  #    outside this compose project can't reconnect between the terminate and the
-  #    rename (cage-match #140, Carnot). Terminate stragglers, then rename. If the
-  #    second rename fails, roll rescue back so live is never lost.
-  docker exec "$container" psql -U "$user" -d postgres -c \
-    "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS false; ALTER DATABASE \"$temp\" WITH ALLOW_CONNECTIONS false;" >/dev/null 2>&1
-  docker exec "$container" psql -U "$user" -d postgres -c \
-    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('$db','$temp') AND pid <> pg_backend_pid();" >/dev/null 2>&1
-  if ! docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$db\" RENAME TO \"$rescue\";" >/dev/null 2>&1; then
-    error "$svc: could not rename live $db -> rescue (connections still open?) — live UNTOUCHED, temp $temp left for inspection."
-    # Un-fence live so the app can reconnect when it comes back up.
-    docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1
-    docker compose up -d >/dev/null 2>&1
-    return 1
+  if ! docker compose up -d postgres >/dev/null 2>&1; then
+    error "$svc: postgres failed to restart for the swap — live $db UNTOUCHED, temp $temp left. Bringing app back up."
+    docker compose up -d >/dev/null 2>&1; return 1
   fi
-  if ! docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$temp\" RENAME TO \"$db\";" >/dev/null 2>&1; then
+  for _ in $(seq 1 30); do docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 && break; sleep 1; done
+  if ! docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1; then
+    error "$svc: postgres not ready after restart — live $db UNTOUCHED, temp $temp left. Bringing app back up."
+    docker compose up -d >/dev/null 2>&1; return 1
+  fi
+
+  # 4. Atomic swap. FENCE connections first (ALLOW_CONNECTIONS false) so an external
+  #    client outside this compose project can't reconnect between terminate and
+  #    rename — and the fence + terminate are CHECKED (a silent fence failure would
+  #    reopen that race: cage-match #140 r2, Carnot+Tesla+Wu). On any failure before
+  #    the live rename, live is still $db and UNTOUCHED — un-fence it and restart.
+  if ! _pgx "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS false; ALTER DATABASE \"$temp\" WITH ALLOW_CONNECTIONS false;"; then
+    error "$svc: could not fence connections — aborting, live $db UNTOUCHED, temp $temp left. Un-fencing + restarting app."
+    _unfence "$db"; docker compose up -d >/dev/null 2>&1; return 1
+  fi
+  if ! _pgx "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('$db','$temp') AND pid <> pg_backend_pid();"; then
+    error "$svc: could not terminate live connections — aborting, live $db UNTOUCHED, temp $temp left. Un-fencing + restarting app."
+    _unfence "$db"; docker compose up -d >/dev/null 2>&1; return 1
+  fi
+  # Rename live->rescue, then temp->live. If the second rename fails, roll rescue
+  # back so live is never lost.
+  if ! _pgx "ALTER DATABASE \"$db\" RENAME TO \"$rescue\";"; then
+    error "$svc: could not rename live $db -> rescue (connections still open?) — live UNTOUCHED, temp $temp left."
+    _unfence "$db"; docker compose up -d >/dev/null 2>&1; return 1
+  fi
+  if ! _pgx "ALTER DATABASE \"$temp\" RENAME TO \"$db\";"; then
     error "$svc: rename temp -> live FAILED after live moved to rescue — rolling back rescue -> live."
-    if docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$rescue\" RENAME TO \"$db\";" >/dev/null 2>&1; then
-      docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1
+    if _pgx "ALTER DATABASE \"$rescue\" RENAME TO \"$db\";"; then
+      _unfence "$db"
       error "$svc: rolled back — live $db is the original; temp $temp left for inspection."
     else
       error "$svc: ROLLBACK ALSO FAILED — original live is under DB '$rescue', candidate under '$temp'. Manual recovery needed; app NOT restarted."
       return 1
     fi
-    docker compose up -d >/dev/null 2>&1
-    return 1
+    docker compose up -d >/dev/null 2>&1; return 1
   fi
-  # Un-fence the new live DB (it inherited ALLOW_CONNECTIONS false from the temp).
-  docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1
 
-  # 5. Success — previous live kept as $rescue (drop it manually once satisfied).
+  # 5. Un-fence the new live DB — CHECKED. It inherited ALLOW_CONNECTIONS false from
+  #    the temp; if this fails, the app would come up against a DB that refuses
+  #    connections (a silent RC=0 false-success — Tesla). Error loudly instead.
+  if ! _pgx "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;"; then
+    error "$svc: swap done but FAILED to re-enable connections on live $db — the app cannot connect. Run: ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true; then restart. Previous live kept as '$rescue'."
+    docker compose up -d >/dev/null 2>&1; return 1
+  fi
+  # Re-enable the rescue DB too so operators can inspect it without a manual ALTER
+  # (it inherited the fence when it was still the live $db — Carnot :207).
+  _unfence "$rescue"
+
+  # Success — previous live kept as $rescue (drop it manually once satisfied).
   log "$svc: atomic swap complete. Previous live DB kept as '$rescue' (drop when satisfied). Bringing app up..."
   docker compose up -d >/dev/null 2>&1
   return 0

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -68,6 +68,14 @@ _validate_pg_dump() {
   if ! grep -q 'CREATE TABLE' "$f"; then
     error "$svc: dump has no CREATE TABLE (empty/wrong DB) — refusing (live DB untouched)"; return 1
   fi
+  # Refuse dumps that can switch databases mid-replay: a `\connect`/`\c` meta-command
+  # or a `CREATE DATABASE` (as emitted by pg_dump --create / pg_dumpall) would make
+  # psql reconnect to the LIVE db and replay there, BEFORE the atomic swap — breaking
+  # the "temp DB only, live untouched" invariant (cage-match #140, Carnot). Our backups
+  # are plain `pg_dump <db>` (no --create), so a real backup never trips this.
+  if grep -qE '^[[:space:]]*(\\c|\\connect|CREATE DATABASE)\b' "$f"; then
+    error "$svc: dump contains \\connect / CREATE DATABASE (could reconnect to the live DB mid-replay) — refusing. Expected a plain 'pg_dump <db>' dump."; return 1
+  fi
   return 0
 }
 
@@ -158,8 +166,11 @@ _restore_pg_atomic() {
   # 2. Integrity gate: the candidate must have loaded at least one public table.
   local ntables
   ntables=$(docker exec "$container" psql -U "$user" -d "$temp" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';" 2>/dev/null)
-  if ! [ "$ntables" -ge 1 ] 2>/dev/null; then
-    error "$svc: temp DB has no public tables (empty/wrong dump) — live $db UNTOUCHED. Dropping temp."
+  # Validate ntables is actually a number before the -ge (a failed docker exec /
+  # psql can emit a non-numeric error line, which would make `[ -ge ]` itself
+  # error — treat any non-digit result as a failed gate, live untouched).
+  if ! [[ "$ntables" =~ ^[0-9]+$ ]] || [ "$ntables" -lt 1 ]; then
+    error "$svc: temp DB integrity gate failed (no public tables, or count query errored: '$ntables') — live $db UNTOUCHED. Dropping temp."
     docker exec "$container" psql -U "$user" -d postgres -c "DROP DATABASE IF EXISTS \"$temp\";" >/dev/null 2>&1
     return 1
   fi
@@ -171,18 +182,26 @@ _restore_pg_atomic() {
   docker compose up -d postgres >/dev/null 2>&1
   for _ in $(seq 1 30); do docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 && break; sleep 1; done
 
-  # 4. Atomic swap: rename live->rescue then temp->live. Terminate any stragglers
-  #    first. If the second rename fails, roll rescue back so live is never lost.
+  # 4. Atomic swap: rename live->rescue then temp->live. FENCE connections first —
+  #    ALLOW_CONNECTIONS false blocks new connects, so an external client/supervisor
+  #    outside this compose project can't reconnect between the terminate and the
+  #    rename (cage-match #140, Carnot). Terminate stragglers, then rename. If the
+  #    second rename fails, roll rescue back so live is never lost.
+  docker exec "$container" psql -U "$user" -d postgres -c \
+    "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS false; ALTER DATABASE \"$temp\" WITH ALLOW_CONNECTIONS false;" >/dev/null 2>&1
   docker exec "$container" psql -U "$user" -d postgres -c \
     "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('$db','$temp') AND pid <> pg_backend_pid();" >/dev/null 2>&1
   if ! docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$db\" RENAME TO \"$rescue\";" >/dev/null 2>&1; then
     error "$svc: could not rename live $db -> rescue (connections still open?) — live UNTOUCHED, temp $temp left for inspection."
+    # Un-fence live so the app can reconnect when it comes back up.
+    docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1
     docker compose up -d >/dev/null 2>&1
     return 1
   fi
   if ! docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$temp\" RENAME TO \"$db\";" >/dev/null 2>&1; then
     error "$svc: rename temp -> live FAILED after live moved to rescue — rolling back rescue -> live."
     if docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$rescue\" RENAME TO \"$db\";" >/dev/null 2>&1; then
+      docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1
       error "$svc: rolled back — live $db is the original; temp $temp left for inspection."
     else
       error "$svc: ROLLBACK ALSO FAILED — original live is under DB '$rescue', candidate under '$temp'. Manual recovery needed; app NOT restarted."
@@ -191,6 +210,8 @@ _restore_pg_atomic() {
     docker compose up -d >/dev/null 2>&1
     return 1
   fi
+  # Un-fence the new live DB (it inherited ALLOW_CONNECTIONS false from the temp).
+  docker exec "$container" psql -U "$user" -d postgres -c "ALTER DATABASE \"$db\" WITH ALLOW_CONNECTIONS true;" >/dev/null 2>&1
 
   # 5. Success — previous live kept as $rescue (drop it manually once satisfied).
   log "$svc: atomic swap complete. Previous live DB kept as '$rescue' (drop when satisfied). Bringing app up..."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -117,6 +117,87 @@ _validate_sqlite_db() {
   return 0
 }
 
+# Atomically restore a postgres DB from a plain dump WITHOUT ever leaving the live
+# DB empty (#29 Phase 2). The postgres analog of _restore_island_core's temp-file +
+# atomic-mv: load the dump into a TEMP database, integrity-gate it, then swap it into
+# place with two ALTER DATABASE renames — keeping the prior live DB as a timestamped
+# rescue. The old restore_kanbn/outline dropped the live DB FIRST then loaded, so a
+# dump that passed validation but errored mid-replay left the DB EMPTY. Here the live
+# DB is untouched until a fully-replayed, non-empty candidate exists.
+#
+# Validated end-to-end against postgres:alpine (cage-match #138 → #29 Phase 2):
+# good dump swaps in with the old DB preserved as rescue; a truncated dump fails the
+# temp load and the live DB is never touched.
+#
+# Args: <svc> <container> <pguser> <db> <composedir> <dumpfile>
+# Requires the dump to have already passed _validate_pg_dump.
+_restore_pg_atomic() {
+  local svc="$1" container="$2" user="$3" db="$4" composedir="$5" dumpfile="$6"
+  local ts temp rescue
+  ts=$(date +%Y%m%d_%H%M%S)
+  temp="${db}_restore_${ts}"
+  rescue="${db}_rescue_${ts}"
+
+  cd "$composedir" || { error "$svc: cannot cd $composedir"; return 1; }
+  docker compose up -d postgres >/dev/null 2>&1 || { error "$svc: postgres failed to start"; return 1; }
+  for _ in $(seq 1 30); do docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 && break; sleep 1; done
+  docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 || { error "$svc: postgres not ready after 30s"; return 1; }
+
+  # 1. Load into a fresh temp DB — live $db untouched. --single-transaction +
+  #    ON_ERROR_STOP so a mid-replay error aborts with the temp DB discarded.
+  log "$svc: loading dump into temp DB $temp (live $db untouched)..."
+  docker exec "$container" psql -U "$user" -d postgres -c "DROP DATABASE IF EXISTS \"$temp\";" >/dev/null 2>&1
+  docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "CREATE DATABASE \"$temp\";" >/dev/null 2>&1 \
+    || { error "$svc: could not create temp DB $temp — live $db untouched"; return 1; }
+  if ! docker exec -i "$container" psql -v ON_ERROR_STOP=1 --single-transaction -U "$user" -d "$temp" < "$dumpfile" >/dev/null 2>&1; then
+    error "$svc: dump failed to replay into temp DB — live $db UNTOUCHED. Dropping temp; investigate the dump before retrying."
+    docker exec "$container" psql -U "$user" -d postgres -c "DROP DATABASE IF EXISTS \"$temp\";" >/dev/null 2>&1
+    return 1
+  fi
+
+  # 2. Integrity gate: the candidate must have loaded at least one public table.
+  local ntables
+  ntables=$(docker exec "$container" psql -U "$user" -d "$temp" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';" 2>/dev/null)
+  if ! [ "$ntables" -ge 1 ] 2>/dev/null; then
+    error "$svc: temp DB has no public tables (empty/wrong dump) — live $db UNTOUCHED. Dropping temp."
+    docker exec "$container" psql -U "$user" -d postgres -c "DROP DATABASE IF EXISTS \"$temp\";" >/dev/null 2>&1
+    return 1
+  fi
+
+  # 3. Stop the app so nothing holds a connection to the live DB (ALTER DATABASE
+  #    RENAME needs zero connections), then bring ONLY postgres back for the swap.
+  log "$svc: stopping app for the atomic swap..."
+  docker compose stop >/dev/null 2>&1
+  docker compose up -d postgres >/dev/null 2>&1
+  for _ in $(seq 1 30); do docker exec "$container" pg_isready -U "$user" >/dev/null 2>&1 && break; sleep 1; done
+
+  # 4. Atomic swap: rename live->rescue then temp->live. Terminate any stragglers
+  #    first. If the second rename fails, roll rescue back so live is never lost.
+  docker exec "$container" psql -U "$user" -d postgres -c \
+    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('$db','$temp') AND pid <> pg_backend_pid();" >/dev/null 2>&1
+  if ! docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$db\" RENAME TO \"$rescue\";" >/dev/null 2>&1; then
+    error "$svc: could not rename live $db -> rescue (connections still open?) — live UNTOUCHED, temp $temp left for inspection."
+    docker compose up -d >/dev/null 2>&1
+    return 1
+  fi
+  if ! docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$temp\" RENAME TO \"$db\";" >/dev/null 2>&1; then
+    error "$svc: rename temp -> live FAILED after live moved to rescue — rolling back rescue -> live."
+    if docker exec "$container" psql -v ON_ERROR_STOP=1 -U "$user" -d postgres -c "ALTER DATABASE \"$rescue\" RENAME TO \"$db\";" >/dev/null 2>&1; then
+      error "$svc: rolled back — live $db is the original; temp $temp left for inspection."
+    else
+      error "$svc: ROLLBACK ALSO FAILED — original live is under DB '$rescue', candidate under '$temp'. Manual recovery needed; app NOT restarted."
+      return 1
+    fi
+    docker compose up -d >/dev/null 2>&1
+    return 1
+  fi
+
+  # 5. Success — previous live kept as $rescue (drop it manually once satisfied).
+  log "$svc: atomic swap complete. Previous live DB kept as '$rescue' (drop when satisfied). Bringing app up..."
+  docker compose up -d >/dev/null 2>&1
+  return 0
+}
+
 restore_kanbn() {
   log "Restoring Kan.bn..."
 
@@ -129,32 +210,12 @@ restore_kanbn() {
     cleanup_backups
     exit 1
   fi
-  # Validate BEFORE the destructive drop — a corrupt/truncated dump must never
-  # reach dropdb (the old code dropped first, then blind-loaded).
+  # Validate the dump, then atomically swap it in via a temp DB (never drops the
+  # live DB before a fully-replayed candidate exists — #29 Phase 2). The old code
+  # dropped+recreated FIRST then loaded, so a dump that errored mid-replay left the
+  # DB empty.
   _validate_pg_dump kanbn "$BACKUP_FILE" || { cleanup_backups; exit 1; }
-
-  # Ensure Kan.bn postgres is running
-  cd ~/apps/kanbn
-  docker compose up -d postgres
-  log "Waiting for PostgreSQL to start..."
-  sleep 10
-
-  # Drop and recreate database
-  log "Dropping existing database..."
-  docker exec -i kanbn_postgres bash -c "psql -U kanbn -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'kanbn' AND pid <> pg_backend_pid();\" postgres && dropdb -U kanbn kanbn && createdb -U kanbn kanbn"
-
-  # Atomic load: --single-transaction + ON_ERROR_STOP so a replay error rolls the
-  # WHOLE load back instead of leaving a half-populated DB. (The DB was just
-  # dropped+recreated, so on failure it ends EMPTY — surfaced loudly below, not
-  # silently logged as success.)
-  log "Restoring database..."
-  if ! docker exec -i kanbn_postgres psql -v ON_ERROR_STOP=1 --single-transaction -U kanbn kanbn < "$BACKUP_FILE"; then
-    error "Kan.bn psql restore FAILED and rolled back — DB is now EMPTY (dump passed syntactic validation but errored on replay). Investigate the dump before retrying; do NOT expect data after an app restart."
-    cleanup_backups; exit 1
-  fi
-
-  log "Restarting Kan.bn..."
-  docker compose restart
+  _restore_pg_atomic kanbn kanbn_postgres kanbn kanbn ~/apps/kanbn "$BACKUP_FILE" || { cleanup_backups; exit 1; }
 
   cleanup_backups
   log "Kan.bn restore complete!"
@@ -171,28 +232,9 @@ restore_outline() {
     cleanup_backups
     exit 1
   fi
-  # Validate BEFORE the destructive drop (see restore_kanbn).
+  # Validate + atomic temp-DB swap (see restore_kanbn / _restore_pg_atomic).
   _validate_pg_dump outline "$BACKUP_FILE" || { cleanup_backups; exit 1; }
-
-  # Ensure Outline postgres is running
-  cd ~/apps/outline
-  docker compose up -d postgres
-  log "Waiting for PostgreSQL to start..."
-  sleep 10
-
-  # Drop and recreate database
-  log "Dropping existing database..."
-  docker exec -i outline_postgres bash -c "psql -U outline -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'outline' AND pid <> pg_backend_pid();\" postgres && dropdb -U outline outline && createdb -U outline outline"
-
-  # Atomic load (see restore_kanbn): rolls back on any replay error.
-  log "Restoring database..."
-  if ! docker exec -i outline_postgres psql -v ON_ERROR_STOP=1 --single-transaction -U outline outline < "$BACKUP_FILE"; then
-    error "Outline psql restore FAILED and rolled back — DB is now EMPTY (dump passed syntactic validation but errored on replay). Investigate the dump before retrying; do NOT expect data after an app restart."
-    cleanup_backups; exit 1
-  fi
-
-  log "Restarting Outline..."
-  docker compose restart
+  _restore_pg_atomic outline outline_postgres outline outline ~/apps/outline "$BACKUP_FILE" || { cleanup_backups; exit 1; }
 
   cleanup_backups
   log "Outline restore complete!"


### PR DESCRIPTION
## What

Postgres atomic restore-into-temp-then-swap for kanbn/outline — the #29 Phase 2 core (issue #2386). The postgres analog of `_restore_island_core`'s temp-file + atomic-`mv`.

Phase 1 (#138, merged+deployed) made a bad dump fail *loud* but not *safe*: restore_kanbn/outline still `dropdb`'d the live DB before loading, so a dump that passed validation but errored mid-replay left the DB EMPTY. This makes it safe.

## How

New `_restore_pg_atomic <svc> <container> <user> <db> <composedir> <dumpfile>`:
1. Load the dump into a **temp DB** (`<db>_restore_<ts>`) — live DB untouched.
2. Integrity gate: temp must have ≥1 public table.
3. Stop the app (so nothing holds a connection), bring only postgres back.
4. **Swap**: `ALTER DATABASE <db> RENAME TO <db>_rescue_<ts>` then `<db>_restore_<ts> RENAME TO <db>`, with **rollback** if the second rename fails (rescue → live).
5. Prior live DB kept as a timestamped **rescue** DB; app restarted.

`restore_kanbn` / `restore_outline` collapse to `_validate_pg_dump` + `_restore_pg_atomic`.

## Verified (watched, not reasoned)

Ran the **actual helper** against `postgres:alpine` via a throwaway compose project (real compose up / readiness poll / temp load / integrity gate / app stop / swap / rescue / restart):
- **good dump** → RC=0, live becomes the restored data, prior live preserved as `kanbn_rescue_<ts>`, app back up.
- **truncated dump** → RC=1, "live UNTOUCHED", temp auto-dropped, live keeps its data. The bad dump never reaches live.

## Scope

- **pm_bot atomic install intentionally dropped** — Nick: "pm_bot can die" (its `bot.db` is disposable).
- Remaining #30 tail findings still open: continuwuity `rm -rf` before validate, claudius/radicale extract atomicity, `set -o pipefail`, min-size floor, `restore_matrix`↔`_restore_island_core` block dedup.

## Note

Rescue DBs accumulate (one per restore) — intentional (mirrors island's rescue files); drop manually once satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)