### PR TITLE
fix(dreamfinder): CALENDAR_URL → /nick/imagineering-events (repair 'zero calendar awareness')

### DIFF
--- a/dreamfinder/secrets.yaml
+++ b/dreamfinder/secrets.yaml
@@ -16,7 +16,7 @@ livekit_api_key: ENC[AES256_GCM,data:NVduA/w4U9TBmPNBJbbuji9Urg==,iv:AA7Y5L1YgW8
 livekit_api_secret: ENC[AES256_GCM,data:R+4ssfUpTVTHiP1e/LcUpgf2ZAJTHnMNX8r29fBpNnWfK7snsXid3kKEiQVuH0W0wiF9MQUHCfaFrN6KvHi9bg==,iv:BcZXEHotQc/3uftpI8Dz3X1cPtt2RoU2XTsoGK3ufiY=,tag:uof7AJGxPejNRuAW0HmJ6Q==,type:str]
 admin_ids: ENC[AES256_GCM,data:1OtYW32mnu8WbuRH7np9yBka3AFcxRxmdxMMhUEBEfEmo3cSyTvQSMEp6BPnz/UA25zPCqn53oUsN05vJLW1w0YtCByYp1Vl03OwzJb3z95FSQ==,iv:aY0Z0c8JtiCcfbQpPufSmNjJBW9liO8CwDAvDRxAbC8=,tag:r35sNmYpEL1aR5hLJHNerg==,type:str]
 matrix_always_respond_rooms: ENC[AES256_GCM,data:HgVPhJsjYRqASvba5IEU+TRl8PPoKYldB4vGY4F2J15Hq5M=,iv:JZ+NE6H2RJ0Pp1myPmEh4AFFm1AUNWwJe4NDeR0+4b4=,tag:syyL8UUX6twGmg3rf+RX3w==,type:str]
-calendar_url: ENC[AES256_GCM,data:YqkXHhWb1KTzJOLN5jm742Stf/BoNLY2TzvzmxN2mG5FSWG6X6l1RLiYx/0A4iNMzMAJPY3lEp7Ky+K0,iv:gqnydGzMVhSgcirleUxwFWkh+da0Hua54WtXKVjwlCs=,tag:illLnGigADWR/XlJ58Zi9A==,type:str]
+calendar_url: ENC[AES256_GCM,data:+UoMg8jj8Zdu+1xE6jqt6QdrkNFM8obPP4nOYlQRmkHUvxnILwLn+UuWqCYblEB7rHq67/c=,iv:nwPJqXZzlxWeEmsD9HbyqirupVfa+uqqaNjx4QGZbAo=,tag:zVLY1SwwXTvdw9lAclQEbQ==,type:str]
 event_timezone: ENC[AES256_GCM,data:3TQqx+qbeJU+25l76fKyLc7OHQ==,iv:Goi/WKwFyMl0IGKG/pWGN3jZIHJmkyUd90M19ZK0CHg=,tag:qr1j5/zVLG7fcgnMtqcC3g==,type:str]
 deploy_announce_group_id: ENC[AES256_GCM,data:S6+bhVlDrI08EgqBiNOw4/ZE8gZJ/TVTUmljyIKbHQ5+VdY=,iv:OxZw4ZK5Q3huNnWF8h5PDm4MreWjbKeSSVEpjEJooP0=,tag:vA1Fgh7LvFK6TxCznJbvkw==,type:str]
 claude_code_oauth_token: ENC[AES256_GCM,data:PFKpkfjhxeZU9r1Y/kHrYGiMCmmDWaum5uM+EsimpDLh1s0txmaz+fbz0kRwaTBkSUKLjUxt19Uiva4UHQ2opRwm5nBdQC3tyB/KHHzNNjqP0OcUaK9BqTOlMrT8kvs+NPK6d/P/GBbQHtxY,iv:iR7fNnepq6EfTBwGbWezAfkocYH21Ijqjb6gbLgiXUk=,tag:LlJ3M9NRTTWAFzYs0za+bQ==,type:str]
@@ -31,7 +31,7 @@ sops:
             cjYremsrWjczcm42QjZDVFQ4czNmMG8Ky2xTXnTpeOAAWjZKvAZ8SuupXqZ+tMFW
             b92n4tsWONqZWY9iALoeIz/N4UhkgYNT5v+gBfNLyq3t9cFXqdXMgQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-21T09:01:38Z"
-    mac: ENC[AES256_GCM,data:iOPaNYT+ohCr08QX+URqqU0mc+o1QkVYC4lHon7B7MnnqQICpbzhONhpeyq+c5WuYRkS1VhzGpn598pF1L/iySFZrBAXY6MpuhwL0fvata1yWdyqPeYaj791zWXChsuYE8k8R+Vi9I//a0CF57kDnwsYZCEKOZ9pBvgqP6XSwI0=,iv:D5kfFLQGFVpdZYHcIQ5LtVI+qV25Xeg30L3vdqz6DE8=,tag:dTxZPuYERp8x3gMRmWVaGQ==,type:str]
+    lastmodified: "2026-08-01T23:56:29Z"
+    mac: ENC[AES256_GCM,data:MhHw/qAlZ+J7WUyy59fO5h2xoyT8OrPeiaJLmjuQBRrLN5Tods1X6/jc8DVzIAG1ImcDGmbDCbOIg+5QCn8s85tpJ3/VkTQh69V4m+oPgd9g6ISlk99ToLWw7nuRs6Yg3Yycd4Tt6KTqg5/0VJOuBAqLfF4YIblqFqrOWMu7Nu8=,iv:qzeBcEvJDHRWlavy9TMjlIVP2qKb2Dw9m9gRF3Mpnjo=,tag:Xw+oeC51bQJa+X812Xh/vw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## What
Repoints dreamfinder's `CALENDAR_URL` from the empty, pm-agent-forbidden `/dreamfinder/imagineering-events/` to `/nick/imagineering-events/` where the events actually live.

## Why
River authenticates as **pm-agent**, which has `RWrw` on `/nick/` (the `[pm-agent-nick]` shared-calendar rule) but **not** `/dreamfinder/`. The old path was empty *and* 403-forbidden, so calendar reads fell closed to `[]` — the **'zero calendar awareness'** symptom.

## Provenance
Extracted from the now-closed **#120**. That PR bundled this fix with an OAuth-token rotation that got obsoleted by `51e84f1` (main is on a newer token). The calendar half never landed — **main still carried the broken path**, so a redeploy-from-main would silently re-break River's calendar. This lands only the fix on the source of truth.

## Verification
- Surgical SOPS diff: only `calendar_url` ciphertext re-encrypted (+ mac/lastmodified), nothing else.
- Decrypt round-trip confirms `/nick/imagineering-events/`.
- Pre-commit secret scan: clean (encrypted values only).

## Gate
⚠️ Needs 1 approving review (branch protection). Independent follow-up: the **original leaked OAuth token** (pre-#120) still needs revoking in the Claude account.

🤖 (claude)