### PR TITLE
fix(deploy): quote MAILTO so cron accepts the health-check entry

### DIFF
--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -126,11 +126,19 @@ deploy_scripts() {
 
     # Set up health check cron. Tokens are NOT inlined here any more — the
     # script reads /etc/imagineering-secrets/telegram.env via lib/telegram.sh.
+    #
+    # MAILTO must be QUOTED. On Ubuntu 24.04 (cron 3.0pl1-184ubuntu2) a bare
+    # `MAILTO=` makes cron reject the whole file with "Error: bad username"
+    # whenever the hour and day-of-month fields are both `*` — which is exactly
+    # the hourly entry below. Cron logs that once, at the scan after the file is
+    # written, and never again, because it only re-parses a cron.d file when the
+    # mtime changes. The result is a health check that installs cleanly, looks
+    # correct in `cat`, runs fine by hand, and never executes.
     echo "Installing /etc/cron.d/health-check..."
     ssh "$REMOTE" "mkdir -p ~/logs && printf '%s\n' \
         'SHELL=/bin/bash' \
         'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
-        'MAILTO=' \
+        'MAILTO=\"\"' \
         '0 * * * * nick /opt/scripts/health-check.sh >> /home/nick/logs/health-check.log 2>&1' \
         | sudo tee /etc/cron.d/health-check > /dev/null && \
         sudo chmod 0644 /etc/cron.d/health-check && sudo chown root:root /etc/cron.d/health-check"


### PR DESCRIPTION
## The bug

`deploy_scripts()` writes `/etc/cron.d/health-check` with a bare `MAILTO=`. On Ubuntu 24.04 (cron `3.0pl1-184ubuntu2`) that makes cron **reject the entire file** with:

```
cron[970]: Error: bad username; while reading /etc/cron.d/health-check
cron[970]: (*system*health-check) ERROR (Syntax error, this crontab file will be ignored)
```

The trigger is a bare `MAILTO=` combined with an entry whose **hour and day-of-month fields are both `*`** — which is exactly the `0 * * * *` entry this script installs. One-line change: `'MAILTO='` → `'MAILTO=\"\"'`.

## Why it matters more than a one-line typo

The failure is silent and survives every check a person would think to run:

- the file exists and `cat`s correctly — a rejected `cron.d` file is byte-identical to a working one;
- `health-check.sh` runs fine by hand;
- a forced alert still arrives, because that exercises the **script**, not cron's willingness to invoke it.

And cron reports it **once** — at the scan following the write — then never again, because it only re-parses a `cron.d` file when the mtime changes. So the log line scrolls away within minutes of the deploy and nothing ever mentions it again. The only symptom is a `health-check.log` that stops growing, which is precisely the file nobody looks at while things are fine.

Net effect: the monitor is installed, looks healthy, and never runs. A host can then go down for as long as it likes without an alert.

## Evidence

Found on another Ubuntu 24.04 host running an equivalent hourly check, installed 2026-07-31 and still never executed on 2026-08-06 — its log file had never been created. Bisected against cron on that host with throwaway `cron.d` files:

| env block | schedule | result |
|---|---|---|
| bare `MAILTO=` | `17 * * * *` | **rejected** |
| bare `MAILTO=` | `0 * * * *` | **rejected** |
| bare `MAILTO=` | `17 0 * * *` (hour not `*`) | ok |
| bare `MAILTO=` | `17 * 31 * *` (dom not `*`) | ok |
| `MAILTO=""` | `0 * * * *` | **ok** |
| `MAILTO=root` | `17 * * * *` | ok |
| no `MAILTO` line | `17 * * * *` | ok |

Re-reading the set reproduced the identical failing subset, so it is deterministic, not flaky NSS. `dpkg -V cron` reports the package unmodified and the unit is stock, so this is cron's own behaviour rather than anything local. I characterised the trigger empirically and did not trace it to a line of `entry.c`, but the rule held in every case tested.

Applying `MAILTO=""` on that host took its hourly check from never-run to running: `CMD (…health-check.sh …)` in the cron journal and an hourly line in the log, confirmed across several hours.

## Verification done here

- Rendered the remote file through the real quoting path (the `ssh "$REMOTE" "…printf…"` string extracted from this file, evaluated by a local shell) — writes `MAILTO=""` exactly, confirmed by hexdump.
- Installed the resulting `MAILTO=""` + `0 * * * *` block on an Ubuntu 24.04 host: parses clean, no `bad username`. Test file removed afterwards.
- `bash -n scripts/deploy-to.sh` passes.

## Worth checking after merge

The Sydney host was very likely deployed by this script and is therefore **probably in this state right now** — I have no access to it, so this is inference, not something I verified:

```sh
sudo journalctl -u cron | grep -i 'health-check'   # want CMD lines, not "bad username"
ls -l ~/logs/health-check.log                      # want a line from within the last hour
```

If it is affected, re-running the deploy fixes it, since the write changes the mtime and forces a re-parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
