### PR TITLE
fix(backup): capture imagineering's Radicale, not xdeca's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,20 @@ jobs:
           REQUIRE_ALL: "1"
         run: ./scripts/test-restore-aiko-island.sh
 
+  backup-libs:
+    name: Backup Library Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Hermetic unit tests for the backup helper libs — `docker` and `gh` are
+      # stubbed, so no daemon, no token, no network, and nothing real is
+      # mutated. These cover the fail-closed guards on container resolution,
+      # where a wrong answer silently backs up the WRONG tenant's data (see
+      # lib/resolve-container.sh) rather than failing visibly.
+      - name: Run resolve-container tests
+        run: ./scripts/test-resolve-container.sh
+
   caddy-validate:
     name: Caddyfile Validate
     runs-on: ubuntu-latest

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -159,9 +159,22 @@ backup_radicale() {
 
   local out="$BACKUP_DIR/radicale-$DATE.tar.gz"
 
+  # Resolve by compose project, NOT by name. `docker exec radicale` resolved to
+  # XDECA's container on this co-located box (imagineering's is `img-radicale`,
+  # project `radicale`; xdeca's is plain `radicale`, project `xdeca-radicale`),
+  # so this backup captured the wrong tenant's calendars while imagineering's
+  # own collections went unbacked. restore.sh drives the RIGHT container via
+  # `cd ~/apps/radicale && docker compose`, so the two halves disagreed: a
+  # restore would have overwritten imagineering's collections with xdeca's.
+  local container
+  if ! container=$(resolve_container_by_compose radicale radicale 2>&1); then
+    error "Radicale container not resolved: $container"
+    return 1
+  fi
+
   # Tar the collections from the Docker volume. The old code ignored tar's exit
   # AND never checked the artifact, so a failed/partial tar committed silently.
-  if ! docker exec radicale tar czf - /data/collections > "$out" 2>/dev/null; then
+  if ! docker exec "$container" tar czf - /data/collections > "$out" 2>/dev/null; then
     error "Radicale tar failed"; rm -f "$out"; return 1
   fi
   # Verify the archive is a readable, complete gzip'd tar (a truncated .tar.gz

--- a/scripts/lib/resolve-container.sh
+++ b/scripts/lib/resolve-container.sh
@@ -45,3 +45,46 @@ resolve_container() {
   fi
   printf '%s\n' "$matches"
 }
+
+# Print the single running container for a compose PROJECT + SERVICE.
+#
+# Prefer this over resolve_container's name pattern whenever the two tenants
+# run the SAME service, because the compose project is the durable identity and
+# the container name is not. Radicale is the worked example: imagineering's
+# container is `img-radicale` (project `radicale`) and xdeca's is plain
+# `radicale` (project `xdeca-radicale`). backup.sh hardcoded `docker exec
+# radicale`, which therefore resolved to XDECA'S container — imagineering's
+# nightly radicale.tar contained xdeca's calendars, imagineering's own Radicale
+# (including dreamfinder's collections) was never backed up at all, and because
+# restore.sh drives the correct container via `cd ~/apps/radicale && docker
+# compose`, a restore would have wiped imagineering's collections and replaced
+# them with the other tenant's. A name pattern would have fixed this instance;
+# the project label makes the class unrepresentable, since two tenants cannot
+# share a compose project on one host.
+#
+# Usage:
+#   cid=$(resolve_container_by_compose radicale radicale) || return 1
+resolve_container_by_compose() {
+  local project=${1:-} service=${2:-} label=${3:-${1:-container}} matches count
+  if [ -z "$project" ] || [ -z "$service" ]; then
+    echo "resolve-container: both a compose project and service are required" >&2
+    return 1
+  fi
+  matches=$(docker ps \
+    --filter "label=com.docker.compose.project=$project" \
+    --filter "label=com.docker.compose.service=$service" \
+    --format '{{.Names}}' || true)
+  count=$(printf '%s' "$matches" | grep -c .)
+  # Fail closed on both edges, same as resolve_container: zero matches must
+  # never degrade to "back up nothing and report success", and an ambiguous
+  # match must never be resolved by picking arbitrarily between tenants.
+  if [ "$count" -eq 0 ]; then
+    echo "resolve-container: no running container for compose project '$project' service '$service' ($label)" >&2
+    return 1
+  fi
+  if [ "$count" -gt 1 ]; then
+    echo "resolve-container: >1 running container for compose project '$project' service '$service' ($(printf '%s' "$matches" | tr '\n' ' ')) — refusing to guess" >&2
+    return 1
+  fi
+  printf '%s\n' "$matches"
+}

--- a/scripts/test-resolve-container.sh
+++ b/scripts/test-resolve-container.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Tests for lib/resolve-container.sh, with the co-located-tenant case that
+# actually bit us as the centrepiece.
+#
+# This box runs imagineering-* and xdeca-* stacks side by side, so the SAME
+# service exists twice with different names. `docker exec radicale` silently
+# selected xdeca's container: imagineering's nightly radicale.tar held xdeca's
+# calendars, imagineering's own collections were never captured, and restore.sh
+# — which resolves the correct container via compose — would have written one
+# tenant's data over the other's.
+#
+# `docker` is stubbed here, so this is hermetic: no daemon, no containers.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/resolve-container.sh
+. "$SCRIPT_DIR/lib/resolve-container.sh"
+
+PASS=0
+FAIL=0
+ok() { PASS=$((PASS + 1)); printf '  \033[0;32mok\033[0m %s\n' "$1"; }
+no() { FAIL=$((FAIL + 1)); printf '  \033[0;31mFAIL\033[0m %s\n     %s\n' "$1" "$2"; }
+assert_eq() {
+  if [ "$1" = "$2" ]; then ok "$3"; else no "$3" "want [$1] got [$2]"; fi
+}
+
+# --- Stub: the real co-located fleet on 149.118.69.221 ---------------------
+# imagineering radicale -> container `img-radicale`, compose project `radicale`
+# xdeca radicale        -> container `radicale`,     compose project `xdeca-radicale`
+# Both expose compose service `radicale`. That collision is the whole point.
+docker() {
+  local project="" service=""
+  for arg in "$@"; do
+    case "$arg" in
+      label=com.docker.compose.project=*) project="${arg#label=com.docker.compose.project=}" ;;
+      label=com.docker.compose.service=*) service="${arg#label=com.docker.compose.service=}" ;;
+    esac
+  done
+  if [ -n "$project" ]; then
+    case "$project/$service" in
+      radicale/radicale)         echo "img-radicale" ;;
+      xdeca-radicale/radicale)   echo "radicale" ;;
+      ambiguous/dup)             printf 'one\ntwo\n' ;;
+      *)                         : ;;   # no match
+    esac
+    return 0
+  fi
+  # Plain `docker ps --format '{{.Names}}'` for the name-pattern resolver.
+  printf 'img-radicale\nradicale\nimagineering-outline-postgres\nxdeca-outline-postgres\n'
+}
+
+echo "== resolve_container_by_compose: picks the right tenant =="
+assert_eq "img-radicale" "$(resolve_container_by_compose radicale radicale 2>/dev/null)" \
+  "imagineering project resolves to img-radicale"
+assert_eq "radicale" "$(resolve_container_by_compose xdeca-radicale radicale 2>/dev/null)" \
+  "xdeca project resolves to the bare radicale container"
+
+echo "== the regression this exists to prevent =="
+# The old code was `docker exec radicale`. Assert the resolver does NOT return
+# the xdeca container for the imagineering project — i.e. that a future rename
+# cannot silently reintroduce cross-tenant capture.
+got=$(resolve_container_by_compose radicale radicale 2>/dev/null)
+if [ "$got" = "radicale" ]; then
+  no "imagineering lookup must not return xdeca's container" "got the xdeca container"
+else
+  ok "imagineering lookup never returns xdeca's container"
+fi
+
+echo "== fail closed on zero matches =="
+out=$(resolve_container_by_compose nosuch radicale 2>&1); rc=$?
+assert_eq "1" "$rc" "zero matches returns non-zero"
+case "$out" in *"no running container"*) ok "zero matches explains why" ;; *) no "zero matches explains why" "$out" ;; esac
+
+echo "== fail closed on ambiguity (never guess between tenants) =="
+out=$(resolve_container_by_compose ambiguous dup 2>&1); rc=$?
+assert_eq "1" "$rc" "ambiguous match returns non-zero"
+case "$out" in *"refusing to guess"*) ok "ambiguous match refuses to guess" ;; *) no "ambiguous match refuses to guess" "$out" ;; esac
+
+echo "== missing arguments are an error, not a wildcard =="
+out=$(resolve_container_by_compose "" "" 2>&1); rc=$?
+assert_eq "1" "$rc" "empty project/service returns non-zero"
+
+echo "== resolve_container (name pattern) still fails closed on ambiguity =="
+# '^radicale$' is exact, so it matches only the xdeca container here; the
+# anchored imagineering pattern must not also match it.
+assert_eq "img-radicale" "$(resolve_container '^img-radicale$' radicale 2>/dev/null)" \
+  "anchored name pattern still works"
+out=$(resolve_container 'radicale' radicale 2>&1); rc=$?
+assert_eq "1" "$rc" "unanchored pattern matching both tenants is refused"
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The bug

`backup_radicale` hardcoded `docker exec radicale`. On the co-located box that name belongs to **xdeca's** container:

| | container | compose project | port |
|---|---|---|---|
| imagineering | `img-radicale` | `radicale` | 5232 |
| xdeca | `radicale` | `xdeca-radicale` | 5233 |

So imagineering's nightly `radicale.tar` has been **xdeca's calendars**, and imagineering's own collections were never backed up.

## Evidence (verified on 149.118.69.221, 2026-08-09)

The committed archive contains `collection-root/nick/B90D1DF4-52F6-45A6-965C-0E09698EF720` — the exact UUID present in the xdeca volume — and lacks `dreamfinder`, who exists only in `img-radicale`:

```
radicale     (xdeca)         → nick, pm-agent
img-radicale (imagineering)  → dreamfinder, nick, pm-agent
```

## Why it's dangerous, not just wrong

The two halves disagree. `restore.sh` resolves the **correct** container (`cd ~/apps/radicale && docker compose stop radicale`). So a restore would have taken xdeca's data out of the imagineering backup and written it over imagineering's live collections — wiping Dreamfinder's and Nick's calendars and cross-contaminating tenants.

## The fix

Resolve by **compose project + service**, not by container name.

A name pattern (`^img-radicale$`) would fix this instance. The project label makes the class unrepresentable: two tenants cannot share a compose project on one host, so no future rename can silently reintroduce cross-tenant capture.

This is the same root cause `lib/resolve-container.sh` was written for after the 2026-03-29 rename broke outline + kanbn for months — radicale was simply missed in that migration. Corpus swept: remaining hardcoded names (`dreamfinder`, `claudius`) are unambiguous on this host, and outline/kanbn already resolve.

## Tests

`scripts/test-resolve-container.sh`, hermetic (`docker` stubbed — no daemon, no containers), wired into CI:

- both tenants resolve to their own container
- the specific regression: an imagineering lookup never returns xdeca's container
- fail closed on zero matches (a backup that quietly captures nothing is the failure this lib exists to end)
- fail closed on ambiguity — never pick arbitrarily between tenants
- empty args are an error, not a wildcard

## Gate

Branch protection needs 1 approving review — that's your hand, not mine.

## Not in this PR

The MinIO → GitHub Releases work is next, on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PA85fPreJNpA8uMRpTpKja