### PR TITLE
feat(backup): back up MinIO object stores via GitHub Release assets

### DIFF
--- a/backups/secrets.yaml
+++ b/backups/secrets.yaml
@@ -3,6 +3,7 @@ gcs_project: ENC[AES256_GCM,data:QAGPwWnATbUSFPWj9Q==,iv:7f7zaUeg5aJFsP6atXrk8p4
 telegram_bot_token: ""
 telegram_chat_id: ENC[AES256_GCM,data:g1u/Xtu68LUNPg==,iv:AVKDjpjq12cBt0D6gyiy6ZzmNSbwcTMBjiQtzFEfbKI=,tag:IbnGEiavN75ZXVe6lve8Mg==,type:str]
 telegram_thread_id: ""
+github_release_token: ENC[AES256_GCM,data:YE4C7Jqc60crLOUINWMZD1st/ocMAFOwK9FhD/UuBiL+ikpVNG+Q8FcYA6x1yAtE0ozJ9n3Xc12unIniZWyHg59NVJUMTLUWqA6PW0SGRbXlFDDyFIkcL88A/IKF,iv:nTFAgk6Rc88BvgkqHDcVEI3k/dIH5P6LUV3mJtupevQ=,tag:lJFAJZIwR3wykJDEcl2NEg==,type:str]
 sops:
     age:
         - recipient: age1mkelwyppmll44ehjnarunmtamcxpee7jljyl475mlvxma7dm4f3q6lnmks
@@ -14,7 +15,7 @@ sops:
             amFOYms1d2pkcExBWEVOS0htdTV6Um8Kol+t7uWZUkKtZXeeE4ah/hsvi7sK+q3X
             o/CiZ+LzqxDkxoltKhyp+vO/3LBKKHSxq5LAuIn+aiabd82Oy87LHQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-06T22:43:24Z"
-    mac: ENC[AES256_GCM,data:mEvjKo1Op3W7RgQ9ZIbpTxnDhtmoEuS4YNlbyPsQKjBakUDJuArDlgqSlY3SOwq4nq1lkaY9jLFpxM/ZvIXZMl3NZrcKZOwo/2GgXjCht9iXyAMj65SAJVjltDHKnnZ1V8mOd4JtkNbjl1mkHXMp16pQA+kVwWBiI/7UXGt7dgc=,iv:ci0LMbyqxxB6QCKVRJUM/Z0Hfh57M6fzeacFRe81D7s=,tag:+A/dpethMFAx10byPRjfPA==,type:str]
+    lastmodified: "2026-08-10T00:12:13Z"
+    mac: ENC[AES256_GCM,data:cqqw2BTIwYbKIy4gQuOgCZq+NcUGddP4hmF7sJBkxjHyxR83/SVi9243qQ1T3xrr8NUGHPJVvPHumUEFsc3CKGAwB/aymZPVotvTfLjZwmOqLGxGa+ieZ/3uG+tnV+ktHxB5x/G/dljHIMRXz4hV+wJPAht/KVzvVN63xmDxc+w=,iv:pCNgeqluC1+sPVlzy4vWBJRxOKdDazfLb7NfIzNnJZU=,tag:+dAPyVRONvIUATFilZxugw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,6 +17,17 @@ FAILED_SERVICES=()
 GITHUB_BACKUP_REPO="git@github-imagineering-backups:imagineering-cc/imagineering-backups.git"
 GITHUB_BACKUP_DIR="/tmp/imagineering-backups"
 GITHUB_REPO_SIZE_ALERT_MB=500
+# owner/repo form, for the REST API (releases). The SSH URL above is for git.
+GITHUB_BACKUP_SLUG="imagineering-cc/imagineering-backups"
+
+# Object-store archives are published as RELEASE ASSETS, never committed to the
+# tree. Two reasons, and the second is a hard stop rather than mere bloat:
+# a committed blob is in history forever (deleting the file reclaims nothing —
+# the whole reason prune_repo_history_if_needed exists), and GitHub blocks any
+# file over 100 MiB outright, which no history rewrite can help. Release assets
+# sit outside history, have no total-size limit, and a delete actually
+# reclaims — so retention here is an ordinary API call.
+OBJECT_RELEASE_RETENTION=${OBJECT_RELEASE_RETENTION:-7}
 
 # Backup-repo history guard. When the repo exceeds this size,
 # prune_repo_history_if_needed collapses history to a fresh root commit (loses
@@ -56,6 +67,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # months after a rename (see lib/resolve-container.sh).
 # shellcheck source=lib/resolve-container.sh
 . "$SCRIPT_DIR/lib/resolve-container.sh"
+# Release-asset tier for large binaries (object stores) — see the file header
+# for why these can't be committed to the backup repo's tree.
+# shellcheck source=lib/release-assets.sh
+. "$SCRIPT_DIR/lib/release-assets.sh"
 
 check_repo_size() {
   if [ ! -d "$GITHUB_BACKUP_DIR" ]; then
@@ -183,6 +198,58 @@ backup_radicale() {
     error "Radicale backup is not a valid tar.gz (truncated/empty)"; rm -f "$out"; return 1
   fi
   log "Radicale backup complete: $(basename "$out") ($(du -h "$out" | cut -f1))"
+}
+
+backup_minio() {
+  log "Backing up MinIO object store..."
+
+  local out="$BACKUP_DIR/minio-$DATE.tar.gz"
+
+  local container
+  if ! container=$(resolve_container_by_compose imagineering-outline minio 2>&1); then
+    error "MinIO container not resolved: $container"
+    return 1
+  fi
+
+  # Read the volume through a throwaway sidecar rather than exec'ing into
+  # MinIO. The minio/minio image is minimal — it ships `mc` and NO `tar`, so
+  # `docker exec <minio> tar` fails and, under `set -e`, dies without a
+  # message while leaving a plausible-looking file containing the runtime's
+  # error text. Mounted :ro so the backup can never write to live object data.
+  local vol
+  vol=$(docker inspect "$container" \
+    --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}' 2>/dev/null)
+  if [ -z "$vol" ]; then
+    error "MinIO /data volume not resolved for $container"
+    return 1
+  fi
+
+  if ! docker run --rm -v "${vol}:/data:ro" alpine tar czf - -C /data . > "$out" 2>/dev/null; then
+    error "MinIO tar failed"; rm -f "$out"; return 1
+  fi
+
+  # Content gate, not just a readability gate. List ONCE to a file and grep
+  # that: piping `tar tzf` into `grep -q` under `set -o pipefail` is a
+  # false-negative trap — grep exits at the first match, tar takes SIGPIPE,
+  # and the pipeline reports failure on a perfectly good archive.
+  local listing
+  listing=$(mktemp)
+  if ! tar tzf "$out" > "$listing" 2>/dev/null; then
+    error "MinIO backup is not a valid tar.gz (truncated/empty)"
+    rm -f "$out" "$listing"; return 1
+  fi
+  # .minio.sys carries bucket policies. Without it a restored bucket serves
+  # 403s to Outline and Kan.bn — a restore that looks successful and isn't.
+  local missing=""
+  if ! grep -q "^\./\.minio\.sys/" "$listing"; then missing=".minio.sys"; fi
+  if ! grep -qE "^\./[a-z0-9.-]+/" "$listing"; then missing="${missing} (no buckets)"; fi
+  if [ -n "$missing" ]; then
+    error "MinIO backup is missing $missing — refusing (would restore to a broken bucket)"
+    rm -f "$out" "$listing"; return 1
+  fi
+  rm -f "$listing"
+
+  log "MinIO backup complete: $(basename "$out") ($(du -h "$out" | cut -f1))"
 }
 
 backup_claudius() {
@@ -478,6 +545,34 @@ prune_repo_history_if_needed() {
   fi
 }
 
+# Publish object-store archives as release assets, then prune aged-out
+# releases. Deliberately NOT routed through backup_to_github: that function
+# copies artifacts into the git tree, which is precisely where these must
+# never go.
+backup_objects_to_releases() {
+  local artifact="$BACKUP_DIR/minio-$DATE.tar.gz"
+
+  if [ ! -s "$artifact" ]; then
+    error "Object-store artifact missing or empty ($artifact) — nothing to publish"
+    return 1
+  fi
+
+  # Fail LOUDLY on a missing token rather than skipping quietly. A silent skip
+  # is how the object store went unbacked for the project's entire history in
+  # the first place; an absent credential must look like a failure, not like
+  # a successful run that happened to do less.
+  if ! release_auth_available; then
+    error "No GitHub release token (expected GH_TOKEN or /etc/imagineering-secrets/github-release.env) — object store NOT backed up"
+    return 1
+  fi
+
+  release_publish_asset "$GITHUB_BACKUP_SLUG" "objects-$DATE" "$artifact" || return 1
+  # Retention failures are non-fatal: the day's backup already landed, and
+  # storage growth is a slower problem than a missing backup. The prune
+  # surfaces and alerts on its own.
+  release_prune "$GITHUB_BACKUP_SLUG" "objects-" "$OBJECT_RELEASE_RETENTION"
+}
+
 backup_to_github() {
   local services=("$@")
 
@@ -611,7 +706,20 @@ case $SERVICE in
     if [ ${#SUCCEEDED[@]} -gt 0 ]; then
       backup_to_github "${SUCCEEDED[@]}" || FAILED_SERVICES+=("github-upload")
     fi
+    # Object store goes to RELEASE ASSETS, not the tree — so it is handled
+    # after backup_to_github and is deliberately absent from SUCCEEDED (which
+    # is that function's copy-into-git list). Tracked in FAILED_SERVICES the
+    # same way, so a failure reaches the nightly alert.
+    if backup_minio; then
+      backup_objects_to_releases || FAILED_SERVICES+=("minio-release")
+    else
+      error "minio backup failed"
+      FAILED_SERVICES+=("minio")
+    fi
     cleanup_old_backups
+    ;;
+  minio)
+    backup_minio && backup_objects_to_releases || FAILED_SERVICES+=(minio)
     ;;
   kanbn)
     backup_kanbn && backup_to_github kanbn || FAILED_SERVICES+=(kanbn)

--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -124,6 +124,39 @@ deploy_scripts() {
         echo "  Add telegram_bot_token, telegram_chat_id, telegram_thread_id to enable alerts"
     fi
 
+    # Install the GitHub release token (root:nick 0640). Deploy keys cannot
+    # create releases — they authenticate git-over-SSH only — so the
+    # object-store tier needs an API token the tree-committed path doesn't.
+    # Same build-locally / scp / install-with-perms shape as the block above,
+    # for the same reason: never put the token on a remote command line.
+    if [ -f "$BACKUP_SECRETS" ] && sops -d "$BACKUP_SECRETS" | yq -e '.github_release_token' > /dev/null 2>&1; then
+        echo "Installing /etc/imagineering-secrets/github-release.env..."
+        local RELEASE_TOKEN RELEASE_TMP RELEASE_PREV_TRAP
+        RELEASE_TOKEN=$(sops -d "$BACKUP_SECRETS" | yq -r '.github_release_token')
+        RELEASE_TMP=$(mktemp)
+        RELEASE_PREV_TRAP=$(trap -p EXIT)
+        # shellcheck disable=SC2064  # expand RELEASE_TMP now, intentional
+        trap "rm -f '$RELEASE_TMP'; ssh -o ConnectTimeout=5 '$REMOTE' 'rm -f /tmp/github-release.env' 2>/dev/null || true" EXIT
+        shell_env_line GH_TOKEN "$RELEASE_TOKEN" > "$RELEASE_TMP"
+        chmod 0600 "$RELEASE_TMP"
+        scp -q "$RELEASE_TMP" "$REMOTE":/tmp/github-release.env
+        ssh "$REMOTE" "sudo mkdir -p /etc/imagineering-secrets && \
+            sudo install -m 0640 -o root -g nick /tmp/github-release.env /etc/imagineering-secrets/github-release.env && \
+            rm -f /tmp/github-release.env"
+        rm -f "$RELEASE_TMP"
+        eval "${RELEASE_PREV_TRAP:-trap - EXIT}"
+        echo "  GitHub release envfile installed (mode 0640 root:nick)"
+    else
+        echo "NOTE: No github_release_token in backups/secrets.yaml — object-store backups will FAIL loudly"
+        echo "  This is deliberate: a missing credential must not look like a successful smaller run"
+    fi
+
+    # `gh` is required for the release-asset tier (object stores). Without it
+    # backup_objects_to_releases fails loudly rather than skipping, so install
+    # it here rather than discovering the gap at 04:00.
+    echo "Ensuring gh (GitHub CLI) is installed on $REMOTE..."
+    ssh "$REMOTE" "command -v gh >/dev/null 2>&1 || (sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq gh)"
+
     # Set up health check cron. Tokens are NOT inlined here any more — the
     # script reads /etc/imagineering-secrets/telegram.env via lib/telegram.sh.
     echo "Installing /etc/cron.d/health-check..."

--- a/scripts/lib/release-assets.sh
+++ b/scripts/lib/release-assets.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# GitHub Release assets — the storage tier for LARGE BINARY backup artifacts
+# (MinIO object-store tarballs), as distinct from the small text artifacts
+# (SQL dumps, radicale tars) that are committed to the backup repo's tree.
+#
+# WHY NOT COMMIT THEM
+# Two independent reasons, and the second is the one that actually stops a
+# backup dead:
+#   1. Retention. A blob committed to git is in history forever; deleting the
+#      file reclaims nothing. That is why prune_repo_history_if_needed exists
+#      in backup.sh at all — and why its archive tags then grew to 4.37 GB
+#      across 45 tags (2026-07-30), pinning the very blobs the prune removed.
+#      A tree-committed binary has no retention story that isn't a rewrite.
+#   2. GitHub blocks any file over 100 MiB outright (warning at 50 MiB). This
+#      is a hard push rejection, not bloat, and no amount of history rewriting
+#      helps: the cap applies to the incoming object.
+#
+# Release assets sit OUTSIDE git history. GitHub states it does not limit the
+# total size of release binaries or the bandwidth to deliver them, and an asset
+# DELETE actually reclaims. So retention becomes an ordinary API call, history
+# stays append-only, and the per-file cap stops being the binding constraint.
+#
+# The guards below deliberately mirror prune_repo_history_if_needed's, which
+# were hardened over 7 cage-match rounds in #141. Same destructive-remote-op
+# hazards, same invariants: validate the retention integer (a garbage cron env
+# must not compute a delete-everything window), cap the blast radius of one
+# unattended run, capture the API's stderr so a failure's WHY reaches the log,
+# and loop per item rather than leaning on word-splitting.
+
+# Auth. A deploy key cannot create releases (it authenticates git-over-SSH
+# only), so this needs a token — the one credential the tree-committed backup
+# path does not require. Loaded from a root:nick 0640 file at source time,
+# never inlined into a cron entry, same convention as lib/telegram.sh.
+if [ -z "${GH_TOKEN:-}" ] && [ -r /etc/imagineering-secrets/github-release.env ]; then
+  # shellcheck disable=SC1091
+  . /etc/imagineering-secrets/github-release.env
+fi
+GH_TOKEN="${GH_TOKEN:-}"
+export GH_TOKEN
+
+# Every GitHub call funnels through this single indirection so the test suite
+# can stub it — hermetically, with no token, no network and no real mutation.
+release_gh() {
+  gh "$@"
+}
+
+# True when a token is present. Callers gate on this so a box without the
+# secret degrades to "text artifacts still back up, object store is SKIPPED
+# and says so" rather than failing the whole nightly run — while never
+# silently pretending the object store was captured.
+release_auth_available() {
+  [ -n "${GH_TOKEN:-}" ]
+}
+
+# Logging indirection. This lib is sourced by backup.sh (which defines log/error
+# with its own timestamped format) AND standalone by the test suite, so it must
+# work either way.
+#
+# It deliberately does NOT probe for a callable named `log`. An earlier version
+# used `declare -F log` and it failed in two compounding ways outside bash:
+# `declare -F` means "declare a float" in zsh rather than "is this a function",
+# so the guard misfired — and `log` is a zsh BUILTIN, so the subsequent call
+# resolved to that builtin instead of erroring. The result was a silent wrong
+# call, not a visible failure. Probing a bare name for callability is unsafe
+# when the name may collide with a shell builtin.
+#
+# So: delegate only when we are demonstrably in bash AND the name is genuinely a
+# shell function; otherwise print our own. Internal names are prefixed so they
+# cannot collide with a builtin in any shell.
+_ra_log() {
+  if [ -n "${BASH_VERSION:-}" ] && declare -f log >/dev/null 2>&1; then
+    _ra_log "$*"
+  else
+    printf '[release-assets] %s\n' "$*"
+  fi
+}
+_ra_err() {
+  if [ -n "${BASH_VERSION:-}" ] && declare -f error >/dev/null 2>&1; then
+    _ra_err "$*"
+  else
+    printf '[release-assets] ERROR: %s\n' "$*" >&2
+  fi
+}
+_ra_alert() {
+  if [ -n "${BASH_VERSION:-}" ] && declare -f send_telegram_alert >/dev/null 2>&1; then
+    send_telegram_alert "$*" || true
+  fi
+}
+
+# release_publish_asset <repo> <tag> <file>
+# Uploads FILE as an asset of release TAG, creating the release if absent.
+# Idempotent: --clobber replaces a same-named asset, so a re-run on the same
+# day overwrites rather than accumulating duplicates.
+release_publish_asset() {
+  local repo=$1 tag=$2 file=$3
+
+  # Fail closed on a missing or EMPTY artifact. An empty file is the shape a
+  # silently-failed dump takes, and publishing it would overwrite a good asset
+  # from an earlier run with nothing — a backup that destroys its predecessor.
+  if [ ! -s "$file" ]; then
+    _ra_err "release asset '$file' is missing or empty — refusing to publish"
+    return 1
+  fi
+
+  if ! release_gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+    local create_err
+    if ! create_err=$(release_gh release create "$tag" --repo "$repo" \
+        --title "$tag" \
+        --notes "Automated backup artifacts. Binary object-store archives are attached as release assets rather than committed, so retention is a real delete and the 100 MiB per-file git limit does not apply." 2>&1); then
+      _ra_err "failed to create release '$tag': $create_err"
+      return 1
+    fi
+    _ra_log "created release $tag"
+  fi
+
+  local upload_err
+  if ! upload_err=$(release_gh release upload "$tag" "$file" --repo "$repo" --clobber 2>&1); then
+    _ra_err "failed to upload '$(basename "$file")' to release '$tag': $upload_err"
+    return 1
+  fi
+
+  _ra_log "published $(basename "$file") ($(du -h "$file" | cut -f1)) to release $tag"
+}
+
+# release_prune <repo> <tag-prefix> <keep>
+# Deletes releases whose tag starts with TAG-PREFIX, keeping the newest KEEP.
+# Tags are expected to carry an ISO date suffix, so a lexical sort is a date
+# sort — `gh release list` orders by creation time, which is NOT the same
+# thing once a backfilled or re-run release exists.
+release_prune() {
+  local repo=$1 prefix=$2 keep=$3
+
+  # Fail closed on a non-positive-integer retention. A garbage value would
+  # compute `tail -n +1` and queue EVERY release for deletion — the entire
+  # recovery window, unattended.
+  case "$keep" in
+    '' | *[!0-9]*)
+      _ra_err "release retention '$keep' is not a non-negative integer — using 7"
+      keep=7
+      ;;
+  esac
+  if [ "$keep" -lt 1 ]; then
+    _ra_err "release retention $keep < 1 would delete ALL releases — using 7"
+    keep=7
+  fi
+
+  local listing
+  if ! listing=$(release_gh release list --repo "$repo" --limit 200 \
+                   --json tagName --jq '.[].tagName' 2>&1); then
+    _ra_err "release retention: list failed — pruning SKIPPED this run (retries next run): $listing"
+    _ra_alert "$(printf '<b>Backup Retention Warning</b>\nRelease listing failed; object-store asset pruning skipped this run. Storage growth may resume until the next successful run.')"
+    return 0
+  fi
+
+  # Prefix-match with a glob, not a regex — the prefix is caller-supplied and
+  # must not be interpreted as a pattern.
+  local matched="" tag
+  while IFS= read -r tag; do
+    [ -n "$tag" ] || continue
+    case "$tag" in
+      "${prefix}"*) matched="${matched}${tag}"$'\n' ;;
+    esac
+  done <<< "$listing"
+
+  local old
+  old=$(printf '%s' "$matched" | grep -v '^$' | sort -ru | tail -n +$((keep + 1)))
+  [ -n "$old" ] || return 0
+
+  local del_count
+  del_count=$(printf '%s\n' "$old" | wc -l | tr -d ' ')
+
+  # Blast-radius cap. Steady state deletes 0-1 releases; an implausibly large
+  # batch means the listing or the parse went wrong, and executing it would
+  # vacuum the recovery window in one unattended cron tick.
+  local ceiling=${RELEASE_DELETE_CEILING:-30}
+  case "$ceiling" in
+    '' | *[!0-9]*) ceiling=30 ;;
+  esac
+  [ "$ceiling" -lt 1 ] && ceiling=30
+  if [ "$del_count" -gt "$ceiling" ]; then
+    _ra_err "release retention: $del_count releases queued for delete exceeds ceiling $ceiling — REFUSING (likely a bad listing parse), nothing deleted"
+    _ra_alert "$(printf '<b>Backup Retention BLOCKED</b>\n%s release(s) queued for delete (ceiling %s) — refused as a likely parse error; nothing deleted.' "$del_count" "$ceiling")"
+    return 0
+  fi
+
+  local del_fail=0 del_err last_err=""
+  while IFS= read -r tag; do
+    [ -n "$tag" ] || continue
+    # Capture stderr: a failed remote delete's WHY (auth revoked, protected
+    # ref, network) is the diagnostic and must reach the log, not /dev/null.
+    if ! del_err=$(release_gh release delete "$tag" --repo "$repo" --yes --cleanup-tag 2>&1); then
+      del_fail=$((del_fail + 1))
+      last_err="$del_err"
+      _ra_err "release retention: failed to delete '$tag': $del_err"
+    fi
+  done <<< "$old"
+
+  if [ "$del_fail" -eq 0 ]; then
+    _ra_log "release retention: kept newest $keep, pruned $del_count old release(s)"
+  else
+    _ra_err "release retention: $del_fail of $del_count releases not deleted (non-fatal, retried next run)"
+    _ra_alert "$(printf '<b>Backup Retention Warning</b>\nRelease delete failed for %s of %s; object-store pruning incomplete this run. Last error: %s' "$del_fail" "$del_count" "$last_err")"
+  fi
+}

--- a/scripts/test-release-assets.sh
+++ b/scripts/test-release-assets.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Tests for lib/release-assets.sh — the storage tier for LARGE BINARY backup
+# artifacts (MinIO object-store tarballs).
+#
+# Every GitHub call in the lib funnels through the `release_gh` indirection,
+# which these tests stub. That keeps the suite hermetic: no token, no network,
+# no mutation of a real repo — while still exercising the real control flow,
+# including the fail-closed guards that gate a DESTRUCTIVE remote delete.
+#
+# The guards mirror prune_repo_history_if_needed's, which were established over
+# 7 cage-match rounds in #141. Same invariants, same failure modes, so they are
+# asserted here rather than re-derived: a non-integer retention must not compute
+# a delete-everything window, and an implausibly large batch must be refused
+# rather than executed unattended.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/release-assets.sh
+. "$SCRIPT_DIR/lib/release-assets.sh"
+
+PASS=0
+FAIL=0
+
+# The stub records to a FILE, not a shell variable. The lib invokes release_gh
+# inside command substitutions so it can capture the API's stderr for
+# diagnostics — which means every call runs in a subshell, and a variable the
+# stub assigned there would be discarded on return. A variable-based recorder
+# silently observes NOTHING and, worse, makes every assert_not_contains pass
+# vacuously: the suite would go green while testing nothing at all.
+GH_LOG=$(mktemp)
+trap 'rm -f "$GH_LOG"' EXIT
+calls() { cat "$GH_LOG"; }
+
+ok() { PASS=$((PASS + 1)); printf '  \033[0;32mok\033[0m %s\n' "$1"; }
+no() { FAIL=$((FAIL + 1)); printf '  \033[0;31mFAIL\033[0m %s\n     %s\n' "$1" "$2"; }
+
+assert_eq() {
+  local want="$1" got="$2" what="$3"
+  if [ "$want" = "$got" ]; then ok "$what"; else no "$what" "want [$want] got [$got]"; fi
+}
+
+assert_contains() {
+  local hay="$1" needle="$2" what="$3"
+  case "$hay" in *"$needle"*) ok "$what" ;; *) no "$what" "[$needle] not in [$hay]" ;; esac
+}
+
+assert_not_contains() {
+  local hay="$1" needle="$2" what="$3"
+  case "$hay" in *"$needle"*) no "$what" "[$needle] unexpectedly in [$hay]" ;; *) ok "$what" ;; esac
+}
+
+# --- Stub -----------------------------------------------------------------
+# Records every invocation and replies with canned output. STUB_RELEASES is
+# the fixture list of existing release tags (newest-first is NOT assumed —
+# the lib must sort, because `gh release list` orders by creation date, which
+# is not the same as the date embedded in the tag name).
+STUB_RELEASES=""
+STUB_FAIL_DELETE=""
+release_gh() {
+  printf 'gh %s\n' "$*" >> "$GH_LOG"
+  case "$1 ${2:-}" in
+    "release list")
+      printf '%s\n' "$STUB_RELEASES"
+      ;;
+    "release delete")
+      if [ -n "$STUB_FAIL_DELETE" ] && [ "$3" = "$STUB_FAIL_DELETE" ]; then
+        echo "HTTP 403: forbidden" >&2
+        return 1
+      fi
+      ;;
+    "release view")
+      # Non-zero means "release does not exist yet".
+      [ -n "$STUB_RELEASE_EXISTS" ] && return 0
+      return 1
+      ;;
+  esac
+  return 0
+}
+STUB_RELEASE_EXISTS=""
+
+reset() { : > "$GH_LOG"; STUB_RELEASES=""; STUB_FAIL_DELETE=""; STUB_RELEASE_EXISTS=""; }
+
+echo "== release_prune: keeps the newest N, deletes the rest =="
+reset
+STUB_RELEASES="objects-2026-08-01
+objects-2026-08-05
+objects-2026-08-03
+objects-2026-08-04
+objects-2026-08-02"
+release_prune "owner/repo" "objects-" 3 >/dev/null 2>&1
+# Newest three by TAG DATE are 08-05, 08-04, 08-03 — so 08-02 and 08-01 go.
+assert_contains "$(calls)" "release delete objects-2026-08-01" "deletes oldest"
+assert_contains "$(calls)" "release delete objects-2026-08-02" "deletes 2nd oldest"
+assert_not_contains "$(calls)" "release delete objects-2026-08-03" "keeps 3rd newest"
+assert_not_contains "$(calls)" "release delete objects-2026-08-05" "keeps newest"
+
+echo "== release_prune: ignores releases outside the prefix =="
+reset
+STUB_RELEASES="objects-2026-08-01
+v1.2.3
+some-other-release
+objects-2026-08-02"
+release_prune "owner/repo" "objects-" 1 >/dev/null 2>&1
+assert_contains "$(calls)" "release delete objects-2026-08-01" "prunes matching prefix"
+assert_not_contains "$(calls)" "release delete v1.2.3" "never touches unrelated release"
+assert_not_contains "$(calls)" "release delete some-other-release" "never touches unrelated tag"
+
+echo "== release_prune: fail-closed on a non-integer retention =="
+# A garbage value from a bad cron env must NOT compute tail -n +1 and delete
+# everything. It must fall back to the safe default and keep the window.
+reset
+STUB_RELEASES="objects-2026-08-01
+objects-2026-08-02"
+release_prune "owner/repo" "objects-" "garbage" >/dev/null 2>&1
+assert_not_contains "$(calls)" "release delete" "garbage retention deletes NOTHING"
+
+echo "== release_prune: fail-closed on zero retention =="
+reset
+STUB_RELEASES="objects-2026-08-01
+objects-2026-08-02"
+release_prune "owner/repo" "objects-" 0 >/dev/null 2>&1
+assert_not_contains "$(calls)" "release delete" "keep=0 deletes NOTHING"
+
+echo "== release_prune: refuses an implausibly large batch =="
+# Steady state deletes 0-1 releases. A huge batch means the listing parse went
+# wrong; executing it unattended would vacuum the whole recovery window.
+reset
+STUB_RELEASES="$(for d in $(seq -w 1 40); do echo "objects-2026-01-$d"; done)"
+out=$(RELEASE_DELETE_CEILING=5 release_prune "owner/repo" "objects-" 1 2>&1)
+assert_not_contains "$(calls)" "release delete" "over-ceiling batch deletes NOTHING"
+assert_contains "$out" "REFUSING" "over-ceiling batch reports refusal"
+
+echo "== release_prune: a failed delete is surfaced, not swallowed =="
+reset
+STUB_RELEASES="objects-2026-08-01
+objects-2026-08-02
+objects-2026-08-03"
+STUB_FAIL_DELETE="objects-2026-08-01"
+out=$(release_prune "owner/repo" "objects-" 1 2>&1)
+assert_contains "$out" "objects-2026-08-01" "failed delete names the release"
+assert_contains "$out" "403" "failed delete surfaces the API error text"
+assert_contains "$(calls)" "release delete objects-2026-08-02" "other deletes still proceed"
+
+echo "== release_prune: nothing to do is not an error =="
+reset
+STUB_RELEASES="objects-2026-08-01"
+release_prune "owner/repo" "objects-" 7 >/dev/null 2>&1
+rc=$?
+assert_eq "0" "$rc" "under-retention prune exits 0"
+assert_not_contains "$(calls)" "release delete" "under-retention deletes nothing"
+
+echo "== release_publish_asset: creates the release when absent =="
+reset
+STUB_RELEASE_EXISTS=""
+tmp=$(mktemp); echo payload > "$tmp"
+release_publish_asset "owner/repo" "objects-2026-08-09" "$tmp" >/dev/null 2>&1
+assert_contains "$(calls)" "release create objects-2026-08-09" "creates missing release"
+assert_contains "$(calls)" "release upload objects-2026-08-09" "uploads the asset"
+
+echo "== release_publish_asset: reuses an existing release =="
+reset
+STUB_RELEASE_EXISTS=1
+release_publish_asset "owner/repo" "objects-2026-08-09" "$tmp" >/dev/null 2>&1
+assert_not_contains "$(calls)" "release create" "does not recreate an existing release"
+assert_contains "$(calls)" "release upload objects-2026-08-09" "still uploads the asset"
+
+echo "== release_publish_asset: --clobber so a re-run replaces, not duplicates =="
+assert_contains "$(calls)" "--clobber" "upload is idempotent via --clobber"
+
+echo "== release_publish_asset: refuses a missing or empty file =="
+reset
+release_publish_asset "owner/repo" "objects-2026-08-09" "/nonexistent/file" >/dev/null 2>&1
+rc=$?
+assert_eq "1" "$rc" "missing file returns non-zero"
+assert_not_contains "$(calls)" "release upload" "missing file uploads NOTHING"
+
+reset
+empty=$(mktemp)
+release_publish_asset "owner/repo" "objects-2026-08-09" "$empty" >/dev/null 2>&1
+rc=$?
+assert_eq "1" "$rc" "empty file returns non-zero"
+assert_not_contains "$(calls)" "release upload" "empty file uploads NOTHING"
+rm -f "$tmp" "$empty"
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**Stacked on #144** — base is `fix/radicale-cross-tenant-backup` (needs `resolve_container_by_compose`). Merge #144 first; this retargets to `main` automatically.

## The gap

imagineering's MinIO object store has **never been backed up**. Verified on the box today:

```
imagineering-outline_minio_data → 52 MB
  kanbn-attachments / kanbn-avatars / outline / .minio.sys
```

The pg_dumps *reference* those objects. Restoring without them gives Outline docs with broken image embeds and Kan.bn cards with dead attachment links — a restore that reports success and silently isn't. xdeca has the identical gap (peer repo, task tracked separately).

## Why release assets, not the tree

| | committed blob | release asset |
|---|---|---|
| Retention | history rewrite (`prune_repo_history_if_needed`) | real DELETE, `--cleanup-tag` removes the tag too |
| Per-file cap | **100 MiB, hard push rejection** | not a constraint at our size |
| History | rewritten, force-pushed | append-only |

At 52 MB per tenant the 100 MiB cap is a live risk, not hypothetical. And the archive tags this repo already carries reached **4.37 GB across 45 tags**, pinning the very blobs the prune removed — release assets don't create that class.

## Verified against the real API, not just stubs

Probe releases created and cleaned up: create · upload · `--clobber` idempotency · empty-artifact refusal · prune keeps newest N · tag removed on delete.

**The live probe caught a bug the 25 stubbed assertions could not.** The logging fallback used `declare -F log` — which in zsh declares a *float* rather than testing for a function — and `log` is a zsh **builtin**, so the call silently resolved to that builtin instead of failing. A stub that's more forgiving than reality is how green tests lie; the lib now uses prefixed internal helpers and delegates only when demonstrably in bash.

## Implementation notes

- **Sidecar, not `docker exec`.** `minio/minio` ships `mc` and no `tar`, so `docker exec <minio> tar` dies under `set -e` with no message, leaving a plausible file containing the runtime's error text. Reads the volume via a throwaway `alpine` with `:ro`.
- **Content gate, not readability gate.** `.minio.sys` must be present (bucket policies — without it a restored bucket 403s) plus at least one bucket.
- **Lists to a file before grepping.** `tar tzf | grep -q` under `pipefail` is a false-negative trap: grep exits early, tar takes SIGPIPE, pipeline reports failure on a good archive.
- **Missing token fails LOUDLY.** A silent skip is how the object store went unbacked for the project's entire history. An absent credential must look like a failure, not a successful smaller run.
- Guards mirror `prune_repo_history_if_needed`'s (#141, 7 rounds): validated retention integer, blast-radius ceiling, stderr captured, per-item loop.

## Deploy plumbing

`github_release_token` added to `backups/secrets.yaml` (SOPS, ciphertext verified — 0 plaintext occurrences). `deploy-to.sh` installs `/etc/imagineering-secrets/github-release.env` at 0640 root:nick using the same build-locally/scp/install shape as the telegram block, and installs `gh` (not currently on the box).

## Gates

1. #144 merges first
2. Your review here
3. Deploy `scripts/` to the box
4. Verify tomorrow's 04:00 run publishes an `objects-YYYY-MM-DD` release

## Token housekeeping

The PAT's lifetime is >366 days, which `enspyrco` org policy forbids (`imagineering-cc` doesn't enforce it, so it works). It was also pasted into a chat transcript. Both are fixed by one rotation once this is verified working — I'll do that on your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PA85fPreJNpA8uMRpTpKja