### PR TITLE
fix(edf): emit KAN_* into the dreamfinder-avatar .env

### DIFF
--- a/scripts/deploy-to.sh
+++ b/scripts/deploy-to.sh
@@ -819,6 +819,12 @@ deploy_embodied_dreamfinder() {
         printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n'     "$(dotenv_quote "$(edf_field '.claude_code_oauth_token')")"
         printf 'VOICE_MODE=%s\n'            "$(dotenv_quote "$(edf_field '.voice_mode' 'realtime')")"
         printf 'OUTLINE_API_KEY=%s\n'       "$(dotenv_quote "$(edf_field '.outline_api_key')")"
+        # KAN_BASE_URL also has a compose default, but KAN_API_KEY/KAN_BOARD_ID
+        # do not — without these the container gets empty strings and the voice
+        # Kan-board tool (/api/kan/board-summary) fails silently.
+        printf 'KAN_BASE_URL=%s\n'          "$(dotenv_quote "$(edf_field '.kan_base_url')")"
+        printf 'KAN_API_KEY=%s\n'           "$(dotenv_quote "$(edf_field '.kan_api_key')")"
+        printf 'KAN_BOARD_ID=%s\n'          "$(dotenv_quote "$(edf_field '.kan_board_id')")"
         printf 'RADICALE_CALENDAR_URL=%s\n' "$(dotenv_quote "$(edf_field '.radicale_calendar_url')")"
         printf 'RADICALE_USERNAME=%s\n'     "$(dotenv_quote "$(edf_field '.radicale_username')")"
         printf 'RADICALE_PASSWORD=%s\n'     "$(dotenv_quote "$(edf_field '.radicale_password')")"


### PR DESCRIPTION
Closes the diagnosis in claude-tasks#2100.

## The bug
`deploy_embodied_dreamfinder()`'s .env generator emitted no `KAN_API_KEY` / `KAN_BOARD_ID`. The container got empty strings, so `/api/kan/board-summary` (the voice Kan-board tool) failed silently, and every deploy logged two `variable is not set` warnings.

## Why it looked fixed
`grep KAN scripts/deploy-to.sh` returns 3 hits — but they are in the **pm_bot** (739-740) and **tech-world-bots** (982-984) generators, not edf. Easy false negative.

## The fix
Three `printf` lines in the edf generator, copied verbatim from the working tech-world-bots pattern. `KAN_BASE_URL` is included so the .env is the single source for all three rather than relying on the compose default for one.

## Premise verified
`sops -d dreamfinder-avatar/secrets.yaml` carries `kan_base_url`, `kan_api_key`, `kan_board_id` (key names checked, values never printed). No new credentials.

`bash -n` clean.

## ⚠️ Gate: not deployed
Merging does not fix production. After merge: redeploy edf, then verify container env lengths are non-zero, the two compose warnings are gone, and board-summary returns data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)