### PR TITLE
chore(avatar-deploy): put the avatar deploy substrate in a repo (task #10 CRUX)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
         with:
           scandir: './scripts'
           additional_files: '.githooks/pre-commit'
@@ -24,7 +24,7 @@ jobs:
       # scripts; scandir above only covers ./scripts, so lint cd-bus/ too —
       # otherwise "Shell Linting" would be green while not covering them.
       - name: Run ShellCheck (cd-bus)
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
         with:
           scandir: './cd-bus'
           severity: warning
@@ -38,7 +38,7 @@ jobs:
       # without its own step "Shell Linting" would be green while blind to the
       # scripts that can roll production back onto a vulnerable image.
       - name: Run ShellCheck (avatar-deploy)
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
         with:
           scandir: './avatar-deploy'
           severity: warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ jobs:
           scandir: './cd-bus'
           severity: warning
 
+      # The avatar deploy/rollback substrate (avatar-deploy/bin/) lived only in
+      # ~/bin on the production box until 2026-08-10 and was never linted. The
+      # very first shellcheck run on it flagged SC2034 "IMG appears unused" —
+      # which was a real, live defect: a trailing comment had swallowed
+      # `echo "image=$IMG"`, silently dropping the image identity from every
+      # lyra release record. scandir above covers neither ./cd-bus nor this, so
+      # without its own step "Shell Linting" would be green while blind to the
+      # scripts that can roll production back onto a vulnerable image.
+      - name: Run ShellCheck (avatar-deploy)
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './avatar-deploy'
+          severity: warning
+
   yaml-lint:
     name: YAML Linting
     runs-on: ubuntu-latest

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -73,16 +73,39 @@ The keys themselves stay on the box and are not in this repo.
 
 There is no automation for this yet; that is the point of the next section. By hand:
 
+**Diff before you overwrite `~/.ssh/config`.** That file is a full-file clobber, and
+the tracked version contains only `Include config.d/*` plus the `github-dreamfinder`
+block. Any `Host` block that exists on the box but never made it into this repo is
+**destroyed** by a naive `scp` — and `verify-matches-box.sh` will then report the box
+and repo as matching, because they will. That is the exact dual of the outage that
+prompted this directory: lyra broke because an alias was *absent*, and this would
+break something by making an alias absent. New host blocks belong in `ssh/config.d/`,
+which is additive.
+
 ```bash
 # from the repo root
+
+# 1. See what the box has that the repo doesn't, BEFORE writing anything.
+ssh imagineering 'cat ~/.ssh/config' | diff - avatar-deploy/ssh/config || true
+ssh imagineering 'ls ~/.ssh/config.d/' | diff - <(ls avatar-deploy/ssh/config.d/) || true
+#    Anything only on the box: import it here first, or you are about to delete it.
+
+# 2. Scripts are safe to push as a set — nothing on the box is authoritative there
+#    any more, and flip-brain-api.sh was deliberately removed (see below).
 scp avatar-deploy/bin/*.sh imagineering:~/bin/
+
+# 3. ssh config, once step 1 is clean.
 scp avatar-deploy/ssh/config imagineering:~/.ssh/config
 scp avatar-deploy/ssh/config.d/* imagineering:~/.ssh/config.d/
 ssh imagineering 'chmod 700 ~/bin/*.sh && chmod 600 ~/.ssh/config ~/.ssh/config.d/*'
 
-# then confirm the box matches the repo
+# 4. Confirm the box matches the repo.
 ./avatar-deploy/bin/verify-matches-box.sh
 ```
+
+Note that `verify-matches-box.sh` answers "are these bytes the same", not "is this
+right". It cannot tell you that a block you just deleted used to be load-bearing.
+Step 1 is the part that protects you; step 4 only confirms the copy landed.
 
 ## What stays on the box (deliberately)
 
@@ -128,6 +151,15 @@ deferred on purpose, with the reason — not overlooked. They are tracked as tas
   pass green on dreamfinder and dispatch load-balances across duplicates. Same
   reasoning as above: aligning it arms a new auto-rollback trigger pre-rehearsal.
   The misleading "exactly-one" comment is corrected in this PR; the gate is not.
+- **lyra's deploy mutates the live tree before any rollback is armed.**
+  `deploy-lyra-avatar.sh` checks out `$SHA` into `src/` — which *is* the running
+  code, via the bind mount — before `rollback()` is even defined, and then builds.
+  A build failure aborts under `set -e` with the tree already advanced. The live
+  container keeps serving the old code from memory, so the site stays up; but the
+  disk now holds an unbuilt release, and the next restart for any reason brings it
+  up. A latent armed state rather than an outage. The real fix is to stage the
+  checkout in a git worktree and swap only at cutover, which is a redesign of the
+  deploy shape, not a patch — it belongs with inverting the authority.
 - **The shellcheck action is pinned to `@master`.** `ludeeus/action-shellcheck@master`
   now lints the scripts that can roll production onto a vulnerable image, on a
   floating ref. Real supply-chain exposure, but it is the existing convention for

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -137,29 +137,19 @@ State and secrets, never source:
 These came in with the verbatim import and are still live on the box. Each is
 deferred on purpose, with the reason — not overlooked. They are tracked as tasks.
 
-- **Neither deploy script has a rollback trap.** `rollback()` is defined after the
-  cutover, and the scripts run under `set -euo pipefail`. A failure in the *gate
-  scaffolding* itself (a `docker inspect` name mismatch, an unexpected `StartedAt`
-  shape, a compose service rename) exits the script without ever calling
-  `rollback()` — after `docker compose up -d` has already gone live. Gate *logic*
-  failures roll back; gate *scaffolding* failures leave the new release running
-  unverified. Fixing this means arming an `ERR` trap that fires a rollback path
-  that has never been rehearsed, which is the same shape as the incident that
-  started all this. It waits for the rehearsal.
+Three items that used to sit on this list were fixed instead, once they had been
+raised in every review round and the deferral reasoning stopped holding up: the
+missing `ERR` trap (a scaffolding failure after cutover left production unverified
+with *no* recovery, which is strictly worse than a possibly-spurious rollback), the
+floating `@master` on the shellcheck action, and lyra's deploy mutating the tree
+before `rollback()` was in scope.
+
 - **dreamfinder's worker-registration gate is lower-bound only** (`-ge 1`), while
   lyra enforces both bounds and rolls back on a ghost worker. Two registrations
-  pass green on dreamfinder and dispatch load-balances across duplicates. Same
-  reasoning as above: aligning it arms a new auto-rollback trigger pre-rehearsal.
-  The misleading "exactly-one" comment is corrected in this PR; the gate is not.
-- **lyra's deploy mutates the live tree before any rollback is armed.**
-  `deploy-lyra-avatar.sh` checks out `$SHA` into `src/` — which *is* the running
-  code, via the bind mount — before `rollback()` is even defined, and then builds.
-  A build failure aborts under `set -e` with the tree already advanced. The live
-  container keeps serving the old code from memory, so the site stays up; but the
-  disk now holds an unbuilt release, and the next restart for any reason brings it
-  up. A latent armed state rather than an outage. The real fix is to stage the
-  checkout in a git worktree and swap only at cutover, which is a redesign of the
-  deploy shape, not a patch — it belongs with inverting the authority.
+  pass green on dreamfinder and dispatch load-balances across duplicates. Aligning
+  it arms a new auto-rollback trigger on a path that has never been rehearsed, so it
+  waits for task #12. The misleading "exactly-one" comment is corrected here; the
+  gate is not.
 - **lyra's freeze is a first-run snapshot while `PREV_SHA` advances every deploy.**
   `env.file`, `docker-compose.yml` and the `pre-traversal-fix` image tag are all
   written only if absent, so they are frozen at whatever the first run saw, while
@@ -187,12 +177,6 @@ deferred on purpose, with the reason — not overlooked. They are tracked as tas
   a whole-line match is feasible. Deliberately not done here: a false RED on this
   gate fires the auto-rollback, which is the failure mode we are most afraid of, and
   it cannot be tested without a live deploy. Sequence it with the rehearsal.
-- **The shellcheck action is pinned to `@master`.** `ludeeus/action-shellcheck@master`
-  now lints the scripts that can roll production onto a vulnerable image, on a
-  floating ref. Real supply-chain exposure, but it is the existing convention for
-  every shellcheck step in this repo (`./scripts`, `./cd-bus`), so pinning only the
-  new one would be worse than either consistent state. Repo-wide decision, not this
-  PR's — tracked separately.
 - **`Host github-lyra` points at `IdentityFile ~/.ssh/embodied-lyra-deploy`.** Fossil
   naming from before the repo rename, on a load-bearing key path. Renaming the key
   is a box mutation, not a repo change, and at 3am a mismatched name reads as a

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -56,11 +56,10 @@ happened, all traceable to that:
 ```
 avatar-deploy/
 ├── bin/
-│   ├── deploy-dreamfinder-avatar.sh    5 gates, auto-rollback on any failure
+│   ├── deploy-dreamfinder-avatar.sh    4 gates, auto-rollback on any failure
 │   ├── deploy-lyra-avatar.sh           5 gates, incl. in-container allowlist assert
 │   ├── rollback-dreamfinder-avatar.sh  QUAD rollback: image + env + compose + worker
 │   ├── rollback-lyra-avatar.sh         QUAD rollback: TREE first, then image + env + worker
-│   ├── flip-brain-api.sh               brain endpoint toggle
 │   └── verify-matches-box.sh           drift check: repo vs ~/bin and ~/.ssh on the box
 └── ssh/
     ├── config                          github-dreamfinder alias + Include config.d/*
@@ -109,6 +108,38 @@ State and secrets, never source:
    It must run **off-loopback**: `LOCALHOST_IPS` in `lib/scope.js` grants base scope, so a
    probe from the box returns 200 and reads as a false green. A probe holding a privilege
    the real caller lacks does not measure the real path.
+
+## Known-live inherited defects (found by review, deliberately NOT fixed here)
+
+These came in with the verbatim import and are still live on the box. Each is
+deferred on purpose, with the reason — not overlooked. They are tracked as tasks.
+
+- **Neither deploy script has a rollback trap.** `rollback()` is defined after the
+  cutover, and the scripts run under `set -euo pipefail`. A failure in the *gate
+  scaffolding* itself (a `docker inspect` name mismatch, an unexpected `StartedAt`
+  shape, a compose service rename) exits the script without ever calling
+  `rollback()` — after `docker compose up -d` has already gone live. Gate *logic*
+  failures roll back; gate *scaffolding* failures leave the new release running
+  unverified. Fixing this means arming an `ERR` trap that fires a rollback path
+  that has never been rehearsed, which is the same shape as the incident that
+  started all this. It waits for the rehearsal.
+- **dreamfinder's worker-registration gate is lower-bound only** (`-ge 1`), while
+  lyra enforces both bounds and rolls back on a ghost worker. Two registrations
+  pass green on dreamfinder and dispatch load-balances across duplicates. Same
+  reasoning as above: aligning it arms a new auto-rollback trigger pre-rehearsal.
+  The misleading "exactly-one" comment is corrected in this PR; the gate is not.
+- **`dreamfinder-avatar-app:pre-engine` is a one-way ratchet.** The anchor is only
+  tagged if absent, which correctly refuses to clobber a good freeze but means the
+  script cannot tell a *poisoned* anchor from a blessed one — and a poisoned anchor
+  is exactly what served a live auth bypass for ten minutes on 2026-08-10. It was
+  repointed by hand. A name-immortal anchor should become content-addressed, which
+  is properly part of inverting the authority (step 2 below).
+
+`flip-brain-api.sh` was imported and then **deleted** rather than deferred: it
+`cd`s to `~/apps/embodied-dreamfinder` and execs `~/bin/deploy-embodied-dreamfinder.sh`,
+and neither path exists on the box any more. Under `set -e` it dies on line 4. A
+break-glass tool that cannot break glass is worse than no tool, because someone
+reaches for it in an emergency. Its history is in this repo if it's ever wanted back.
 
 ## Known-unrehearsed
 

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -56,7 +56,7 @@ happened, all traceable to that:
 ```
 avatar-deploy/
 ├── bin/
-│   ├── deploy-dreamfinder-avatar.sh    4 gates, auto-rollback on any failure
+│   ├── deploy-dreamfinder-avatar.sh    5 gates, incl. in-container allowlist assert
 │   ├── deploy-lyra-avatar.sh           5 gates, incl. in-container allowlist assert
 │   ├── rollback-dreamfinder-avatar.sh  QUAD rollback: image + env + compose + worker
 │   ├── rollback-lyra-avatar.sh         QUAD rollback: TREE first, then image + env + worker
@@ -160,16 +160,6 @@ deferred on purpose, with the reason — not overlooked. They are tracked as tas
   up. A latent armed state rather than an outage. The real fix is to stage the
   checkout in a git worktree and swap only at cutover, which is a redesign of the
   deploy shape, not a patch — it belongs with inverting the authority.
-- **dreamfinder has no gate 5, and dreamfinder is where the hole actually bled.**
-  lyra's deploy closes with an in-container `isRendererAsset` assert against the
-  traversal vectors; dreamfinder stops at four gates. The 2026-08-10 bleed was
-  `df.imagineering.cc/avatars/../server.js`. This PR fixed the false-RED that
-  *reopened* the hole (StartedAt, `--force-recreate`) and never added the
-  instrument that would refuse a false-GREEN *while the hole is open*. Health and
-  banner can both sing while the allowlist is broken. Adding it is new gate
-  functionality against a differently-shaped image (dreamfinder bakes source in
-  rather than bind-mounting), not a fix to anything this PR changed — but it is
-  the most valuable single thing left on this list.
 - **lyra's freeze is a first-run snapshot while `PREV_SHA` advances every deploy.**
   `env.file`, `docker-compose.yml` and the `pre-traversal-fix` image tag are all
   written only if absent, so they are frozen at whatever the first run saw, while

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -128,6 +128,16 @@ deferred on purpose, with the reason — not overlooked. They are tracked as tas
   pass green on dreamfinder and dispatch load-balances across duplicates. Same
   reasoning as above: aligning it arms a new auto-rollback trigger pre-rehearsal.
   The misleading "exactly-one" comment is corrected in this PR; the gate is not.
+- **The shellcheck action is pinned to `@master`.** `ludeeus/action-shellcheck@master`
+  now lints the scripts that can roll production onto a vulnerable image, on a
+  floating ref. Real supply-chain exposure, but it is the existing convention for
+  every shellcheck step in this repo (`./scripts`, `./cd-bus`), so pinning only the
+  new one would be worse than either consistent state. Repo-wide decision, not this
+  PR's — tracked separately.
+- **`Host github-lyra` points at `IdentityFile ~/.ssh/embodied-lyra-deploy`.** Fossil
+  naming from before the repo rename, on a load-bearing key path. Renaming the key
+  is a box mutation, not a repo change, and at 3am a mismatched name reads as a
+  config bug rather than as history. Left as-is, named here so it doesn't surprise.
 - **`dreamfinder-avatar-app:pre-engine` is a one-way ratchet.** The anchor is only
   tagged if absent, which correctly refuses to clobber a good freeze but means the
   script cannot tell a *poisoned* anchor from a blessed one — and a poisoned anchor

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -160,6 +160,19 @@ deferred on purpose, with the reason — not overlooked. They are tracked as tas
   up. A latent armed state rather than an outage. The real fix is to stage the
   checkout in a git worktree and swap only at cutover, which is a redesign of the
   deploy shape, not a patch — it belongs with inverting the authority.
+- **A deploy always execs `$HOME/bin/rollback-*.sh`, by absolute path.** Correct
+  while the box is the source of truth, but it means a PARTIAL install — new deploy
+  script, stale rollback script — silently couples a new gate narrative to an old
+  recovery path. `verify-matches-box.sh` will report the drift if someone runs it;
+  nothing enforces that they do. The seam closes when the deploy comes from CI as
+  an atomic set. Named here so the inversion work knows to look at it.
+- **lyra's banner gate tests PRESENCE (`grep -F`), dreamfinder's tests EQUALITY.**
+  Presence is the weaker instrument — a substring collision would be a false GREEN
+  on the gate that once reopened the hole. Verified on the box that lyra's contract
+  (`Auth enabled — password required`) does appear as a bare line, so tightening to
+  a whole-line match is feasible. Deliberately not done here: a false RED on this
+  gate fires the auto-rollback, which is the failure mode we are most afraid of, and
+  it cannot be tested without a live deploy. Sequence it with the rehearsal.
 - **The shellcheck action is pinned to `@master`.** `ludeeus/action-shellcheck@master`
   now lints the scripts that can roll production onto a vulnerable image, on a
   floating ref. Real supply-chain exposure, but it is the existing convention for

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -1,0 +1,119 @@
+# avatar-deploy
+
+The deploy and rollback substrate for the two avatar sites on the shared Sydney box.
+
+| Site | URL | App dir on box | Port | Deploy unit |
+|---|---|---|---|---|
+| dreamfinder-avatar | df.imagineering.cc | `~/apps/dreamfinder-avatar` | 3015 | image (source baked in) |
+| lyra-avatar | lyra.imagineering.cc | `~/apps/lyra-avatar` | 3017 | src TREE (compose bind-mounts `./src:/app`) |
+
+Consumers live in `imagineering-cc/dreamfinder-avatar` and `imagineering-cc/lyra-avatar`;
+both vendor `enspyrco/avatar-engine` as an `engine/` subtree.
+
+## Status: this directory is NOT yet authoritative
+
+Read this before trusting anything here.
+
+These files are a **tracked copy** of what currently lives in `~/bin/` and `~/.ssh/` on
+`ssh imagineering` (149.118.69.221). **The box is still the source of truth.** Nothing
+deploys from this repo. Editing a file here changes nothing in production until someone
+copies it up by hand.
+
+That inversion is the actual problem and it is the next piece of work — see
+"Where this is going" below. Until it lands, the honest description of this directory is:
+a snapshot that makes the substrate reviewable, not a substrate that runs.
+
+**If you change something on the box, mirror it here in the same session.** A tracked copy
+that silently drifts is worse than no copy, because it invites people to read it as truth.
+`bin/verify-matches-box.sh` exists to catch exactly that drift.
+
+## Why it was imported
+
+For roughly a year this path had no repo, no review and no history — ~370 lines of bash
+hand-edited in place on a production host. The import is a response to four things that
+happened, all traceable to that:
+
+- **lyra ran a month unpatched.** `~/.ssh/config` had no `github-lyra` block, so every
+  fetch on the box died at name resolution and `~/apps/lyra-avatar/src` sat frozen at
+  `2e3f109` (2026-07-14). Nothing in any repo recorded the alias→key map, which is
+  precisely why its absence was invisible for a month.
+- **An untracked gate reopened a live vulnerability.** `docker logs --since 3m` was used
+  as a proxy for "this boot". A no-op deploy (cached image → no recreate) returned an
+  empty window, the gate declared a contract violation, and the auto-rollback reverted
+  production onto a 4-week-old image with the path-traversal auth bypass still in it.
+  `df.imagineering.cc/avatars/../server.js` served 200 for ~10 minutes. It was caught by a
+  human noticing `docker ps` said "Up 5 minutes".
+- **Four more defects went into these scripts in a single afternoon** — stale gate vectors
+  that would have rolled lyra back, a shell-quoting crash, and a self-overwriting rollback
+  anchor. None exotic. All four would have been caught by review.
+- **A fifth defect was found by the import itself, within minutes.** A trailing `#` comment
+  swallowed `echo "image=$IMG"`, silently dropping the image identity from every lyra
+  release record. `shellcheck` flags it for free as `SC2034: IMG appears unused` — see the
+  git history of `bin/deploy-lyra-avatar.sh` for the before and after.
+
+## Layout
+
+```
+avatar-deploy/
+├── bin/
+│   ├── deploy-dreamfinder-avatar.sh    5 gates, auto-rollback on any failure
+│   ├── deploy-lyra-avatar.sh           5 gates, incl. in-container allowlist assert
+│   ├── rollback-dreamfinder-avatar.sh  QUAD rollback: image + env + compose + worker
+│   ├── rollback-lyra-avatar.sh         QUAD rollback: TREE first, then image + env + worker
+│   ├── flip-brain-api.sh               brain endpoint toggle
+│   └── verify-matches-box.sh           drift check: repo vs ~/bin and ~/.ssh on the box
+└── ssh/
+    ├── config                          github-dreamfinder alias + Include config.d/*
+    └── config.d/                       github-lyra, and the two backup aliases
+```
+
+`ssh/` carries **no key material** — hostnames, usernames and `IdentityFile` *paths* only.
+The keys themselves stay on the box and are not in this repo.
+
+## Installing to the box
+
+There is no automation for this yet; that is the point of the next section. By hand:
+
+```bash
+# from the repo root
+scp avatar-deploy/bin/*.sh imagineering:~/bin/
+scp avatar-deploy/ssh/config imagineering:~/.ssh/config
+scp avatar-deploy/ssh/config.d/* imagineering:~/.ssh/config.d/
+ssh imagineering 'chmod 700 ~/bin/*.sh && chmod 600 ~/.ssh/config ~/.ssh/config.d/*'
+
+# then confirm the box matches the repo
+./avatar-deploy/bin/verify-matches-box.sh
+```
+
+## What stays on the box (deliberately)
+
+State and secrets, never source:
+
+| Path | What |
+|---|---|
+| `~/apps/*/DEPLOY_SHA` | the pinned deploy target |
+| `~/apps/*/BOOT_CONTRACT` | the exact expected boot-banner line |
+| `~/apps/*/.env` | secrets |
+| `~/demo-freeze/`, `~/lyra-freeze/` | rollback anchors (`PREV_SHA`, `env.file`, compose) and `deployed.txt` |
+| `~/.ssh/*-deploy` | the private keys the aliases point at |
+
+## Where this is going
+
+1. ~~Import verbatim so the substrate is reviewable.~~ (this PR)
+2. **Invert the direction of authority.** Deploy the scripts *from CI* so the repo is the
+   source and the box is downstream. Until that lands, every improvement to the deploy path
+   is another artisanal edit — including the ones in this PR.
+3. **Alerting.** There is currently none on either site. The regression above was caught by
+   eyeball. The first canary is an off-box `curl --path-as-is` probe of
+   `/avatars/../server.js` and `/avatars/%252e%252e/server.js` on both hosts, expecting 303.
+   It must run **off-loopback**: `LOCALHOST_IPS` in `lib/scope.js` grants base scope, so a
+   probe from the box returns 200 and reads as a false green. A probe holding a privilege
+   the real caller lacks does not measure the real path.
+
+## Known-unrehearsed
+
+**Both rollback paths changed on 2026-08-10 and neither has ever been run.** dreamfinder's
+`pre-engine` image anchor was repointed (the old one predated the security fix and reopened
+a live hole when it fired); lyra's rollback is a different shape entirely, restoring the src
+tree rather than the image. Rolling either back is safe with respect to the traversal hole —
+both anchors carry the fix and were checked on 2026-08-10 — but "safe" is not "rehearsed".

--- a/avatar-deploy/README.md
+++ b/avatar-deploy/README.md
@@ -160,6 +160,30 @@ deferred on purpose, with the reason — not overlooked. They are tracked as tas
   up. A latent armed state rather than an outage. The real fix is to stage the
   checkout in a git worktree and swap only at cutover, which is a redesign of the
   deploy shape, not a patch — it belongs with inverting the authority.
+- **dreamfinder has no gate 5, and dreamfinder is where the hole actually bled.**
+  lyra's deploy closes with an in-container `isRendererAsset` assert against the
+  traversal vectors; dreamfinder stops at four gates. The 2026-08-10 bleed was
+  `df.imagineering.cc/avatars/../server.js`. This PR fixed the false-RED that
+  *reopened* the hole (StartedAt, `--force-recreate`) and never added the
+  instrument that would refuse a false-GREEN *while the hole is open*. Health and
+  banner can both sing while the allowlist is broken. Adding it is new gate
+  functionality against a differently-shaped image (dreamfinder bakes source in
+  rather than bind-mounting), not a fix to anything this PR changed — but it is
+  the most valuable single thing left on this list.
+- **lyra's freeze is a first-run snapshot while `PREV_SHA` advances every deploy.**
+  `env.file`, `docker-compose.yml` and the `pre-traversal-fix` image tag are all
+  written only if absent, so they are frozen at whatever the first run saw, while
+  the tree anchor moves. A rollback therefore restores the *immediately previous
+  tree* alongside *first-run* image/env/compose. The script itself notes the image
+  carries node_modules, ENV and CMD, so a future deploy with a dependency or config
+  change rolls back into a combination that never existed. Four legs, not one
+  state. The fix is a coherent per-release freeze tuple, which is a redesign of the
+  freeze model.
+- **The retry path and the escape path are the same wire.** When `PREV_SHA == $SHA`
+  the tree anchor is correctly left alone, but the deploy still recreates and still
+  auto-rolls-back on a flaky gate — to `PREV_SHA`, which is now an *older* release
+  than the one being re-verified. "Run the deploy again at the current SHA" is not
+  a closed loop.
 - **A deploy always execs `$HOME/bin/rollback-*.sh`, by absolute path.** Correct
   while the box is the source of truth, but it means a PARTIAL install — new deploy
   script, stale rollback script — silently couples a new gate narrative to an old

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -81,7 +81,14 @@ for V in VOICE_MODE BRAIN STT TTS BRAIN_MODEL CLAUDE_CODE_OAUTH_TOKEN; do
 done
 echo "gate 3/4 printenv OK"
 
-# --- 8. gate: exactly-one worker registered as dreamfinder ---
+# --- 8. gate: AT LEAST ONE worker registered as dreamfinder ---
+# NOTE the asymmetry with lyra, which also enforces an UPPER bound and rolls back
+# on a ghost worker. This gate is lower-bound only; two registrations pass green
+# here and dispatch then load-balances across duplicates. The comment used to read
+# "exactly-one", which described an enforcement that was never written.
+# Deliberately NOT aligned in this PR: arming a new auto-rollback trigger on a
+# script whose rollback path has never once been rehearsed is how the 2026-08-10
+# regression happened. Align it after the rehearsal — see the follow-up task.
 REG=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -ci "registered worker" || true)
 [ "$REG" -ge 1 ] || rollback "no worker registration in logs"
 echo "gate 4/4 worker registered (lines: $REG)"

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -52,7 +52,7 @@ rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-dreamf
 
 # --- 5. gate: health ---
 ok=""
-for i in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && { ok=1; break; }; sleep 2; done
+for _ in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && { ok=1; break; }; sleep 2; done
 [ -n "$ok" ] || rollback "health"
 echo "gate 1/4 health OK"
 

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -17,6 +17,10 @@ APP_DIR="$HOME/apps/dreamfinder-avatar"
 SRC_DIR="$APP_DIR/src"
 REPO_URL="git@github-dreamfinder:imagineering-cc/dreamfinder-avatar.git"
 FREEZE="$HOME/demo-freeze"
+# mkdir -p, matching lyra. Without it the deploy can pass all five gates and then
+# die on the record step, leaving a green release with no identity file — a
+# scaffolding failure after live mutation, the class this script keeps meeting.
+mkdir -p "$FREEZE"
 cd "$APP_DIR"
 
 SHA=$(cat "$APP_DIR/DEPLOY_SHA")          # pinned — never a floating branch
@@ -56,6 +60,17 @@ docker image inspect dreamfinder-avatar-app:pre-engine >/dev/null 2>&1 \
 # --- 3. build while the old container still serves ---
 docker compose -f docker-compose.next.yml build --pull
 
+# rollback() is defined BEFORE the cutover, not after it, so that everything from
+# the first live mutation onward has a recovery path in scope. `trap - ERR` inside
+# it disarms the trap armed below, so a failure DURING the rollback cannot re-enter
+# rollback and recurse.
+rollback() {
+  trap - ERR
+  echo "GATE FAILED: $1 — rolling back"
+  "$HOME/bin/rollback-dreamfinder-avatar.sh"
+  exit 1
+}
+
 # --- 4. ATOMIC cutover: env + compose + override flip together, then one up -d ---
 [ -f .env.next ] && [ -f docker-compose.next.yml ] || { echo "staged .env.next / docker-compose.next.yml missing"; exit 1; }
 grep -q "^BRAIN=" .env.next && grep -q "^STT=" .env.next && grep -q "^TTS=" .env.next && grep -q "^BRAIN_MODEL=" .env.next \
@@ -73,7 +88,19 @@ cp docker-compose.next.yml docker-compose.yml
 # makes "a new process started" a fact rather than an inference.
 docker compose up -d --force-recreate
 
-rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-dreamfinder-avatar.sh"; exit 1; }
+# ARM the rollback for everything after the cutover. Until now, gate LOGIC failures
+# called rollback() explicitly while gate SCAFFOLDING failures — a container rename,
+# a compose service rename, an unexpected `docker inspect` shape — exited under
+# `set -e` with the new release ALREADY LIVE and no rollback fired. The script's
+# stated contract is "ANY gate failure auto-runs the QUAD rollback"; this is what
+# makes that sentence true rather than aspirational.
+#
+# Deferred through six review rounds on the grounds that arming an unrehearsed
+# rollback is risky. That reasoning was backwards: the status quo is that a
+# scaffolding failure leaves production unverified with NO recovery at all, which is
+# strictly worse than a possibly-spurious rollback to a known-good freeze. Raised by
+# all three reviewers in every round; they were right.
+trap 'rollback "unhandled failure at line $LINENO"' ERR
 
 # --- 5. gate: health ---
 ok=""
@@ -82,7 +109,6 @@ for _ in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && { ok=1
 echo "gate 1/5 health OK"
 
 # --- 6. gate: boot-banner contract (exact line, from THIS boot) ---
-sleep 10
 
 # Anchor the log window to the dreamfinder-avatar'S OWN boot, not the wall clock.
 # A wall-clock window (`--since 3m`) is only a PROXY for "this boot", and it stops being one the moment
@@ -106,7 +132,20 @@ BOOT_SINCE=""
 [ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
 [ -n "$BOOT_SINCE" ] || rollback "cannot read dreamfinder-avatar StartedAt — the boot anchor is unavailable, so gates 2-5 cannot be trusted"
 echo "log window anchored to container boot: $BOOT_SINCE"
-BANNER=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
+# POLL for the banner rather than `sleep 10` and look once. A fixed sleep is the
+# same instrument class as the wall-clock log window in a softer register: it
+# asserts "the banner has been printed by now" using elapsed time as the proxy.
+# Under a slow voice init the banner arrives late, gate 2 reads empty, and the
+# auto-rollback fires on a perfectly good deploy — reproducing the 2026-08-10
+# topology without a single `--since 3m` left in the file. Waiting for the thing
+# itself can only ever be more patient than waiting for the clock; the deploy is
+# still bounded, it just fails on the CONTRACT rather than on the stopwatch.
+BANNER=""
+for _ in $(seq 1 30); do
+  BANNER=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
+  [ "$BANNER" = "$CONTRACT" ] && break
+  sleep 2
+done
 [ "$BANNER" = "$CONTRACT" ] || { echo "banner: [$BANNER]"; echo "expect: [$CONTRACT]"; rollback "boot-banner contract"; }
 echo "gate 2/5 contract OK: $BANNER"
 

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -46,7 +46,14 @@ cp .env.next .env
 cp docker-compose.next.yml docker-compose.yml
 # override becomes opt-in again (its true name); BRAIN=oauth must not carry the lyra key
 [ -f docker-compose.override.yml ] && mv docker-compose.override.yml docker-compose.lyra.yml.was-override
-docker compose up -d
+# --force-recreate, matching lyra's deploy and both rollbacks. The log window was
+# taught to stop proxying "this boot"; the CUTOVER was still proxying "this
+# release". When compose elects a no-op (cached image, config that happens to
+# match), the container is never recreated and gates 2-4 sample the PREVIOUS
+# incarnation under a fresh contract narrative — a false GREEN, the mirror image
+# of the false RED that caused the 2026-08-10 regression. Forcing the recreate
+# makes "a new process started" a fact rather than an inference.
+docker compose up -d --force-recreate
 
 rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-dreamfinder-avatar.sh"; exit 1; }
 

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -71,6 +71,33 @@ rollback() {
   exit 1
 }
 
+# PREFLIGHT THE FREEZE before the cutover. rollback-dreamfinder-avatar.sh
+# hard-requires env.file, docker-compose.yml, docker-compose.override.yml and the
+# pre-engine image, and exits 1 having changed NOTHING if any is absent. Without
+# this check the sequence is: cutover goes live -> a gate fails -> the auto-rollback
+# refuses to run -> the bad release stays up, while the script header promises QUAD
+# recovery. An auto-rollback is a switch; this makes sure the breaker behind it is
+# actually installed. Seed-if-absent first (matching lyra), since the correct freeze
+# content IS the pre-cutover state we are standing in right now.
+[ -f "$FREEZE/env.file" ]                       || cp .env "$FREEZE/env.file"
+[ -f "$FREEZE/docker-compose.yml" ]             || cp docker-compose.yml "$FREEZE/docker-compose.yml"
+if [ ! -f "$FREEZE/docker-compose.override.yml" ] && [ -f docker-compose.override.yml ]; then
+  cp docker-compose.override.yml "$FREEZE/docker-compose.override.yml"
+fi
+FREEZE_MISSING=""
+for f in env.file docker-compose.yml docker-compose.override.yml; do
+  [ -f "$FREEZE/$f" ] || FREEZE_MISSING="$FREEZE_MISSING $f"
+done
+docker image inspect dreamfinder-avatar-app:pre-engine >/dev/null 2>&1 \
+  || FREEZE_MISSING="$FREEZE_MISSING image:pre-engine"
+if [ -n "$FREEZE_MISSING" ]; then
+  echo "FATAL: the rollback freeze is incomplete -$FREEZE_MISSING"
+  echo "       Refusing to cut over: the auto-rollback armed below could not run,"
+  echo "       so a gate failure would leave the new release live with no recovery."
+  echo "       Nothing has been changed."
+  exit 1
+fi
+
 # --- 4. ATOMIC cutover: env + compose + override flip together, then one up -d ---
 [ -f .env.next ] && [ -f docker-compose.next.yml ] || { echo "staged .env.next / docker-compose.next.yml missing"; exit 1; }
 grep -q "^BRAIN=" .env.next && grep -q "^STT=" .env.next && grep -q "^TTS=" .env.next && grep -q "^BRAIN_MODEL=" .env.next \
@@ -249,6 +276,15 @@ console.log("allowlist: " + mustDeny.length + " denied, " + mustAllow.length + "
   + meshMustDeny.length + " denied, " + meshMustAllow.length + " allowed");
 ASSERT
 echo "gate 5/5 allowlist assert OK"
+
+# DISARM. The trap covers the window from cutover to the last gate — a failure in
+# there means the release is unverified and should be rolled back. Past this line
+# the release has PASSED all five gates, and everything remaining is bookkeeping:
+# docker inspect, a tag, writing deployed.txt. Leaving the trap armed wires the
+# record step into the recovery bus, so a full disk or a permissions slip would
+# roll back a release that was just proven good. "Any GATE failure rolls back" is
+# the contract; a bookkeeping spark is not a gate failure.
+trap - ERR
 
 # --- 9. record release identity + preserve the forward image ---
 IMG=$(docker inspect --format "{{.Image}}" dreamfinder-avatar)

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -27,7 +27,15 @@ fi
 cd "$SRC_DIR"
 git fetch origin
 git checkout -q "$SHA"
-git lfs pull
+# Guarded to match deploy-lyra-avatar.sh: an ABSENT client is skippable, an
+# INSTALLED one that fails must fail closed. A bare `git lfs pull` under `set -e`
+# turns a missing binary into a hard deploy stop, which is the opposite of the
+# sibling's behaviour on the same substrate.
+if command -v git-lfs >/dev/null 2>&1; then
+  git lfs pull
+else
+  echo "(git-lfs not installed — skipping lfs pull)"
+fi
 echo "src at: $(git log -1 --oneline)"
 cd "$APP_DIR"
 
@@ -114,6 +122,6 @@ echo "gate 4/4 worker registered (lines: $REG)"
 # --- 9. record release identity + preserve the forward image ---
 IMG=$(docker inspect --format "{{.Image}}" dreamfinder-avatar)
 docker tag dreamfinder-avatar-app:latest dreamfinder-avatar-app:post-engine
-{ echo "sha=$SHA"; echo "image=$IMG"; echo "env_md5=$(md5sum .env | cut -d" " -f1)"; echo "container=$(docker ps -qf name=dreamfinder-avatar)"; echo "date=$(date -u +%FT%TZ)"; } > "$FREEZE/deployed.txt"
+{ echo "sha=$SHA"; echo "image=$IMG"; echo "env_md5=$(md5sum .env | cut -d" " -f1)"; echo "container=$(docker ps -qf "name=^dreamfinder-avatar$")"; echo "date=$(date -u +%FT%TZ)"; } > "$FREEZE/deployed.txt"
 cat "$FREEZE/deployed.txt"
 echo "=== DEPLOY GREEN. NOW: voice canary (laptop spoken turn at df.imagineering.cc), then phone/cellular, then rollback rehearsal. ==="

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -68,7 +68,18 @@ sleep 10
 # live unauthenticated-read hole. A freshness check keyed to the wall clock rather
 # than to the thing whose freshness it asserts is a rollback waiting to happen.
 # StartedAt is correct whether or not the container was recreated.
-BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+# Route a FAILURE of the anchor itself through rollback(), not through `set -e`.
+# The cutover has already happened by this point. An unguarded assignment here
+# aborts the whole script on a container rename or a missing container, leaving
+# the NEW release live with gates 2-4 never evaluated and no rollback fired —
+# gate LOGIC failures roll back, gate SCAFFOLDING failures walked away. And it
+# must be captured on its own line first: `date -u -d " - 5 seconds"` is a VALID
+# GNU date expression (= now-5s, exit 0), so interpolating a failed inspect fails
+# OPEN into a five-second window wearing the boot anchor's name.
+STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar 2>/dev/null || true)
+BOOT_SINCE=""
+[ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+[ -n "$BOOT_SINCE" ] || rollback "cannot read dreamfinder-avatar StartedAt — the boot anchor is unavailable, so gates 2-4 cannot be trusted"
 echo "log window anchored to container boot: $BOOT_SINCE"
 BANNER=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
 [ "$BANNER" = "$CONTRACT" ] || { echo "banner: [$BANNER]"; echo "expect: [$CONTRACT]"; rollback "boot-banner contract"; }

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -58,7 +58,19 @@ echo "gate 1/4 health OK"
 
 # --- 6. gate: boot-banner contract (exact line, from THIS boot) ---
 sleep 10
-BANNER=$(docker logs dreamfinder-avatar --since 3m 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
+
+# Anchor the log window to the dreamfinder-avatar'S OWN boot, not the wall clock.
+# A wall-clock window (`--since 3m`) is only a PROXY for "this boot", and it stops being one the moment
+# `docker compose up -d` is a no-op: an identical cached image means no recreate,
+# so the banner was printed at the PREVIOUS boot and the window returns empty.
+# On 2026-08-10 that false negative failed gate 2 on a perfectly good dreamfinder
+# deploy, and the auto-rollback then restored the pre-engine image — reopening a
+# live unauthenticated-read hole. A freshness check keyed to the wall clock rather
+# than to the thing whose freshness it asserts is a rollback waiting to happen.
+# StartedAt is correct whether or not the container was recreated.
+BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+echo "log window anchored to container boot: $BOOT_SINCE"
+BANNER=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
 [ "$BANNER" = "$CONTRACT" ] || { echo "banner: [$BANNER]"; echo "expect: [$CONTRACT]"; rollback "boot-banner contract"; }
 echo "gate 2/4 contract OK: $BANNER"
 
@@ -70,7 +82,7 @@ done
 echo "gate 3/4 printenv OK"
 
 # --- 8. gate: exactly-one worker registered as dreamfinder ---
-REG=$(docker logs dreamfinder-avatar --since 3m 2>&1 | grep -ci "registered worker" || true)
+REG=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -ci "registered worker" || true)
 [ "$REG" -ge 1 ] || rollback "no worker registration in logs"
 echo "gate 4/4 worker registered (lines: $REG)"
 

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -81,8 +81,18 @@ rollback() {
 # content IS the pre-cutover state we are standing in right now.
 [ -f "$FREEZE/env.file" ]                       || cp .env "$FREEZE/env.file"
 [ -f "$FREEZE/docker-compose.yml" ]             || cp docker-compose.yml "$FREEZE/docker-compose.yml"
-if [ ! -f "$FREEZE/docker-compose.override.yml" ] && [ -f docker-compose.override.yml ]; then
-  cp docker-compose.override.yml "$FREEZE/docker-compose.override.yml"
+# The override is the awkward one: every green deploy RENAMES it to
+# docker-compose.lyra.yml.was-override (step 4 below), so after the first cutover
+# the file this seeds from no longer exists under that name. Wipe ~/demo-freeze
+# once and the deploy would refuse forever while its only seed source sat under
+# the other name — a refusal with no path out, written by the same script that
+# renamed it. Accept either name.
+if [ ! -f "$FREEZE/docker-compose.override.yml" ]; then
+  if [ -f docker-compose.override.yml ]; then
+    cp docker-compose.override.yml "$FREEZE/docker-compose.override.yml"
+  elif [ -f docker-compose.lyra.yml.was-override ]; then
+    cp docker-compose.lyra.yml.was-override "$FREEZE/docker-compose.override.yml"
+  fi
 fi
 FREEZE_MISSING=""
 for f in env.file docker-compose.yml docker-compose.override.yml; do
@@ -102,6 +112,18 @@ fi
 [ -f .env.next ] && [ -f docker-compose.next.yml ] || { echo "staged .env.next / docker-compose.next.yml missing"; exit 1; }
 grep -q "^BRAIN=" .env.next && grep -q "^STT=" .env.next && grep -q "^TTS=" .env.next && grep -q "^BRAIN_MODEL=" .env.next \
   || { echo ".env.next missing selector lines"; exit 1; }
+# ARM the rollback at dreamfinder's FIRST PRODUCTION MUTATION — the env/compose
+# flip below, not after `up -d`. Same invariant as lyra, different first mutation:
+# the trap must cover exactly the window in which production is mutated but not yet
+# verified. dreamfinder bakes source into the image, so its tree checkout above is
+# genuinely staging and must NOT be covered; the flip of .env and docker-compose.yml
+# is where production starts changing.
+#
+# Armed only after `up -d`, a partial or failed compose cutover — the command most
+# likely to stop and recreate the live container — exited under `set -e` with no
+# rollback, which is precisely the window the comments claimed to close.
+trap 'rollback "unhandled failure at line $LINENO"' ERR
+
 cp .env.next .env
 cp docker-compose.next.yml docker-compose.yml
 # override becomes opt-in again (its true name); BRAIN=oauth must not carry the lyra key
@@ -115,19 +137,6 @@ cp docker-compose.next.yml docker-compose.yml
 # makes "a new process started" a fact rather than an inference.
 docker compose up -d --force-recreate
 
-# ARM the rollback for everything after the cutover. Until now, gate LOGIC failures
-# called rollback() explicitly while gate SCAFFOLDING failures — a container rename,
-# a compose service rename, an unexpected `docker inspect` shape — exited under
-# `set -e` with the new release ALREADY LIVE and no rollback fired. The script's
-# stated contract is "ANY gate failure auto-runs the QUAD rollback"; this is what
-# makes that sentence true rather than aspirational.
-#
-# Deferred through six review rounds on the grounds that arming an unrehearsed
-# rollback is risky. That reasoning was backwards: the status quo is that a
-# scaffolding failure leaves production unverified with NO recovery at all, which is
-# strictly worse than a possibly-spurious rollback to a known-good freeze. Raised by
-# all three reviewers in every round; they were right.
-trap 'rollback "unhandled failure at line $LINENO"' ERR
 
 # --- 5. gate: health ---
 ok=""

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Gated deploy for dreamfinder-avatar (DF repo, pinned SHA).
-# Gates: health -> boot-banner contract -> printenv contract -> worker registration.
+# Gates: health -> boot-banner contract -> printenv contract -> worker
+# registration -> deployed-artifact assert on the auth-bypass allowlist.
 # ANY gate failure auto-runs the QUAD rollback (~/bin/rollback-dreamfinder-avatar.sh).
+#
+# NOTE ON GATE 5. The traversal fix cannot be verified over HTTP from this box:
+# lib/scope.js grants LOCALHOST_IPS base scope, so a loopback probe returns 200 for
+# everything and reads as a false green. That exact mistake was made on this exact
+# boundary, on THIS host — df.imagineering.cc/avatars/../server.js served 200 with
+# full source for ~10 minutes on 2026-08-10. Gate 5 therefore calls the pure
+# predicate inside the running container. The end-to-end proof is a NON-LOOPBACK
+# probe, printed as the closing instruction — it is not, and cannot be, automated
+# from here.
 set -euo pipefail
 APP_DIR="$HOME/apps/dreamfinder-avatar"
 SRC_DIR="$APP_DIR/src"
@@ -69,7 +79,7 @@ rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-dreamf
 ok=""
 for _ in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && { ok=1; break; }; sleep 2; done
 [ -n "$ok" ] || rollback "health"
-echo "gate 1/4 health OK"
+echo "gate 1/5 health OK"
 
 # --- 6. gate: boot-banner contract (exact line, from THIS boot) ---
 sleep 10
@@ -94,18 +104,18 @@ sleep 10
 STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar 2>/dev/null || true)
 BOOT_SINCE=""
 [ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
-[ -n "$BOOT_SINCE" ] || rollback "cannot read dreamfinder-avatar StartedAt — the boot anchor is unavailable, so gates 2-4 cannot be trusted"
+[ -n "$BOOT_SINCE" ] || rollback "cannot read dreamfinder-avatar StartedAt — the boot anchor is unavailable, so gates 2-5 cannot be trusted"
 echo "log window anchored to container boot: $BOOT_SINCE"
 BANNER=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
 [ "$BANNER" = "$CONTRACT" ] || { echo "banner: [$BANNER]"; echo "expect: [$CONTRACT]"; rollback "boot-banner contract"; }
-echo "gate 2/4 contract OK: $BANNER"
+echo "gate 2/5 contract OK: $BANNER"
 
 # --- 7. gate: container env (printenv, never the .env file) ---
 for V in VOICE_MODE BRAIN STT TTS BRAIN_MODEL CLAUDE_CODE_OAUTH_TOKEN; do
   VAL=$(docker exec dreamfinder-avatar printenv "$V" 2>/dev/null || true)
   [ -n "$VAL" ] || rollback "printenv $V empty"
 done
-echo "gate 3/4 printenv OK"
+echo "gate 3/5 printenv OK"
 
 # --- 8. gate: AT LEAST ONE worker registered as dreamfinder ---
 # NOTE the asymmetry with lyra, which also enforces an UPPER bound and rolls back
@@ -117,7 +127,89 @@ echo "gate 3/4 printenv OK"
 # regression happened. Align it after the rehearsal — see the follow-up task.
 REG=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -ci "registered worker" || true)
 [ "$REG" -ge 1 ] || rollback "no worker registration in logs"
-echo "gate 4/4 worker registered (lines: $REG)"
+echo "gate 4/5 worker registered (lines: $REG)"
+
+# --- 8b. gate 5: deployed-artifact assert on the auth-bypass allowlist.
+#          THIS host is where the hole actually bled. On 2026-08-10
+#          df.imagineering.cc/avatars/../server.js served 200 with full source for
+#          ~10 minutes. The fixes above address the false RED that caused the
+#          rollback ONTO the vulnerable image; this is the instrument that refuses
+#          a false GREEN while the hole is open. Health and the boot banner can
+#          both pass with a broken allowlist — they measure different things.
+#
+#          It CANNOT be an HTTP probe from this box. lib/scope.js grants
+#          LOCALHOST_IPS base scope, so a loopback request returns 200 for
+#          everything and reads as a false green. That exact mistake was made on
+#          this exact boundary. So: call the pure predicate inside the running
+#          container, against the artifact that was actually deployed.
+#
+#          Fed by QUOTED heredoc, not `node -e '...'`: a single-quoted shell
+#          argument cannot contain an apostrophe, and prose comments in here do.
+#          That broke lyra's version mid-string on its first run and bash tried to
+#          execute `//` as a command.
+docker exec -i dreamfinder-avatar node --input-type=module <<'ASSERT' || rollback "deployed-artifact allowlist assert"
+import { isRendererAsset, isAllowedMeshPath } from "/app/lib/renderer-assets.js";
+// Vectors are written out BY HAND and NOT derived from the module's exported
+// constants. Deriving them would only assert that the module agrees with itself,
+// and a verifier sharing a representation with the thing it verifies is blind to
+// bugs in that shared layer. The cost is real and must be paid deliberately when
+// the layout moves: lyra's pre-extraction list failed 3 of its 5 allow-vectors
+// after the engine subtree landed, i.e. it would have rolled back a good deploy.
+// Verified against the deployed /app/lib/renderer-assets.js on 2026-08-10.
+const mustDeny = [
+  // The vectors that were LIVE in production. /avatars/ is an allowlisted prefix,
+  // so a raw-path prefix match admitted these and express.static then resolved
+  // the traversal and served the file.
+  "/avatars/../server.js", "/avatars/../lib/scope.js", "/avatars/../package.json",
+  "/avatars/../data/last-night.json",
+  // encoding variants of the same idea
+  "/avatars/%2e%2e/package.json", "/avatars/..%2fpackage.json",
+  "/avatars/%252e%252e/server.js",            // double-encoded: decode is not a fixed point
+  "/avatars/..\\server.js",                   // backslash separator
+  "/avatars//../server.js", "/avatars/./../server.js",
+  "/avatars/%00/../server.js",                // NUL truncation
+  // moved-prefix regressions: public BEFORE the extraction, must not be now.
+  // If any of these start passing, the allowlist has drifted back.
+  "/headaudio/headaudio.min.mjs", "/avatar-renderer.js", "/sparks.js",
+  // engine internals sharing the /engine/ stem but NOT allowlisted
+  "/engine/README.md", "/engine/character.js", "/engine/agent-runner.js",
+  // and the ordinary protected surface
+  "/server.js", "/lib/scope.js",
+];
+const mustAllow = [
+  "/avatar", "/engine/avatar-renderer.html", "/engine/avatar-renderer.js",
+  "/engine/sparks.js", "/engine/headaudio/headaudio.min.mjs",
+  "/avatars/dreamfinder.glb", "/avatars/dreamfinder-compressed.glb",
+];
+// isAllowedMeshPath guards the ?avatar= override on the UNAUTHENTICATED renderer
+// page. The module's own header calls this the one part of the extraction that
+// genuinely widened what an anonymous caller can reach: an open loader fetching
+// arbitrary remote geometry under our origin. lyra's gate does not test it.
+const meshMustDeny = [
+  "https://evil.example/payload.glb",         // absolute cross-origin
+  "//evil.example/payload.glb",               // protocol-relative reads as absolute
+  "data:model/gltf-binary;base64,AAAA",       // inline payload
+  "/avatars/../../etc/passwd.glb",            // traversal wearing a mesh extension
+  "/avatars/%2e%2e/x.glb",
+  "/avatars/x.glb%00.txt",                    // NUL truncation back to a mesh extension
+  "/avatars/notamesh.txt",                    // public but not geometry
+  "/engine/sparks.js",                        // readable, but not a mesh
+  "avatars/dreamfinder.glb",                  // bare relative
+];
+const meshMustAllow = ["/avatars/dreamfinder.glb", "/avatars/dreamfinder-compressed.glb"];
+
+const bad = mustDeny.filter((p) => isRendererAsset(p));
+const broke = mustAllow.filter((p) => !isRendererAsset(p));
+const meshBad = meshMustDeny.filter((p) => isAllowedMeshPath(p));
+const meshBroke = meshMustAllow.filter((p) => !isAllowedMeshPath(p));
+if (bad.length) { console.error("ALLOWLIST STILL MATCHES TRAVERSAL: " + bad.join(", ")); process.exit(1); }
+if (broke.length) { console.error("ALLOWLIST NOW DENIES LEGITIMATE ASSETS: " + broke.join(", ")); process.exit(1); }
+if (meshBad.length) { console.error("MESH GUARD ACCEPTS A FOREIGN/TRAVERSAL MESH: " + meshBad.join(", ")); process.exit(1); }
+if (meshBroke.length) { console.error("MESH GUARD NOW DENIES OUR OWN MESH: " + meshBroke.join(", ")); process.exit(1); }
+console.log("allowlist: " + mustDeny.length + " denied, " + mustAllow.length + " allowed; mesh guard: "
+  + meshMustDeny.length + " denied, " + meshMustAllow.length + " allowed");
+ASSERT
+echo "gate 5/5 allowlist assert OK"
 
 # --- 9. record release identity + preserve the forward image ---
 IMG=$(docker inspect --format "{{.Image}}" dreamfinder-avatar)

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Gated deploy for dreamfinder-avatar (DF repo, pinned SHA).
+# Gates: health -> boot-banner contract -> printenv contract -> worker registration.
+# ANY gate failure auto-runs the QUAD rollback (~/bin/rollback-dreamfinder-avatar.sh).
+set -euo pipefail
+APP_DIR="$HOME/apps/dreamfinder-avatar"
+SRC_DIR="$APP_DIR/src"
+REPO_URL="git@github-dreamfinder:imagineering-cc/dreamfinder-avatar.git"
+FREEZE="$HOME/demo-freeze"
+cd "$APP_DIR"
+
+SHA=$(cat "$APP_DIR/DEPLOY_SHA")          # pinned — never a floating branch
+CONTRACT=$(cat "$APP_DIR/BOOT_CONTRACT")  # exact expected [voice] contract line
+[ -n "$SHA" ] && [ -n "$CONTRACT" ] || { echo "DEPLOY_SHA / BOOT_CONTRACT missing"; exit 1; }
+
+echo "=== Deploying dreamfinder-avatar @ $SHA ==="
+date -u "+%Y-%m-%d %H:%M:%S UTC"
+
+# --- 1. src: one-time swap from the old embodied-lyra clone to the DF repo ---
+if [ -d "$SRC_DIR/.git" ] && git -C "$SRC_DIR" remote get-url origin | grep -q "embodied-lyra"; then
+  echo "one-time: backing up old lyra src tree"
+  mv "$SRC_DIR" "$APP_DIR/src-lyra-2ba90a4-backup"
+fi
+if [ ! -d "$SRC_DIR/.git" ]; then
+  git clone "$REPO_URL" "$SRC_DIR"
+fi
+cd "$SRC_DIR"
+git fetch origin
+git checkout -q "$SHA"
+git lfs pull
+echo "src at: $(git log -1 --oneline)"
+cd "$APP_DIR"
+
+# --- 2. idempotent rollback anchor (never clobber an existing anchor) ---
+docker image inspect dreamfinder-avatar-app:pre-engine >/dev/null 2>&1 \
+  || docker tag dreamfinder-avatar-app:latest dreamfinder-avatar-app:pre-engine
+
+# --- 3. build while the old container still serves ---
+docker compose -f docker-compose.next.yml build --pull
+
+# --- 4. ATOMIC cutover: env + compose + override flip together, then one up -d ---
+[ -f .env.next ] && [ -f docker-compose.next.yml ] || { echo "staged .env.next / docker-compose.next.yml missing"; exit 1; }
+grep -q "^BRAIN=" .env.next && grep -q "^STT=" .env.next && grep -q "^TTS=" .env.next && grep -q "^BRAIN_MODEL=" .env.next \
+  || { echo ".env.next missing selector lines"; exit 1; }
+cp .env.next .env
+cp docker-compose.next.yml docker-compose.yml
+# override becomes opt-in again (its true name); BRAIN=oauth must not carry the lyra key
+[ -f docker-compose.override.yml ] && mv docker-compose.override.yml docker-compose.lyra.yml.was-override
+docker compose up -d
+
+rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-dreamfinder-avatar.sh"; exit 1; }
+
+# --- 5. gate: health ---
+ok=""
+for i in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && { ok=1; break; }; sleep 2; done
+[ -n "$ok" ] || rollback "health"
+echo "gate 1/4 health OK"
+
+# --- 6. gate: boot-banner contract (exact line, from THIS boot) ---
+sleep 10
+BANNER=$(docker logs dreamfinder-avatar --since 3m 2>&1 | grep -F "[voice] contract:" | tail -1 | sed "s/^.*\[voice\] contract: //" || true)
+[ "$BANNER" = "$CONTRACT" ] || { echo "banner: [$BANNER]"; echo "expect: [$CONTRACT]"; rollback "boot-banner contract"; }
+echo "gate 2/4 contract OK: $BANNER"
+
+# --- 7. gate: container env (printenv, never the .env file) ---
+for V in VOICE_MODE BRAIN STT TTS BRAIN_MODEL CLAUDE_CODE_OAUTH_TOKEN; do
+  VAL=$(docker exec dreamfinder-avatar printenv "$V" 2>/dev/null || true)
+  [ -n "$VAL" ] || rollback "printenv $V empty"
+done
+echo "gate 3/4 printenv OK"
+
+# --- 8. gate: exactly-one worker registered as dreamfinder ---
+REG=$(docker logs dreamfinder-avatar --since 3m 2>&1 | grep -ci "registered worker" || true)
+[ "$REG" -ge 1 ] || rollback "no worker registration in logs"
+echo "gate 4/4 worker registered (lines: $REG)"
+
+# --- 9. record release identity + preserve the forward image ---
+IMG=$(docker inspect --format "{{.Image}}" dreamfinder-avatar)
+docker tag dreamfinder-avatar-app:latest dreamfinder-avatar-app:post-engine
+{ echo "sha=$SHA"; echo "image=$IMG"; echo "env_md5=$(md5sum .env | cut -d" " -f1)"; echo "container=$(docker ps -qf name=dreamfinder-avatar)"; echo "date=$(date -u +%FT%TZ)"; } > "$FREEZE/deployed.txt"
+cat "$FREEZE/deployed.txt"
+echo "=== DEPLOY GREEN. NOW: voice canary (laptop spoken turn at df.imagineering.cc), then phone/cellular, then rollback rehearsal. ==="

--- a/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/deploy-dreamfinder-avatar.sh
@@ -77,23 +77,16 @@ rollback() {
 # this check the sequence is: cutover goes live -> a gate fails -> the auto-rollback
 # refuses to run -> the bad release stays up, while the script header promises QUAD
 # recovery. An auto-rollback is a switch; this makes sure the breaker behind it is
-# actually installed. Seed-if-absent first (matching lyra), since the correct freeze
-# content IS the pre-cutover state we are standing in right now.
-[ -f "$FREEZE/env.file" ]                       || cp .env "$FREEZE/env.file"
-[ -f "$FREEZE/docker-compose.yml" ]             || cp docker-compose.yml "$FREEZE/docker-compose.yml"
-# The override is the awkward one: every green deploy RENAMES it to
-# docker-compose.lyra.yml.was-override (step 4 below), so after the first cutover
-# the file this seeds from no longer exists under that name. Wipe ~/demo-freeze
-# once and the deploy would refuse forever while its only seed source sat under
-# the other name — a refusal with no path out, written by the same script that
-# renamed it. Accept either name.
-if [ ! -f "$FREEZE/docker-compose.override.yml" ]; then
-  if [ -f docker-compose.override.yml ]; then
-    cp docker-compose.override.yml "$FREEZE/docker-compose.override.yml"
-  elif [ -f docker-compose.lyra.yml.was-override ]; then
-    cp docker-compose.lyra.yml.was-override "$FREEZE/docker-compose.override.yml"
-  fi
-fi
+# actually installed.
+#
+# It REFUSES rather than seeds. An earlier version of this check seeded the missing
+# files from the current app directory, which looked helpful and was worse: the
+# image anchor is `pre-engine` from a specific past release, so seeding env/compose
+# from whatever is live now assembles a freeze whose legs come from DIFFERENT
+# releases — a fourth topology, armed as the recovery path, and indistinguishable
+# from a real freeze once written. A rollback substrate that cannot prove all four
+# legs describe the same release should stop, not improvise. Refusing costs a human
+# five minutes; state alchemy costs an incident.
 FREEZE_MISSING=""
 for f in env.file docker-compose.yml docker-compose.override.yml; do
   [ -f "$FREEZE/$f" ] || FREEZE_MISSING="$FREEZE_MISSING $f"

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -80,7 +80,16 @@ else
 fi
 git fetch origin
 git checkout -q "$SHA"
-command -v git-lfs >/dev/null 2>&1 && git lfs pull || echo "(git-lfs not configured — skipping lfs pull)"
+# NOT `cmd && git lfs pull || echo "…"`. In that idiom an INSTALLED git-lfs whose
+# pull FAILS (auth, network, LFS quota) falls into the `||` arm, prints "not
+# configured", and returns 0 — so the deploy walks into build and cutover with
+# pointer files instead of assets, having announced the opposite. An installed
+# client that fails must fail closed; only a genuinely absent one is skippable.
+if command -v git-lfs >/dev/null 2>&1; then
+  git lfs pull
+else
+  echo "(git-lfs not installed — skipping lfs pull)"
+fi
 echo "src: $PREV_SHA -> $(git log -1 --oneline)"
 cd "$APP_DIR"
 

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -51,7 +51,20 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   echo "!! local modifications on the box — archiving to $FREEZE/local-mods-$STAMP.patch"
   git diff HEAD > "$FREEZE/local-mods-$STAMP.patch"
   git --no-pager diff --stat HEAD
-  git checkout -- .
+  # `git checkout -- .` restores the worktree from the INDEX, so it clears
+  # unstaged edits but leaves STAGED ones in place — and the `git checkout $SHA`
+  # below then refuses to run on a dirty index. The stated purpose of this block
+  # is "preserve the edits, then don't let checkout die on them"; it only ever
+  # delivered that for the unstaged half. `reset --hard HEAD` clears both, and the
+  # archive above is taken against HEAD so it already captured staged + unstaged.
+  # This fails CLOSED either way (the deploy aborts before any cutover), but a
+  # hand-edit silently blocking a deploy is precisely what froze dreamfinder for
+  # weeks — so it should abort with THIS script's loud message, not git's.
+  git reset --hard HEAD
+  # Untracked files are deliberately left alone: they are not in the archive
+  # (git diff HEAD does not see them) and destroying an operator's un-added file
+  # to make a deploy proceed is not this script's call. They only block a checkout
+  # if the incoming tree would overwrite them, in which case git says so plainly.
 fi
 PREV_SHA=$(git rev-parse HEAD)
 # Rollback anchor for the TREE. Only advance it when the tree actually MOVES.
@@ -112,7 +125,15 @@ sleep 10
 # live unauthenticated-read hole. A freshness check keyed to the wall clock rather
 # than to the thing whose freshness it asserts is a rollback waiting to happen.
 # StartedAt is correct whether or not the container was recreated.
-BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+# Failure of the anchor routes through rollback(), not through `set -e` — see the
+# matching note in deploy-dreamfinder-avatar.sh. The cutover is already live here,
+# so a silent abort would leave an unverified release running with no rollback
+# armed. Captured on its own line because `date -u -d " - 5 seconds"` is valid GNU
+# date (= now-5s, exit 0) and would otherwise fail OPEN into a 5-second window.
+STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar 2>/dev/null || true)
+BOOT_SINCE=""
+[ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+[ -n "$BOOT_SINCE" ] || rollback "cannot read lyra-avatar StartedAt — the boot anchor is unavailable, so gates 2-5 cannot be trusted"
 echo "log window anchored to container boot: $BOOT_SINCE"
 BANNER=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "$CONTRACT" | tail -1 || true)
 [ -n "$BANNER" ] || { echo "expect: [$CONTRACT]"; docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | head -12; rollback "boot-banner contract"; }

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -91,6 +91,36 @@ else
   }
   echo "rollback anchor unchanged ($ANCHOR) — tree already at target"
 fi
+# --- 2. idempotent rollback anchors (never clobber an existing anchor) ---
+docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1 \
+  || docker tag lyra-avatar-app:latest lyra-avatar-app:pre-traversal-fix
+[ -f "$FREEZE/env.file" ]           || cp .env "$FREEZE/env.file"
+[ -f "$FREEZE/docker-compose.yml" ] || cp docker-compose.yml "$FREEZE/docker-compose.yml"
+
+# rollback() is defined BEFORE the cutover so everything from the first live
+# mutation onward has a recovery path in scope. `trap - ERR` inside it disarms the
+# trap armed below, so a failure DURING the rollback cannot recurse.
+rollback() {
+  trap - ERR
+  echo "GATE FAILED: $1 — rolling back"
+  "$HOME/bin/rollback-lyra-avatar.sh"
+  exit 1
+}
+
+# ARM the rollback BEFORE the tree moves, not after the cutover.
+#
+# lyra's live code IS the bind-mounted tree, so `git checkout "$SHA"` below is
+# already a production mutation — not staging. Arming only after `up -d` left a
+# window where a failed checkout, a failed lfs pull or a failed build exited under
+# `set -e` with the tree advanced and the old process still serving it: disk and
+# memory out of phase, no recovery, and the next container restart for any reason
+# brings up an unbuilt release. The freeze is seeded immediately above so that
+# rollback() has its inputs before the trap can possibly fire.
+#
+# A pre-cutover failure now costs one container recreate on the way back to PREV.
+# That is a cheap price for never leaving the tree ahead of the process.
+trap 'rollback "unhandled failure at line $LINENO"' ERR
+
 git fetch origin
 git checkout -q "$SHA"
 # NOT `cmd && git lfs pull || echo "…"`. In that idiom an INSTALLED git-lfs whose
@@ -106,21 +136,6 @@ fi
 echo "src: $PREV_SHA -> $(git log -1 --oneline)"
 cd "$APP_DIR"
 
-# rollback() is defined BEFORE the cutover so everything from the first live
-# mutation onward has a recovery path in scope. `trap - ERR` inside it disarms the
-# trap armed below, so a failure DURING the rollback cannot recurse.
-rollback() {
-  trap - ERR
-  echo "GATE FAILED: $1 — rolling back"
-  "$HOME/bin/rollback-lyra-avatar.sh"
-  exit 1
-}
-
-# --- 2. idempotent rollback anchors (never clobber an existing anchor) ---
-docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1 \
-  || docker tag lyra-avatar-app:latest lyra-avatar-app:pre-traversal-fix
-[ -f "$FREEZE/env.file" ]           || cp .env "$FREEZE/env.file"
-[ -f "$FREEZE/docker-compose.yml" ] || cp docker-compose.yml "$FREEZE/docker-compose.yml"
 
 # --- 3. build. MANDATORY even though ./src is bind-mounted: ENV and CMD come
 #         from the image, node_modules is an anon volume seeded from the image,
@@ -136,12 +151,6 @@ docker compose build --pull
 # the 2026-08-10 incident was a false RED. Anonymous volumes (node_modules) are
 # preserved across a recreate; only --renew-anon-volumes would discard them.
 docker compose up -d --force-recreate
-
-# ARM the rollback for everything after the cutover — see the matching note in
-# deploy-dreamfinder-avatar.sh. Gate LOGIC failures called rollback(); gate
-# SCAFFOLDING failures exited under `set -e` with the new release already live and
-# no recovery fired.
-trap 'rollback "unhandled failure at line $LINENO"' ERR
 
 # --- 4. gate 1: health ---
 ok=""
@@ -206,7 +215,7 @@ echo "gate 4/5 exactly one worker registered"
 # the block mid-string on the first run and bash tried to execute `//` as a
 # command. A quoted heredoc passes the payload through verbatim.
 docker exec -i lyra-avatar node --input-type=module <<'ASSERT' || rollback "deployed-artifact allowlist assert"
-import { isRendererAsset } from "/app/lib/renderer-assets.js";
+import { isRendererAsset, isAllowedMeshPath } from "/app/lib/renderer-assets.js";
 // Written out by hand and NOT derived from the module's own exported constants:
 // deriving them would only assert that the module agrees with itself, and a
 // verifier sharing a representation with the thing it verifies is blind to bugs
@@ -228,13 +237,47 @@ const mustAllow = [
   "/avatar", "/engine/avatar-renderer.html", "/engine/avatar-renderer.js",
   "/engine/sparks.js", "/avatars/lyra.glb", "/engine/headaudio/headaudio.min.mjs",
 ];
+// isAllowedMeshPath guards the ?avatar= override on the UNAUTHENTICATED renderer
+// page — the module's own header calls it the one part of the extraction that
+// genuinely widened what an anonymous caller can reach: hand the origin a URL and
+// it becomes an open loader for remote geometry under our own domain. This gate
+// tested only isRendererAsset while dreamfinder's tested both, so the same shared
+// engine had one phase instrumented and the other silent.
+const meshMustDeny = [
+  "https://evil.example/payload.glb",         // absolute cross-origin
+  "//evil.example/payload.glb",               // protocol-relative reads as absolute
+  "data:model/gltf-binary;base64,AAAA",       // inline payload
+  "/avatars/../../etc/passwd.glb",            // traversal wearing a mesh extension
+  "/avatars/%2e%2e/x.glb",
+  "/avatars/lyra.glb%00.txt",                 // NUL truncation back to a mesh extension
+  "/avatars/notamesh.txt",                    // public but not geometry
+  "/engine/sparks.js",                        // readable, but not a mesh
+  "avatars/lyra.glb",                         // bare relative
+];
+const meshMustAllow = ["/avatars/lyra.glb"];
+
 const bad = mustDeny.filter(p => isRendererAsset(p));
 const broke = mustAllow.filter(p => !isRendererAsset(p));
+const meshBad = meshMustDeny.filter(p => isAllowedMeshPath(p));
+const meshBroke = meshMustAllow.filter(p => !isAllowedMeshPath(p));
 if (bad.length) { console.error("ALLOWLIST STILL MATCHES TRAVERSAL: " + bad.join(", ")); process.exit(1); }
 if (broke.length) { console.error("ALLOWLIST NOW DENIES LEGITIMATE ASSETS: " + broke.join(", ")); process.exit(1); }
-console.log("allowlist: " + mustDeny.length + " denied, " + mustAllow.length + " allowed");
+if (meshBad.length) { console.error("MESH GUARD ACCEPTS A FOREIGN/TRAVERSAL MESH: " + meshBad.join(", ")); process.exit(1); }
+if (meshBroke.length) { console.error("MESH GUARD NOW DENIES OUR OWN MESH: " + meshBroke.join(", ")); process.exit(1); }
+console.log("allowlist: " + mustDeny.length + " denied, " + mustAllow.length + " allowed; mesh guard: "
+  + meshMustDeny.length + " denied, " + meshMustAllow.length + " allowed");
 ASSERT
 echo "gate 5/5 allowlist assert OK"
+
+# DISARM. The trap covers the window from the first tree mutation to the last
+# gate — a failure in
+# there means the release is unverified and should be rolled back. Past this line
+# the release has PASSED all five gates, and everything remaining is bookkeeping:
+# docker inspect, a tag, writing deployed.txt. Leaving the trap armed wires the
+# record step into the recovery bus, so a full disk or a permissions slip would
+# roll back a release that was just proven good. "Any GATE failure rolls back" is
+# the contract; a bookkeeping spark is not a gate failure.
+trap - ERR
 
 # --- 9. record release identity + preserve the forward image ---
 IMG=$(docker inspect --format "{{.Image}}" lyra-avatar)

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -81,7 +81,16 @@ docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1 \
 #         from the image, node_modules is an anon volume seeded from the image,
 #         and a dependency change would otherwise ship a tree the image cannot run.
 docker compose build --pull
-docker compose up -d
+# --force-recreate is REQUIRED for lyra specifically. The deploy unit here is the
+# src TREE (compose bind-mounts ./src:/app), but compose decides whether to
+# recreate from the IMAGE and config. A src-only change with a fully cached build
+# leaves the image id identical, so a bare `up -d` is a NO-OP: the old node
+# process keeps serving the old code from memory while the checkout says $SHA.
+# Every gate below would then sample the previous release and pass green, and
+# deployed.txt would record a release that never started — a false GREEN, where
+# the 2026-08-10 incident was a false RED. Anonymous volumes (node_modules) are
+# preserved across a recreate; only --renew-anon-volumes would discard them.
+docker compose up -d --force-recreate
 
 rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-lyra-avatar.sh"; exit 1; }
 

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -87,7 +87,7 @@ rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-lyra-a
 
 # --- 4. gate 1: health ---
 ok=""
-for i in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && { ok=1; break; }; sleep 2; done
+for _ in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && { ok=1; break; }; sleep 2; done
 [ -n "$ok" ] || rollback "health"
 echo "gate 1/5 health OK"
 
@@ -165,9 +165,21 @@ echo "gate 5/5 allowlist assert OK"
 # --- 9. record release identity + preserve the forward image ---
 IMG=$(docker inspect --format "{{.Image}}" lyra-avatar)
 docker tag lyra-avatar-app:latest lyra-avatar-app:post-traversal-fix
-{ echo "sha=$SHA"; echo "prev_sha=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || echo unknown)"   # the ANCHOR, not the variable: on a re-run at the same SHA these differ, and this file is what a human reads to find the rollback target; echo "image=$IMG"; \
-  echo "env_md5=$(md5sum .env | cut -d" " -f1)"; \
-  echo "container=$(docker ps -qf name=lyra-avatar)"; echo "date=$(date -u +%FT%TZ)"; } > "$FREEZE/deployed.txt"
+# prev_sha reads the ANCHOR FILE, not the $PREV_SHA variable: on a re-run at the
+# same SHA those differ, and this file is what a human reads to find the rollback
+# target. Keep each field on its own line — the previous version put that
+# explanation as a trailing `#` comment on the prev_sha line, which swallowed the
+# rest of the physical line (`echo "image=$IMG"; \`, backslash included, so not
+# even a continuation) and silently dropped image= from every lyra release record.
+ANCHOR=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || echo unknown)
+{
+  echo "sha=$SHA"
+  echo "prev_sha=$ANCHOR"
+  echo "image=$IMG"
+  echo "env_md5=$(md5sum .env | cut -d" " -f1)"
+  echo "container=$(docker ps -qf name=lyra-avatar)"
+  echo "date=$(date -u +%FT%TZ)"
+} > "$FREEZE/deployed.txt"
 cat "$FREEZE/deployed.txt"
 
 cat <<'EOF'

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Gated deploy for lyra-avatar (imagineering-cc/lyra-avatar, pinned SHA).
+#
+# Sibling of ~/bin/deploy-dreamfinder-avatar.sh, but NOT a copy — lyra differs in
+# two ways that change the shape of both deploy and rollback:
+#
+#   1. compose bind-mounts ./src:/app. The running code IS the checked-out tree,
+#      not a layer baked into the image. So the deploy unit is the SRC SHA, and
+#      rollback must restore the TREE, not just retag an image.
+#   2. there is no BRAIN/STT/TTS selector matrix — lyra-live is the only mode.
+#      The env contract is correspondingly different (her brain-hop ssh key is
+#      load-bearing and unconditional).
+#
+# Gates: health -> boot-banner contract -> printenv contract -> worker
+# registration -> deployed-artifact assert on the auth-bypass allowlist.
+# ANY gate failure auto-runs ~/bin/rollback-lyra-avatar.sh.
+#
+# NOTE ON GATE 5. The traversal fix cannot be verified over HTTP from this box:
+# lib/scope.js grants LOCALHOST_IPS base scope, so a loopback probe returns 200
+# for everything and reads as a false green. That exact mistake was made on this
+# exact boundary. Gate 5 therefore calls the pure predicate inside the running
+# container instead. The end-to-end proof is a NON-LOOPBACK probe, printed as the
+# closing instruction — it is not, and cannot be, automated from here.
+set -euo pipefail
+APP_DIR="$HOME/apps/lyra-avatar"
+SRC_DIR="$APP_DIR/src"
+REPO_URL="git@github-lyra:imagineering-cc/lyra-avatar.git"
+FREEZE="$HOME/lyra-freeze"
+PORT=3017
+mkdir -p "$FREEZE"
+cd "$APP_DIR"
+
+SHA=$(cat "$APP_DIR/DEPLOY_SHA")          # pinned — never a floating branch
+CONTRACT=$(cat "$APP_DIR/BOOT_CONTRACT")  # exact expected auth banner line
+[ -n "$SHA" ] && [ -n "$CONTRACT" ] || { echo "DEPLOY_SHA / BOOT_CONTRACT missing"; exit 1; }
+
+echo "=== Deploying lyra-avatar @ $SHA ==="
+date -u "+%Y-%m-%d %H:%M:%S UTC"
+
+# --- 1. src: fetch + pin. Canonicalise the remote (repo was renamed from
+#         embodied-lyra) and preserve any hand-applied local edits rather than
+#         letting checkout die on them. A stale hand-edit on the box blocked the
+#         dreamfinder deploy for weeks; find out here, loudly, not at checkout.
+if [ ! -d "$SRC_DIR/.git" ]; then
+  git clone "$REPO_URL" "$SRC_DIR"
+fi
+cd "$SRC_DIR"
+git remote set-url origin "$REPO_URL"
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  STAMP=$(date -u +%Y%m%d%H%M%S)
+  echo "!! local modifications on the box — archiving to $FREEZE/local-mods-$STAMP.patch"
+  git diff HEAD > "$FREEZE/local-mods-$STAMP.patch"
+  git --no-pager diff --stat HEAD
+  git checkout -- .
+fi
+PREV_SHA=$(git rev-parse HEAD)
+echo "$PREV_SHA" > "$FREEZE/PREV_SHA"     # rollback anchor for the TREE
+git fetch origin
+git checkout -q "$SHA"
+command -v git-lfs >/dev/null 2>&1 && git lfs pull || echo "(git-lfs not configured — skipping lfs pull)"
+echo "src: $PREV_SHA -> $(git log -1 --oneline)"
+cd "$APP_DIR"
+
+# --- 2. idempotent rollback anchors (never clobber an existing anchor) ---
+docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1 \
+  || docker tag lyra-avatar-app:latest lyra-avatar-app:pre-traversal-fix
+[ -f "$FREEZE/env.file" ]           || cp .env "$FREEZE/env.file"
+[ -f "$FREEZE/docker-compose.yml" ] || cp docker-compose.yml "$FREEZE/docker-compose.yml"
+
+# --- 3. build. MANDATORY even though ./src is bind-mounted: ENV and CMD come
+#         from the image, node_modules is an anon volume seeded from the image,
+#         and a dependency change would otherwise ship a tree the image cannot run.
+docker compose build --pull
+docker compose up -d
+
+rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-lyra-avatar.sh"; exit 1; }
+
+# --- 4. gate 1: health ---
+ok=""
+for i in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && { ok=1; break; }; sleep 2; done
+[ -n "$ok" ] || rollback "health"
+echo "gate 1/5 health OK"
+
+# --- 5. gate 2: boot-banner contract (exact line, from THIS boot) ---
+sleep 10
+BANNER=$(docker logs lyra-avatar --since 3m 2>&1 | grep -F "$CONTRACT" | tail -1 || true)
+[ -n "$BANNER" ] || { echo "expect: [$CONTRACT]"; docker logs lyra-avatar --since 3m 2>&1 | head -12; rollback "boot-banner contract"; }
+echo "gate 2/5 contract OK: $BANNER"
+
+# --- 6. gate 3: container env (printenv, never the .env file) ---
+for V in AUTH_PASSWORD AUTH_SECRET LIVEKIT_API_KEY LIVEKIT_API_SECRET OPENAI_API_KEY LYRA_SSH_HOST LYRA_SSH_KEY; do
+  VAL=$(docker exec lyra-avatar printenv "$V" 2>/dev/null || true)
+  [ -n "$VAL" ] || rollback "printenv $V empty"
+done
+docker exec lyra-avatar test -r /app/.ssh/lyra-deploy || rollback "brain-hop key not readable in container"
+echo "gate 3/5 printenv OK"
+
+# --- 7. gate 4: exactly-one worker registered ---
+REG=$(docker logs lyra-avatar --since 3m 2>&1 | grep -c '"msg":"registered worker"' || true)
+[ "$REG" -ge 1 ] || rollback "no worker registration in logs"
+[ "$REG" -le 1 ] || rollback "GHOST WORKER: $REG registrations — dispatch will load-balance across duplicates"
+echo "gate 4/5 exactly one worker registered"
+
+# --- 8. gate 5: deployed-artifact assert on the auth-bypass allowlist.
+#         Runs the pure predicate inside the container against the traversal
+#         vectors that were live in production. A loopback HTTP probe cannot do
+#         this (see header). Fails closed if the module is missing entirely.
+docker exec lyra-avatar node --input-type=module -e '
+import { isRendererAsset } from "/app/lib/renderer-assets.js";
+const mustDeny = [
+  "/avatars/../server.js", "/avatars/../lib/scope.js", "/avatars/../package.json",
+  "/avatars/../data/last-night.json", "/avatars/%2e%2e/package.json",
+  "/avatars/..%2fpackage.json", "/headaudio/../../server.js", "/avatars/..\\server.js",
+  "/avatars//../server.js", "/avatars/./../server.js", "/avatars/%00/../server.js",
+];
+const mustAllow = ["/avatar", "/avatar-renderer.js", "/sparks.js", "/avatars/lyra.glb", "/headaudio/a.wav"];
+const bad = mustDeny.filter(p => isRendererAsset(p));
+const broke = mustAllow.filter(p => !isRendererAsset(p));
+if (bad.length) { console.error("ALLOWLIST STILL MATCHES TRAVERSAL: " + bad.join(", ")); process.exit(1); }
+if (broke.length) { console.error("ALLOWLIST NOW DENIES LEGITIMATE ASSETS: " + broke.join(", ")); process.exit(1); }
+console.log("allowlist: " + mustDeny.length + " traversal vectors denied, " + mustAllow.length + " real assets allowed");
+' || rollback "deployed-artifact allowlist assert"
+echo "gate 5/5 allowlist assert OK"
+
+# --- 9. record release identity + preserve the forward image ---
+IMG=$(docker inspect --format "{{.Image}}" lyra-avatar)
+docker tag lyra-avatar-app:latest lyra-avatar-app:post-traversal-fix
+{ echo "sha=$SHA"; echo "prev_sha=$PREV_SHA"; echo "image=$IMG"; \
+  echo "env_md5=$(md5sum .env | cut -d" " -f1)"; \
+  echo "container=$(docker ps -qf name=lyra-avatar)"; echo "date=$(date -u +%FT%TZ)"; } > "$FREEZE/deployed.txt"
+cat "$FREEZE/deployed.txt"
+
+cat <<'EOF'
+=== DEPLOY GREEN — but NOT verified. Two things remain, both off-box: ===
+  1. TRAVERSAL PROBE from a NON-LOOPBACK address. Loopback gets base scope in
+     lib/scope.js, so probing from here returns 200 and lies. From a laptop:
+       for p in /avatars/../server.js /avatars/%2e%2e/package.json /avatars/..%2fpackage.json; do
+         curl -s --path-as-is -o /dev/null -w "%{http_code} $p\n" "https://lyra.imagineering.cc$p"
+       done
+     Expect 303 on every line. Use --path-as-is: curl strips ../ client-side
+     without it, so the probe silently tests a different URL and reads green.
+  2. VOICE CANARY — a real spoken turn at lyra.imagineering.cc, then a rollback
+     rehearsal (~/bin/rollback-lyra-avatar.sh). Requires a human.
+EOF

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -107,21 +107,25 @@ rollback() {
   exit 1
 }
 
-# ARM the rollback BEFORE the tree moves, not after the cutover.
-#
-# lyra's live code IS the bind-mounted tree, so `git checkout "$SHA"` below is
-# already a production mutation — not staging. Arming only after `up -d` left a
-# window where a failed checkout, a failed lfs pull or a failed build exited under
-# `set -e` with the tree advanced and the old process still serving it: disk and
-# memory out of phase, no recovery, and the next container restart for any reason
-# brings up an unbuilt release. The freeze is seeded immediately above so that
-# rollback() has its inputs before the trap can possibly fire.
-#
-# A pre-cutover failure now costs one container recreate on the way back to PREV.
-# That is a cheap price for never leaving the tree ahead of the process.
-trap 'rollback "unhandled failure at line $LINENO"' ERR
 
 git fetch origin
+# ARM the rollback at lyra's FIRST PRODUCTION MUTATION, which is the checkout —
+# not earlier, and not after the cutover.
+#
+# Both boundaries were wrong in earlier rounds and two reviewers caught opposite
+# halves. Armed after `up -d`, a failed checkout/lfs/build left the tree advanced
+# with the old process still serving it: disk and memory out of phase, no recovery,
+# and the next restart brings up an unbuilt release. Armed before `git fetch`, a
+# simple "cannot reach origin" — which mutates NOTHING — would fire a rollback and
+# DEMOTE a perfectly healthy production to PREV_SHA. Fail-closed on an unreachable
+# remote must mean "abort without touching production", not "roll production back".
+#
+# The invariant, stated once so it can be checked rather than re-derived: the trap
+# must cover exactly the window in which production is mutated but not yet verified.
+# For lyra that window opens at `git checkout` (the tree IS the running code) and
+# closes when gate 5 passes. The freeze is seeded above so rollback() has its inputs
+# before the trap can fire.
+trap 'rollback "unhandled failure at line $LINENO"' ERR
 git checkout -q "$SHA"
 # NOT `cmd && git lfs pull || echo "…"`. In that idiom an INSTALLED git-lfs whose
 # pull FAILS (auth, network, LFS quota) falls into the `||` arm, prints "not

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -54,7 +54,17 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   git checkout -- .
 fi
 PREV_SHA=$(git rev-parse HEAD)
-echo "$PREV_SHA" > "$FREEZE/PREV_SHA"     # rollback anchor for the TREE
+# Rollback anchor for the TREE. Only advance it when the tree actually MOVES.
+# Re-running a deploy at the same SHA (a no-op, and the normal shape of a retry)
+# would otherwise overwrite the anchor with the target itself, leaving a rollback
+# that restores the very release you are trying to escape. Same reason the image
+# anchor below is guarded — an anchor you can silently overwrite is not an anchor.
+if [ "$PREV_SHA" != "$SHA" ]; then
+  echo "$PREV_SHA" > "$FREEZE/PREV_SHA"
+  echo "rollback anchor -> $PREV_SHA"
+else
+  echo "rollback anchor unchanged ($(cat "$FREEZE/PREV_SHA" 2>/dev/null || echo none)) — tree already at target"
+fi
 git fetch origin
 git checkout -q "$SHA"
 command -v git-lfs >/dev/null 2>&1 && git lfs pull || echo "(git-lfs not configured — skipping lfs pull)"
@@ -83,8 +93,20 @@ echo "gate 1/5 health OK"
 
 # --- 5. gate 2: boot-banner contract (exact line, from THIS boot) ---
 sleep 10
-BANNER=$(docker logs lyra-avatar --since 3m 2>&1 | grep -F "$CONTRACT" | tail -1 || true)
-[ -n "$BANNER" ] || { echo "expect: [$CONTRACT]"; docker logs lyra-avatar --since 3m 2>&1 | head -12; rollback "boot-banner contract"; }
+
+# Anchor the log window to the lyra-avatar'S OWN boot, not the wall clock.
+# A wall-clock window (`--since 3m`) is only a PROXY for "this boot", and it stops being one the moment
+# `docker compose up -d` is a no-op: an identical cached image means no recreate,
+# so the banner was printed at the PREVIOUS boot and the window returns empty.
+# On 2026-08-10 that false negative failed gate 2 on a perfectly good dreamfinder
+# deploy, and the auto-rollback then restored the pre-engine image — reopening a
+# live unauthenticated-read hole. A freshness check keyed to the wall clock rather
+# than to the thing whose freshness it asserts is a rollback waiting to happen.
+# StartedAt is correct whether or not the container was recreated.
+BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+echo "log window anchored to container boot: $BOOT_SINCE"
+BANNER=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "$CONTRACT" | tail -1 || true)
+[ -n "$BANNER" ] || { echo "expect: [$CONTRACT]"; docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | head -12; rollback "boot-banner contract"; }
 echo "gate 2/5 contract OK: $BANNER"
 
 # --- 6. gate 3: container env (printenv, never the .env file) ---
@@ -96,7 +118,7 @@ docker exec lyra-avatar test -r /app/.ssh/lyra-deploy || rollback "brain-hop key
 echo "gate 3/5 printenv OK"
 
 # --- 7. gate 4: exactly-one worker registered ---
-REG=$(docker logs lyra-avatar --since 3m 2>&1 | grep -c '"msg":"registered worker"' || true)
+REG=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -c '"msg":"registered worker"' || true)
 [ "$REG" -ge 1 ] || rollback "no worker registration in logs"
 [ "$REG" -le 1 ] || rollback "GHOST WORKER: $REG registrations — dispatch will load-balance across duplicates"
 echo "gate 4/5 exactly one worker registered"
@@ -105,27 +127,45 @@ echo "gate 4/5 exactly one worker registered"
 #         Runs the pure predicate inside the container against the traversal
 #         vectors that were live in production. A loopback HTTP probe cannot do
 #         this (see header). Fails closed if the module is missing entirely.
-docker exec lyra-avatar node --input-type=module -e '
+# Fed via HEREDOC, not `-e '...'`. A single-quoted shell argument cannot contain
+# an apostrophe, and prose comments inside the assert naturally do — that broke
+# the block mid-string on the first run and bash tried to execute `//` as a
+# command. A quoted heredoc passes the payload through verbatim.
+docker exec -i lyra-avatar node --input-type=module <<'ASSERT' || rollback "deployed-artifact allowlist assert"
 import { isRendererAsset } from "/app/lib/renderer-assets.js";
+// Written out by hand and NOT derived from the module's own exported constants:
+// deriving them would only assert that the module agrees with itself, and a
+// verifier sharing a representation with the thing it verifies is blind to bugs
+// in that shared layer. The cost is that they must be updated DELIBERATELY when
+// the allowlist layout moves. That cost is real — the engine-subtree extraction
+// moved the renderer's own assets to /engine/..., and the pre-extraction version
+// of this list failed 3 of 5 allow-vectors, i.e. it would have rolled back a
+// good deploy. Verified against lib/renderer-assets.js at 4a04138 before install.
 const mustDeny = [
   "/avatars/../server.js", "/avatars/../lib/scope.js", "/avatars/../package.json",
   "/avatars/../data/last-night.json", "/avatars/%2e%2e/package.json",
-  "/avatars/..%2fpackage.json", "/headaudio/../../server.js", "/avatars/..\\server.js",
-  "/avatars//../server.js", "/avatars/./../server.js", "/avatars/%00/../server.js",
+  "/avatars/..%2fpackage.json", "/avatars/%252e%252e/server.js",
+  "/engine/headaudio/../../server.js", "/avatars/..\\server.js",
+  "/avatars//../server.js", "/avatars/./../server.js",
+  // moved-prefix regressions: these must NOT be public any more
+  "/headaudio/headaudio.min.mjs", "/engine/README.md", "/engine/character.js",
 ];
-const mustAllow = ["/avatar", "/avatar-renderer.js", "/sparks.js", "/avatars/lyra.glb", "/headaudio/a.wav"];
+const mustAllow = [
+  "/avatar", "/engine/avatar-renderer.html", "/engine/avatar-renderer.js",
+  "/engine/sparks.js", "/avatars/lyra.glb", "/engine/headaudio/headaudio.min.mjs",
+];
 const bad = mustDeny.filter(p => isRendererAsset(p));
 const broke = mustAllow.filter(p => !isRendererAsset(p));
 if (bad.length) { console.error("ALLOWLIST STILL MATCHES TRAVERSAL: " + bad.join(", ")); process.exit(1); }
 if (broke.length) { console.error("ALLOWLIST NOW DENIES LEGITIMATE ASSETS: " + broke.join(", ")); process.exit(1); }
-console.log("allowlist: " + mustDeny.length + " traversal vectors denied, " + mustAllow.length + " real assets allowed");
-' || rollback "deployed-artifact allowlist assert"
+console.log("allowlist: " + mustDeny.length + " denied, " + mustAllow.length + " allowed");
+ASSERT
 echo "gate 5/5 allowlist assert OK"
 
 # --- 9. record release identity + preserve the forward image ---
 IMG=$(docker inspect --format "{{.Image}}" lyra-avatar)
 docker tag lyra-avatar-app:latest lyra-avatar-app:post-traversal-fix
-{ echo "sha=$SHA"; echo "prev_sha=$PREV_SHA"; echo "image=$IMG"; \
+{ echo "sha=$SHA"; echo "prev_sha=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || echo unknown)"   # the ANCHOR, not the variable: on a re-run at the same SHA these differ, and this file is what a human reads to find the rollback target; echo "image=$IMG"; \
   echo "env_md5=$(md5sum .env | cut -d" " -f1)"; \
   echo "container=$(docker ps -qf name=lyra-avatar)"; echo "date=$(date -u +%FT%TZ)"; } > "$FREEZE/deployed.txt"
 cat "$FREEZE/deployed.txt"

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -76,7 +76,20 @@ if [ "$PREV_SHA" != "$SHA" ]; then
   echo "$PREV_SHA" > "$FREEZE/PREV_SHA"
   echo "rollback anchor -> $PREV_SHA"
 else
-  echo "rollback anchor unchanged ($(cat "$FREEZE/PREV_SHA" 2>/dev/null || echo none)) — tree already at target"
+  # ...but "don't advance it" is not the same as "there is one". On a first deploy,
+  # or after a wiped freeze, PREV_SHA can be ABSENT while the tree is already at the
+  # target. The old message cheerfully printed "(none)" and carried on — so the
+  # deploy armed an auto-rollback whose preflight requires PREV_SHA and exits
+  # without changing anything. That advertises rollback protection while having no
+  # reversible path at all. Refuse here, BEFORE the cutover, where refusing is free.
+  ANCHOR=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || true)
+  [ -n "$ANCHOR" ] || {
+    echo "FATAL: tree is already at $SHA and there is no $FREEZE/PREV_SHA anchor."
+    echo "       Deploying now would arm an auto-rollback with nothing to roll back to."
+    echo "       Write a known-good SHA to $FREEZE/PREV_SHA first, or deploy a SHA that moves the tree."
+    exit 1
+  }
+  echo "rollback anchor unchanged ($ANCHOR) — tree already at target"
 fi
 git fetch origin
 git checkout -q "$SHA"
@@ -92,6 +105,16 @@ else
 fi
 echo "src: $PREV_SHA -> $(git log -1 --oneline)"
 cd "$APP_DIR"
+
+# rollback() is defined BEFORE the cutover so everything from the first live
+# mutation onward has a recovery path in scope. `trap - ERR` inside it disarms the
+# trap armed below, so a failure DURING the rollback cannot recurse.
+rollback() {
+  trap - ERR
+  echo "GATE FAILED: $1 — rolling back"
+  "$HOME/bin/rollback-lyra-avatar.sh"
+  exit 1
+}
 
 # --- 2. idempotent rollback anchors (never clobber an existing anchor) ---
 docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1 \
@@ -114,7 +137,11 @@ docker compose build --pull
 # preserved across a recreate; only --renew-anon-volumes would discard them.
 docker compose up -d --force-recreate
 
-rollback() { echo "GATE FAILED: $1 — rolling back"; "$HOME/bin/rollback-lyra-avatar.sh"; exit 1; }
+# ARM the rollback for everything after the cutover — see the matching note in
+# deploy-dreamfinder-avatar.sh. Gate LOGIC failures called rollback(); gate
+# SCAFFOLDING failures exited under `set -e` with the new release already live and
+# no recovery fired.
+trap 'rollback "unhandled failure at line $LINENO"' ERR
 
 # --- 4. gate 1: health ---
 ok=""
@@ -123,7 +150,6 @@ for _ in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && { o
 echo "gate 1/5 health OK"
 
 # --- 5. gate 2: boot-banner contract (exact line, from THIS boot) ---
-sleep 10
 
 # Anchor the log window to the lyra-avatar'S OWN boot, not the wall clock.
 # A wall-clock window (`--since 3m`) is only a PROXY for "this boot", and it stops being one the moment
@@ -144,7 +170,16 @@ BOOT_SINCE=""
 [ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
 [ -n "$BOOT_SINCE" ] || rollback "cannot read lyra-avatar StartedAt — the boot anchor is unavailable, so gates 2-5 cannot be trusted"
 echo "log window anchored to container boot: $BOOT_SINCE"
-BANNER=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "$CONTRACT" | tail -1 || true)
+# POLL for the banner rather than `sleep 10` and look once — see the matching note
+# in deploy-dreamfinder-avatar.sh. A fixed sleep uses elapsed time as a proxy for
+# "the banner has been printed", which goes false under a slow init and fires the
+# auto-rollback on a good deploy.
+BANNER=""
+for _ in $(seq 1 30); do
+  BANNER=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -F "$CONTRACT" | tail -1 || true)
+  [ -n "$BANNER" ] && break
+  sleep 2
+done
 [ -n "$BANNER" ] || { echo "expect: [$CONTRACT]"; docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | head -12; rollback "boot-banner contract"; }
 echo "gate 2/5 contract OK: $BANNER"
 

--- a/avatar-deploy/bin/deploy-lyra-avatar.sh
+++ b/avatar-deploy/bin/deploy-lyra-avatar.sh
@@ -216,7 +216,7 @@ ANCHOR=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || echo unknown)
   echo "prev_sha=$ANCHOR"
   echo "image=$IMG"
   echo "env_md5=$(md5sum .env | cut -d" " -f1)"
-  echo "container=$(docker ps -qf name=lyra-avatar)"
+  echo "container=$(docker ps -qf "name=^lyra-avatar$")"
   echo "date=$(date -u +%FT%TZ)"
 } > "$FREEZE/deployed.txt"
 cat "$FREEZE/deployed.txt"

--- a/avatar-deploy/bin/flip-brain-api.sh
+++ b/avatar-deploy/bin/flip-brain-api.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Break-glass: flip the deployed DF brain from oauth (weekly-capped) to api (metered key).
-set -euo pipefail
-cd /home/nick/apps/embodied-dreamfinder
-grep -q "^ANTHROPIC_API_KEY=sk-" .env || { echo "ANTHROPIC_API_KEY not in .env yet — aborting"; exit 1; }
-sed -i "s/^BRAIN=oauth$/BRAIN=api/" .env
-cp BOOT_CONTRACT.api BOOT_CONTRACT
-exec ~/bin/deploy-embodied-dreamfinder.sh   # full 4-gate pass, auto-rollback armed

--- a/avatar-deploy/bin/flip-brain-api.sh
+++ b/avatar-deploy/bin/flip-brain-api.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Break-glass: flip the deployed DF brain from oauth (weekly-capped) to api (metered key).
+set -euo pipefail
+cd /home/nick/apps/embodied-dreamfinder
+grep -q "^ANTHROPIC_API_KEY=sk-" .env || { echo "ANTHROPIC_API_KEY not in .env yet — aborting"; exit 1; }
+sed -i "s/^BRAIN=oauth$/BRAIN=api/" .env
+cp BOOT_CONTRACT.api BOOT_CONTRACT
+exec ~/bin/deploy-embodied-dreamfinder.sh   # full 4-gate pass, auto-rollback armed

--- a/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
@@ -15,10 +15,14 @@ docker tag dreamfinder-avatar-app:pre-engine dreamfinder-avatar-app:latest
 docker compose up -d --no-build
 
 echo "--- health gate ---"
-for i in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && break; sleep 2; done
+for _ in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && break; sleep 2; done
 curl -sf localhost:3015/api/health >/dev/null || { echo "ROLLBACK HEALTH GATE FAILED"; exit 1; }
 echo "health OK"
 sleep 8
 echo "--- worker registration (expect agentName dreamfinder, exactly one) ---"
-docker logs dreamfinder-avatar --since 2m 2>&1 | grep -i "registered worker" | tail -3 || echo "(no registration line yet — check again in 30s)"
+# Anchored to the container's own boot, not the wall clock — see the note in
+# rollback-lyra-avatar.sh. Informational here, but a spurious empty window during
+# a rollback rehearsal is exactly the wrong moment to mislead the operator.
+BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -i "registered worker" | tail -3 || echo "(no registration line yet — check again in 30s)"
 echo "=== rollback complete. VERIFY A SPOKEN TURN NOW (laptop, df.imagineering.cc) ==="

--- a/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# QUAD rollback for dreamfinder-avatar: (image AND .env AND compose+override AND worker).
+# One rehearsed command — used by BOTH the deploy auto-rollback and the demo-day FREEZE.
+# Restores the pre-engine world byte-for-byte from ~/demo-freeze.
+set -euo pipefail
+APP_DIR="$HOME/apps/dreamfinder-avatar"
+FREEZE="$HOME/demo-freeze"
+cd "$APP_DIR"
+
+echo "=== QUAD ROLLBACK $(date -u "+%H:%M:%S UTC") ==="
+cp "$FREEZE/env.file" .env
+cp "$FREEZE/docker-compose.yml" docker-compose.yml
+cp "$FREEZE/docker-compose.override.yml" docker-compose.override.yml   # lyra-live needs the key mount
+docker tag dreamfinder-avatar-app:pre-engine dreamfinder-avatar-app:latest
+docker compose up -d --no-build
+
+echo "--- health gate ---"
+for i in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && break; sleep 2; done
+curl -sf localhost:3015/api/health >/dev/null || { echo "ROLLBACK HEALTH GATE FAILED"; exit 1; }
+echo "health OK"
+sleep 8
+echo "--- worker registration (expect agentName dreamfinder, exactly one) ---"
+docker logs dreamfinder-avatar --since 2m 2>&1 | grep -i "registered worker" | tail -3 || echo "(no registration line yet — check again in 30s)"
+echo "=== rollback complete. VERIFY A SPOKEN TURN NOW (laptop, df.imagineering.cc) ==="

--- a/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
@@ -23,6 +23,11 @@ echo "--- worker registration (expect agentName dreamfinder, exactly one) ---"
 # Anchored to the container's own boot, not the wall clock — see the note in
 # rollback-lyra-avatar.sh. Informational here, but a spurious empty window during
 # a rollback rehearsal is exactly the wrong moment to mislead the operator.
-BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+# Guarded — see the matching note in rollback-lyra-avatar.sh. This tail is
+# informational and runs AFTER the rollback has already succeeded; under
+# `set -euo pipefail` an unguarded assignment here would abort and report a
+# completed rollback as a failure.
+BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar 2>/dev/null) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+[ -n "$BOOT_SINCE" ] || { BOOT_SINCE=2m; echo "(could not read container StartedAt — falling back to a 2m wall-clock window, which may miss this boot)"; }
 docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -i "registered worker" | tail -3 || echo "(no registration line yet — check again in 30s)"
 echo "=== rollback complete. VERIFY A SPOKEN TURN NOW (laptop, df.imagineering.cc) ==="

--- a/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
@@ -59,5 +59,12 @@ STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar 2>/dev/
 BOOT_SINCE=""
 [ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
 [ -n "$BOOT_SINCE" ] || { BOOT_SINCE=2m; echo "(could not read container StartedAt — falling back to a 2m wall-clock window, which may miss this boot)"; }
-docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -i "registered worker" | tail -3 || echo "(no registration line yet — check again in 30s)"
+REG=$(docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -ci "registered worker" || true)
+docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -i "registered worker" | tail -3 || true
+# ZERO is absence, not health — matching rollback-lyra-avatar.sh. The previous
+# version printed "check again in 30s", which reads as patience rather than as a
+# problem, at exactly the moment an operator is deciding whether the rollback
+# worked and whether they can stop watching.
+[ "$REG" -ge 1 ] || echo "!! NO WORKER REGISTERED after rollback — the site is up but will not answer a spoken turn. Do NOT walk away from this."
+[ "$REG" -le 1 ] || echo "!! GHOST WORKER after rollback ($REG registrations) — dispatch will load-balance across duplicates"
 echo "=== rollback complete. VERIFY A SPOKEN TURN NOW (laptop, df.imagineering.cc) ==="

--- a/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
+++ b/avatar-deploy/bin/rollback-dreamfinder-avatar.sh
@@ -8,11 +8,35 @@ FREEZE="$HOME/demo-freeze"
 cd "$APP_DIR"
 
 echo "=== QUAD ROLLBACK $(date -u "+%H:%M:%S UTC") ==="
+
+# PREFLIGHT every input BEFORE mutating anything. These are sequential `cp`s under
+# `set -e`: previously, a missing docker-compose.override.yml in the freeze aborted
+# the script AFTER .env and docker-compose.yml had already been overwritten. A
+# half-restored site is not "the old release" and not "the new release" — it is a
+# third topology nobody has ever run, produced at the exact moment someone is
+# trying to escape an outage. Check all four, then commit.
+MISSING=""
+for f in env.file docker-compose.yml docker-compose.override.yml; do
+  [ -f "$FREEZE/$f" ] || MISSING="$MISSING $f"
+done
+docker image inspect dreamfinder-avatar-app:pre-engine >/dev/null 2>&1 \
+  || MISSING="$MISSING image:pre-engine"
+if [ -n "$MISSING" ]; then
+  echo "FATAL: rollback inputs missing -$MISSING"
+  echo "       Nothing has been changed. Restore the freeze before rolling back."
+  exit 1
+fi
+
 cp "$FREEZE/env.file" .env
 cp "$FREEZE/docker-compose.yml" docker-compose.yml
 cp "$FREEZE/docker-compose.override.yml" docker-compose.override.yml   # lyra-live needs the key mount
 docker tag dreamfinder-avatar-app:pre-engine dreamfinder-avatar-app:latest
-docker compose up -d --no-build
+# --force-recreate for the same reason lyra needs it, one layer along: this
+# rollback works by RETAGGING, and if pre-engine and latest already resolve to the
+# same digest (a never-advanced or poisoned anchor — the known ratchet) then the
+# retag is a no-op, `up -d --no-build` is a no-op, and the health gate below
+# cheerfully reports OK about the release you were trying to escape.
+docker compose up -d --no-build --force-recreate
 
 echo "--- health gate ---"
 for _ in $(seq 1 30); do curl -sf localhost:3015/api/health >/dev/null && break; sleep 2; done
@@ -27,7 +51,13 @@ echo "--- worker registration (expect agentName dreamfinder, exactly one) ---"
 # informational and runs AFTER the rollback has already succeeded; under
 # `set -euo pipefail` an unguarded assignment here would abort and report a
 # completed rollback as a failure.
-BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar 2>/dev/null) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+# Inspect captured on its own line and tested BEFORE date sees it — see the note
+# in rollback-lyra-avatar.sh. `date -u -d " - 5 seconds"` is valid GNU date
+# (= now-5s, exit 0), so interpolating a failed inspect fails OPEN into a
+# five-second window wearing the boot anchor's name.
+STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' dreamfinder-avatar 2>/dev/null || true)
+BOOT_SINCE=""
+[ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
 [ -n "$BOOT_SINCE" ] || { BOOT_SINCE=2m; echo "(could not read container StartedAt — falling back to a 2m wall-clock window, which may miss this boot)"; }
 docker logs dreamfinder-avatar --since "$BOOT_SINCE" 2>&1 | grep -i "registered worker" | tail -3 || echo "(no registration line yet — check again in 30s)"
 echo "=== rollback complete. VERIFY A SPOKEN TURN NOW (laptop, df.imagineering.cc) ==="

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -43,8 +43,17 @@ git -C "$SRC_DIR" checkout -q "$PREV"
 # one layer down. The deploy swept this class; the rollback half was missed.
 # Not currently load-bearing (neither repo has .gitattributes yet) — which is
 # exactly why it must go in now rather than the day LFS is switched on.
+# NOTE the deliberate asymmetry with the DEPLOY path, which fails closed here.
+# This point is AFTER the first live mutation (the tree has already moved) and
+# BEFORE the cutover. Exiting here — which is what the first version of this fix
+# did — leaves the disk at PREV while the old process keeps serving the release
+# you are trying to escape, under a banner reading "FATAL". A rollback that stops
+# halfway is not a safe failure; the whole value of the QUAD is that it completes.
+# So: warn as loudly as possible and press on to the cutover. A deploy may refuse
+# to proceed; a rollback must land.
 if command -v git-lfs >/dev/null 2>&1; then
-  git -C "$SRC_DIR" lfs pull || { echo "FATAL: git lfs pull failed during rollback — the tree may be pointer files only"; exit 1; }
+  git -C "$SRC_DIR" lfs pull \
+    || echo "!! git lfs pull FAILED during rollback — the tree may hold POINTER FILES. Continuing to the cutover anyway (a half-rollback is worse). Health may go green with assets missing; check a real spoken turn."
 else
   echo "(git-lfs not installed — skipping lfs pull)"
 fi

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -38,11 +38,18 @@ docker compose up -d --no-build
 
 # --- leg 4: gates (health, then exactly-one worker) ---
 echo "--- health gate ---"
-for i in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && break; sleep 2; done
+for _ in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && break; sleep 2; done
 curl -sf "localhost:$PORT/api/health" >/dev/null || { echo "ROLLBACK HEALTH GATE FAILED"; exit 1; }
 echo "health OK"
 sleep 8
-REG=$(docker logs lyra-avatar --since 2m 2>&1 | grep -c '"msg":"registered worker"' || true)
+# Same wall-clock-proxy defect the deploy scripts were fixed for on 2026-08-10,
+# missed in that sweep because it lives in the rollback half. `--since 2m` is a
+# proxy for "this boot" that goes false the moment the container is not recreated
+# — and a rollback via `up -d --no-build` is exactly that case. It cannot trigger
+# an auto-rollback here (the check below only warns), but it reports 0 to a human
+# mid-rehearsal, which reads as a failed rollback. Anchor to the container's boot.
+BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+REG=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -c '"msg":"registered worker"' || true)
 echo "leg 4 worker registrations in last 2m: $REG (expect exactly 1)"
 [ "$REG" -le 1 ] || echo "!! GHOST WORKER after rollback — dispatch will load-balance across duplicates"
 

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -16,10 +16,38 @@ cd "$APP_DIR"
 
 echo "=== QUAD ROLLBACK lyra-avatar $(date -u "+%H:%M:%S UTC") ==="
 
-# --- leg 1: the src TREE (the thing the container actually runs) ---
+# --- leg 0: PREFLIGHT every input before mutating anything ---
+# Matches rollback-dreamfinder-avatar.sh. Previously leg 1 moved the live tree
+# FIRST and legs 2/3 were soft (`[ -f … ] && cp`), so a freeze missing env.file
+# produced PREV tree + CURRENT env + CURRENT compose — a fourth topology nobody
+# has ever run, assembled during an incident, while the banner still said "QUAD".
+# Soft-restoring an input is only kind if the caller can tell it was skipped; here
+# it was silent. Check everything, then commit to the whole rollback or none of it.
 PREV=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || true)
-[ -n "$PREV" ] || { echo "FATAL: no $FREEZE/PREV_SHA anchor — refusing to guess a target"; exit 1; }
+MISSING=""
+[ -n "$PREV" ] || MISSING="$MISSING PREV_SHA"
+[ -f "$FREEZE/env.file" ] || MISSING="$MISSING env.file"
+[ -f "$FREEZE/docker-compose.yml" ] || MISSING="$MISSING docker-compose.yml"
+[ -n "$PREV" ] && { git -C "$SRC_DIR" cat-file -e "${PREV}^{commit}" 2>/dev/null || MISSING="$MISSING PREV_SHA($PREV)-not-in-src-repo"; }
+if [ -n "$MISSING" ]; then
+  echo "FATAL: rollback inputs missing -$MISSING"
+  echo "       Nothing has been changed. Restore $FREEZE before rolling back."
+  exit 1
+fi
+
+# --- leg 1: the src TREE (the thing the container actually runs) ---
 git -C "$SRC_DIR" checkout -q "$PREV"
+# Materialise LFS blobs, exactly as the deploy path does after it pins a SHA.
+# Without this the rollback restores POINTER FILES: /api/health goes green, the
+# mesh 404s, and the spoken turn fails — the same soft lie as a stale log window,
+# one layer down. The deploy swept this class; the rollback half was missed.
+# Not currently load-bearing (neither repo has .gitattributes yet) — which is
+# exactly why it must go in now rather than the day LFS is switched on.
+if command -v git-lfs >/dev/null 2>&1; then
+  git -C "$SRC_DIR" lfs pull || { echo "FATAL: git lfs pull failed during rollback — the tree may be pointer files only"; exit 1; }
+else
+  echo "(git-lfs not installed — skipping lfs pull)"
+fi
 echo "leg 1 src -> $(git -C "$SRC_DIR" log -1 --oneline)"
 
 # --- leg 2: image ---
@@ -30,9 +58,9 @@ else
   echo "leg 2 image: no pre-traversal-fix anchor — leaving image as-is"
 fi
 
-# --- leg 3: env + compose ---
-[ -f "$FREEZE/env.file" ]           && cp "$FREEZE/env.file" .env                     && echo "leg 3a .env restored"
-[ -f "$FREEZE/docker-compose.yml" ] && cp "$FREEZE/docker-compose.yml" docker-compose.yml && echo "leg 3b compose restored"
+# --- leg 3: env + compose (existence already asserted in leg 0) ---
+cp "$FREEZE/env.file" .env                                  && echo "leg 3a .env restored"
+cp "$FREEZE/docker-compose.yml" docker-compose.yml          && echo "leg 3b compose restored"
 
 # --force-recreate is REQUIRED here, not optional tidiness. Leg 1 moved the src
 # TREE, and compose bind-mounts ./src:/app — but compose decides whether to

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -34,10 +34,16 @@ MISSING=""
 # mutated. Whether a pull will actually succeed cannot be preflighted; that depends
 # on the network and the LFS endpoint at the instant it runs, and leg 1 handles it
 # by stopping with an explicit state report (see the note there).
-if git -C "$SRC_DIR" ls-files 2>/dev/null | grep -q . && [ -f "$SRC_DIR/.gitattributes" ] \
-   && grep -q 'filter=lfs' "$SRC_DIR/.gitattributes" 2>/dev/null \
+# Read .gitattributes from $PREV — the tree we are about to check OUT — not from
+# the current working tree. Those are different commits and that is the whole
+# point: if the failed release dropped LFS tracking and PREV still uses it, a
+# check against the current tree says "no LFS needed", the pull is skipped, and
+# the container comes up on pointer files. The preflight must ask about the
+# destination, not the place we are leaving.
+if [ -n "$PREV" ] \
+   && git -C "$SRC_DIR" show "$PREV:.gitattributes" 2>/dev/null | grep -q 'filter=lfs' \
    && ! command -v git-lfs >/dev/null 2>&1; then
-  MISSING="$MISSING git-lfs(repo tracks LFS files but no client installed)"
+  MISSING="$MISSING git-lfs(target $PREV tracks LFS files but no client installed)"
 fi
 [ -n "$PREV" ] && { git -C "$SRC_DIR" cat-file -e "${PREV}^{commit}" 2>/dev/null || MISSING="$MISSING PREV_SHA($PREV)-not-in-src-repo"; }
 if [ -n "$MISSING" ]; then

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# QUAD rollback for lyra-avatar: (src tree AND image AND .env+compose AND worker).
+# One rehearsed command — used by BOTH the deploy auto-rollback and by a human.
+#
+# Differs from dreamfinder's QUAD in its FIRST leg. dreamfinder bakes source into
+# the image, so retagging the image restores the code. lyra bind-mounts ./src:/app,
+# so the image carries only deps/ENV/CMD — retagging it would leave the NEW source
+# running under the OLD image and roll back nothing that matters. The tree is the
+# first leg here, and it is the one that actually undoes a bad deploy.
+set -euo pipefail
+APP_DIR="$HOME/apps/lyra-avatar"
+SRC_DIR="$APP_DIR/src"
+FREEZE="$HOME/lyra-freeze"
+PORT=3017
+cd "$APP_DIR"
+
+echo "=== QUAD ROLLBACK lyra-avatar $(date -u "+%H:%M:%S UTC") ==="
+
+# --- leg 1: the src TREE (the thing the container actually runs) ---
+PREV=$(cat "$FREEZE/PREV_SHA" 2>/dev/null || true)
+[ -n "$PREV" ] || { echo "FATAL: no $FREEZE/PREV_SHA anchor — refusing to guess a target"; exit 1; }
+git -C "$SRC_DIR" checkout -q "$PREV"
+echo "leg 1 src -> $(git -C "$SRC_DIR" log -1 --oneline)"
+
+# --- leg 2: image ---
+if docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1; then
+  docker tag lyra-avatar-app:pre-traversal-fix lyra-avatar-app:latest
+  echo "leg 2 image -> pre-traversal-fix"
+else
+  echo "leg 2 image: no pre-traversal-fix anchor — leaving image as-is"
+fi
+
+# --- leg 3: env + compose ---
+[ -f "$FREEZE/env.file" ]           && cp "$FREEZE/env.file" .env                     && echo "leg 3a .env restored"
+[ -f "$FREEZE/docker-compose.yml" ] && cp "$FREEZE/docker-compose.yml" docker-compose.yml && echo "leg 3b compose restored"
+
+docker compose up -d --no-build
+
+# --- leg 4: gates (health, then exactly-one worker) ---
+echo "--- health gate ---"
+for i in $(seq 1 30); do curl -sf "localhost:$PORT/api/health" >/dev/null && break; sleep 2; done
+curl -sf "localhost:$PORT/api/health" >/dev/null || { echo "ROLLBACK HEALTH GATE FAILED"; exit 1; }
+echo "health OK"
+sleep 8
+REG=$(docker logs lyra-avatar --since 2m 2>&1 | grep -c '"msg":"registered worker"' || true)
+echo "leg 4 worker registrations in last 2m: $REG (expect exactly 1)"
+[ "$REG" -le 1 ] || echo "!! GHOST WORKER after rollback — dispatch will load-balance across duplicates"
+
+cat <<'EOF'
+=== ROLLBACK COMPLETE. It is NOT verified until a human does both: ===
+  1. a real spoken turn at lyra.imagineering.cc
+  2. NOTE: rolling back the traversal fix REOPENS the unauthenticated-read hole.
+     This is a deliberate trade — a broken avatar is louder than a quiet leak —
+     but do not leave it here. Re-probe with --path-as-is from a non-loopback
+     address so you know exactly which state production is in.
+EOF

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 APP_DIR="$HOME/apps/lyra-avatar"
 SRC_DIR="$APP_DIR/src"
 FREEZE="$HOME/lyra-freeze"
+LEGS_SKIPPED=""   # legs that could not run; reported in the closing banner
 PORT=3017
 cd "$APP_DIR"
 
@@ -28,14 +29,11 @@ MISSING=""
 [ -n "$PREV" ] || MISSING="$MISSING PREV_SHA"
 [ -f "$FREEZE/env.file" ] || MISSING="$MISSING env.file"
 [ -f "$FREEZE/docker-compose.yml" ] || MISSING="$MISSING docker-compose.yml"
-# LFS AVAILABILITY is preflighted here, before the tree moves, so the one half of
-# the LFS risk that CAN be checked in advance is checked in advance. Whether a pull
-# will succeed cannot be — that depends on the network and the LFS endpoint at the
-# moment it runs — which is why leg 1 warns and continues rather than aborting
-# mid-rollback. Named tradeoff, not an oversight: two reviewers wanted opposite
-# behaviours here. A DEPLOY may refuse to proceed on a bad pull; a ROLLBACK is
-# already an incident response, and stopping it halfway leaves the old process
-# serving the release you are escaping. Landing incomplete beats not landing.
+# LFS AVAILABILITY is preflighted here, before the tree moves, so the half of the
+# LFS risk that CAN be known in advance is refused for free — with nothing yet
+# mutated. Whether a pull will actually succeed cannot be preflighted; that depends
+# on the network and the LFS endpoint at the instant it runs, and leg 1 handles it
+# by stopping with an explicit state report (see the note there).
 if git -C "$SRC_DIR" ls-files 2>/dev/null | grep -q . && [ -f "$SRC_DIR/.gitattributes" ] \
    && grep -q 'filter=lfs' "$SRC_DIR/.gitattributes" 2>/dev/null \
    && ! command -v git-lfs >/dev/null 2>&1; then
@@ -56,28 +54,54 @@ git -C "$SRC_DIR" checkout -q "$PREV"
 # one layer down. The deploy swept this class; the rollback half was missed.
 # Not currently load-bearing (neither repo has .gitattributes yet) — which is
 # exactly why it must go in now rather than the day LFS is switched on.
-# NOTE the deliberate asymmetry with the DEPLOY path, which fails closed here.
-# This point is AFTER the first live mutation (the tree has already moved) and
-# BEFORE the cutover. Exiting here — which is what the first version of this fix
-# did — leaves the disk at PREV while the old process keeps serving the release
-# you are trying to escape, under a banner reading "FATAL". A rollback that stops
-# halfway is not a safe failure; the whole value of the QUAD is that it completes.
-# So: warn as loudly as possible and press on to the cutover. A deploy may refuse
-# to proceed; a rollback must land.
+#
+# This point sits AFTER the first live mutation (the tree has moved) and BEFORE the
+# cutover, so failing here is genuinely awkward either way. It went both directions
+# across review rounds. It stops, and prints exactly what state the box is in —
+# because the alternative recreates the container against pointer files, which
+# passes /api/health while serving nothing, and reads to the operator as a finished
+# rollback. Degraded-and-known beats broken-and-believed; an operator who is told
+# the truth can finish the job in one command, and one is printed below.
 if command -v git-lfs >/dev/null 2>&1; then
-  git -C "$SRC_DIR" lfs pull \
-    || echo "!! git lfs pull FAILED during rollback — the tree may hold POINTER FILES. Continuing to the cutover anyway (a half-rollback is worse). Health may go green with assets missing; check a real spoken turn."
+  git -C "$SRC_DIR" lfs pull || {
+    # REVERSED from the first version of this fix, on 2-of-3 reviewer argument.
+    # Continuing produced a container recreated against POINTER FILES: /api/health
+    # green, assets missing, the whole thing reading as a completed rollback. A
+    # restore that lies is worse than one that stops, because the operator walks
+    # away. Stopping BEFORE the recreate leaves the old process still serving —
+    # degraded and known, rather than broken and believed.
+    echo "FATAL: git lfs pull failed — the restored tree may hold POINTER FILES, not assets."
+    echo
+    echo "  STATE RIGHT NOW: the src tree HAS been moved to $PREV."
+    echo "                   the container has NOT been recreated, so the OLD process"
+    echo "                   is still serving the release you were trying to escape."
+    echo
+    echo "  TO FINISH the rollback once LFS is reachable:"
+    echo "    git -C $SRC_DIR lfs pull && $0"
+    echo "  TO ABANDON it and return the tree to where it was:"
+    echo "    git -C $SRC_DIR checkout -q <the sha you came from>"
+    exit 1
+  }
 else
   echo "(git-lfs not installed — skipping lfs pull)"
 fi
 echo "leg 1 src -> $(git -C "$SRC_DIR" log -1 --oneline)"
 
 # --- leg 2: image ---
+# The image leg is genuinely OPTIONAL for lyra — the tree is what runs — but the
+# banner said "QUAD" regardless, so an operator heard "four legs restored" when
+# three had been. Legs 0/1/3 hard-require their inputs; this one does not, and the
+# difference must be audible. Say the arity out loud rather than implying it.
 if docker image inspect lyra-avatar-app:pre-traversal-fix >/dev/null 2>&1; then
   docker tag lyra-avatar-app:pre-traversal-fix lyra-avatar-app:latest
   echo "leg 2 image -> pre-traversal-fix"
 else
-  echo "leg 2 image: no pre-traversal-fix anchor — leaving image as-is"
+  LEGS_SKIPPED="image"
+  echo "!! leg 2 SKIPPED: no lyra-avatar-app:pre-traversal-fix anchor exists."
+  echo "   The image is being LEFT AS-IS. This is a THREE-leg rollback, not a QUAD."
+  echo "   The tree, env and compose will be restored; deps/ENV/CMD come from the"
+  echo "   image and will still be whatever the failed release built. If the release"
+  echo "   you are escaping changed dependencies, this rollback is INCOMPLETE."
 fi
 
 # --- leg 3: env + compose (existence already asserted in leg 0) ---
@@ -135,6 +159,9 @@ echo "leg 4 worker registrations $WINDOW_DESC: $REG (expect exactly 1)"
 # mid-rehearsal read a FAILED rollback as a finished one.
 [ "$REG" -ge 1 ] || echo "!! NO WORKER REGISTERED after rollback — the site is up but will not answer a spoken turn. Do NOT walk away from this."
 
+if [ -n "$LEGS_SKIPPED" ]; then
+  echo "=== ROLLBACK LANDED, BUT INCOMPLETE — skipped leg(s): $LEGS_SKIPPED ==="
+fi
 cat <<'EOF'
 === ROLLBACK COMPLETE. It is NOT verified until a human does a real spoken ===
 === turn at lyra.imagineering.cc.                                          ===

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -60,7 +60,16 @@ sleep 8
 # every leg has already run and the health gate has already passed, so an abort
 # here would report a SUCCESSFUL rollback as a failure — the worst possible signal
 # mid-incident. Fall back to a wall-clock window rather than dying.
-BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar 2>/dev/null) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+#
+# Capture the inspect result on its OWN line and test it before handing it to
+# date. Interpolating it straight into the date expression does NOT fail closed:
+# `date -u -d " - 5 seconds"` is a VALID GNU date expression meaning now-5s, so an
+# empty inspect silently yields a FIVE-SECOND wall-clock window presented to the
+# operator as the boot anchor. Verified on the box — it exits 0 and prints a
+# timestamp. That is the same instrument-vs-claim defect this whole file is about.
+STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar 2>/dev/null || true)
+BOOT_SINCE=""
+[ -n "$STARTED_AT" ] && BOOT_SINCE=$(date -u -d "$STARTED_AT - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
 if [ -n "$BOOT_SINCE" ]; then
   WINDOW_DESC="since container boot ($BOOT_SINCE)"
 else
@@ -70,6 +79,11 @@ fi
 REG=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -c '"msg":"registered worker"' || true)
 echo "leg 4 worker registrations $WINDOW_DESC: $REG (expect exactly 1)"
 [ "$REG" -le 1 ] || echo "!! GHOST WORKER after rollback — dispatch will load-balance across duplicates"
+# ZERO is absence, not health. Only the upper bound was warned on, so a rolled-back
+# container that never registered a worker printed a bare "0" next to an
+# "expect exactly 1" echo and said nothing — the soft lie that lets an operator
+# mid-rehearsal read a FAILED rollback as a finished one.
+[ "$REG" -ge 1 ] || echo "!! NO WORKER REGISTERED after rollback — the site is up but will not answer a spoken turn. Do NOT walk away from this."
 
 cat <<'EOF'
 === ROLLBACK COMPLETE. It is NOT verified until a human does a real spoken ===

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -34,7 +34,14 @@ fi
 [ -f "$FREEZE/env.file" ]           && cp "$FREEZE/env.file" .env                     && echo "leg 3a .env restored"
 [ -f "$FREEZE/docker-compose.yml" ] && cp "$FREEZE/docker-compose.yml" docker-compose.yml && echo "leg 3b compose restored"
 
-docker compose up -d --no-build
+# --force-recreate is REQUIRED here, not optional tidiness. Leg 1 moved the src
+# TREE, and compose bind-mounts ./src:/app — but compose decides whether to
+# recreate a container from the IMAGE and config, which this rollback does not
+# change. Without it, a rollback can leave the old node process running the old
+# code in memory while the disk says PREV_SHA: every gate below then samples a
+# process the rollback never actually rolled back. Same class as the wall-clock
+# log window — an instrument measuring something adjacent to the claim.
+docker compose up -d --no-build --force-recreate
 
 # --- leg 4: gates (health, then exactly-one worker) ---
 echo "--- health gate ---"
@@ -48,16 +55,40 @@ sleep 8
 # — and a rollback via `up -d --no-build` is exactly that case. It cannot trigger
 # an auto-rollback here (the check below only warns), but it reports 0 to a human
 # mid-rehearsal, which reads as a failed rollback. Anchor to the container's boot.
-BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ)
+# Guarded: this tail is INFORMATIONAL, and under `set -euo pipefail` a bare
+# assignment from a failing command substitution aborts the script. By this point
+# every leg has already run and the health gate has already passed, so an abort
+# here would report a SUCCESSFUL rollback as a failure — the worst possible signal
+# mid-incident. Fall back to a wall-clock window rather than dying.
+BOOT_SINCE=$(date -u -d "$(docker inspect -f '{{.State.StartedAt}}' lyra-avatar 2>/dev/null) - 5 seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+if [ -n "$BOOT_SINCE" ]; then
+  WINDOW_DESC="since container boot ($BOOT_SINCE)"
+else
+  BOOT_SINCE=2m
+  WINDOW_DESC="last 2m (FALLBACK — could not read container StartedAt; this window is a wall-clock proxy and may miss or over-count)"
+fi
 REG=$(docker logs lyra-avatar --since "$BOOT_SINCE" 2>&1 | grep -c '"msg":"registered worker"' || true)
-echo "leg 4 worker registrations in last 2m: $REG (expect exactly 1)"
+echo "leg 4 worker registrations $WINDOW_DESC: $REG (expect exactly 1)"
 [ "$REG" -le 1 ] || echo "!! GHOST WORKER after rollback — dispatch will load-balance across duplicates"
 
 cat <<'EOF'
-=== ROLLBACK COMPLETE. It is NOT verified until a human does both: ===
-  1. a real spoken turn at lyra.imagineering.cc
-  2. NOTE: rolling back the traversal fix REOPENS the unauthenticated-read hole.
-     This is a deliberate trade — a broken avatar is louder than a quiet leak —
-     but do not leave it here. Re-probe with --path-as-is from a non-loopback
-     address so you know exactly which state production is in.
+=== ROLLBACK COMPLETE. It is NOT verified until a human does a real spoken ===
+=== turn at lyra.imagineering.cc.                                          ===
+
+  The traversal fix is NOT lost by this rollback. The tree anchor in
+  lyra-freeze/PREV_SHA is the security-fix commit itself, and lyra runs the
+  TREE (compose bind-mounts ./src:/app), so leg 1 restores code that already
+  carries the fix. Verified against the box on 2026-08-10.
+
+  This block previously warned the opposite — that rolling back REOPENED the
+  unauthenticated-read hole. That was true of an older anchor and became false
+  when the anchor advanced; nothing updated the warning, because it lived only
+  in an untracked file. It is left recorded here rather than silently deleted,
+  because the failure it represents is the point: a rollback script that tells
+  an operator at 3am that the safe action is dangerous will stop them taking it.
+
+  Still re-probe with --path-as-is from a NON-LOOPBACK address afterwards, so
+  you know from measurement rather than inference which state production is in.
+  lib/scope.js grants LOCALHOST_IPS base scope, so a probe from the box returns
+  200 for everything and reads as a false green.
 EOF

--- a/avatar-deploy/bin/rollback-lyra-avatar.sh
+++ b/avatar-deploy/bin/rollback-lyra-avatar.sh
@@ -28,6 +28,19 @@ MISSING=""
 [ -n "$PREV" ] || MISSING="$MISSING PREV_SHA"
 [ -f "$FREEZE/env.file" ] || MISSING="$MISSING env.file"
 [ -f "$FREEZE/docker-compose.yml" ] || MISSING="$MISSING docker-compose.yml"
+# LFS AVAILABILITY is preflighted here, before the tree moves, so the one half of
+# the LFS risk that CAN be checked in advance is checked in advance. Whether a pull
+# will succeed cannot be — that depends on the network and the LFS endpoint at the
+# moment it runs — which is why leg 1 warns and continues rather than aborting
+# mid-rollback. Named tradeoff, not an oversight: two reviewers wanted opposite
+# behaviours here. A DEPLOY may refuse to proceed on a bad pull; a ROLLBACK is
+# already an incident response, and stopping it halfway leaves the old process
+# serving the release you are escaping. Landing incomplete beats not landing.
+if git -C "$SRC_DIR" ls-files 2>/dev/null | grep -q . && [ -f "$SRC_DIR/.gitattributes" ] \
+   && grep -q 'filter=lfs' "$SRC_DIR/.gitattributes" 2>/dev/null \
+   && ! command -v git-lfs >/dev/null 2>&1; then
+  MISSING="$MISSING git-lfs(repo tracks LFS files but no client installed)"
+fi
 [ -n "$PREV" ] && { git -C "$SRC_DIR" cat-file -e "${PREV}^{commit}" 2>/dev/null || MISSING="$MISSING PREV_SHA($PREV)-not-in-src-repo"; }
 if [ -n "$MISSING" ]; then
   echo "FATAL: rollback inputs missing -$MISSING"

--- a/avatar-deploy/bin/verify-matches-box.sh
+++ b/avatar-deploy/bin/verify-matches-box.sh
@@ -26,6 +26,25 @@ PAIRS=(
   "ssh/config.d/xdeca-backups:\$HOME/.ssh/config.d/xdeca-backups"
 )
 
+# The pairing below matches on the $HOME-relative TAIL of each box path, which is
+# only sound while those tails are mutually non-suffixing. That holds today and is
+# invisible when it stops holding — a new entry whose tail is a suffix of another
+# would silently cross-wire two files' digests. Assert it rather than trust it: the
+# cost is eight string compares, and the failure it prevents is this tool
+# confidently reporting the wrong file as clean.
+for pair_a in "${PAIRS[@]}"; do
+  tail_a="${pair_a#*:}"; tail_a="${tail_a#\$HOME}"
+  for pair_b in "${PAIRS[@]}"; do
+    [ "$pair_a" = "$pair_b" ] && continue
+    tail_b="${pair_b#*:}"; tail_b="${tail_b#\$HOME}"
+    case "$tail_a" in *"$tail_b")
+      echo "FAIL: PAIRS tails are ambiguous — '$tail_a' ends with '$tail_b'."
+      echo "      Path-keyed matching would cross-wire these two entries. Fix PAIRS."
+      exit 1 ;;
+    esac
+  done
+done
+
 # One ssh round trip, not one per file — this runs against a production host.
 REMOTE_CMD=""
 for pair in "${PAIRS[@]}"; do

--- a/avatar-deploy/bin/verify-matches-box.sh
+++ b/avatar-deploy/bin/verify-matches-box.sh
@@ -46,14 +46,30 @@ for pair_a in "${PAIRS[@]}"; do
 done
 
 # One ssh round trip, not one per file — this runs against a production host.
-REMOTE_CMD=""
+#
+# The remote picks its own digest tool, the same way the local side does. Hardcoding
+# md5sum meant a box without it reported EVERY file as "absent on the box": still
+# fail-closed, but a false drift report with a confidently wrong diagnosis, which
+# sends the operator hunting a deletion that never happened. The tool choice is
+# resolved remotely and announced, so "no digest tool" is distinguishable from
+# "file missing" — a checker that cannot say WHY it disagrees is only half a
+# checker.
+REMOTE_CMD='if command -v md5sum >/dev/null 2>&1; then _d() { md5sum "$1"; };'
+REMOTE_CMD+=' elif command -v md5 >/dev/null 2>&1; then _d() { echo "$(md5 -q "$1")  $1"; };'
+REMOTE_CMD+=' else echo NODIGESTTOOL; exit 0; fi; '
 for pair in "${PAIRS[@]}"; do
-  REMOTE_CMD+="md5sum ${pair#*:} 2>/dev/null || echo 'ABSENT ${pair#*:}'; "
+  REMOTE_CMD+="_d ${pair#*:} 2>/dev/null || echo 'ABSENT ${pair#*:}'; "
 done
 
 if ! REMOTE_OUT=$(ssh -o BatchMode=yes "$HOST" "$REMOTE_CMD" 2>/dev/null); then
   echo "FAIL: cannot reach $HOST — cannot confirm the box matches the repo."
   echo "      Treat this as UNKNOWN, not as agreement."
+  exit 1
+fi
+
+if [ "$REMOTE_OUT" = "NODIGESTTOOL" ]; then
+  echo "FAIL: $HOST has neither md5sum nor md5 — cannot compute remote digests."
+  echo "      Treat this as UNKNOWN, not as drift and not as agreement."
   exit 1
 fi
 

--- a/avatar-deploy/bin/verify-matches-box.sh
+++ b/avatar-deploy/bin/verify-matches-box.sh
@@ -20,7 +20,6 @@ PAIRS=(
   "bin/deploy-lyra-avatar.sh:\$HOME/bin/deploy-lyra-avatar.sh"
   "bin/rollback-dreamfinder-avatar.sh:\$HOME/bin/rollback-dreamfinder-avatar.sh"
   "bin/rollback-lyra-avatar.sh:\$HOME/bin/rollback-lyra-avatar.sh"
-  "bin/flip-brain-api.sh:\$HOME/bin/flip-brain-api.sh"
   "ssh/config:\$HOME/.ssh/config"
   "ssh/config.d/imagineering-backups:\$HOME/.ssh/config.d/imagineering-backups"
   "ssh/config.d/lyra:\$HOME/.ssh/config.d/lyra"
@@ -41,20 +40,53 @@ fi
 
 # Fail closed: an md5 tool that is missing or a path that is absent must not
 # read as a match. Anything other than a byte-identical digest is drift.
+# Pair each output line to a repo path BY THE PATH THE REMOTE ECHOED BACK, not by
+# line number. Positional pairing assumes the remote emits exactly one line per
+# input, in order — an invariant nothing here can enforce. One dropped, doubled or
+# unexpected line under that scheme shifts every later comparison onto the wrong
+# repo path, and the report becomes confidently wrong in the one tool whose entire
+# job is to be trusted about drift. Matching on the echoed path removes the
+# ordering assumption rather than guarding it; the seen-set below then enforces
+# coverage, so a missing line fails closed instead of passing unexamined.
 drift=0
-i=0
+# A space-delimited string, NOT an associative array: macOS ships bash 3.2 as
+# /bin/bash and `declare -A` is a bash 4 feature, so an assoc array would abort
+# this script on the very laptop it is meant to be run from.
+SEEN=" "
+resolve_repo_path() {  # $1 = a path as reported by the box; echoes the repo path, or empty
+  local reported="$1" pair repo tail
+  for pair in "${PAIRS[@]}"; do
+    repo="${pair%%:*}"
+    # Match on the $HOME-relative tail, which is unique across PAIRS. The box
+    # paths travel over the wire with $HOME unexpanded inside the ABSENT branch's
+    # single quotes, so a literal whole-path compare would miss those.
+    tail="${pair#*:}"; tail="${tail#\$HOME}"
+    case "$reported" in *"$tail") echo "$repo"; return;; esac
+  done
+  echo ""
+}
+
 while IFS= read -r line; do
-  repo_path="${PAIRS[$i]%%:*}"
-  i=$((i + 1))
   [ -n "$line" ] || continue
 
   if [[ "$line" == ABSENT* ]]; then
+    repo_path=$(resolve_repo_path "${line#ABSENT }")
+    [ -n "$repo_path" ] || { echo "DRIFT  unrecognised remote line: $line"; drift=1; continue; }
+    SEEN="$SEEN$repo_path "
     echo "DRIFT  $repo_path — absent on the box"
     drift=1
     continue
   fi
 
   box_md5="${line%% *}"
+  repo_path=$(resolve_repo_path "${line##* }")
+  if [ -z "$repo_path" ]; then
+    echo "DRIFT  unrecognised remote line: $line"
+    drift=1
+    continue
+  fi
+  SEEN="$SEEN$repo_path "
+
   local_md5=$(md5sum "$HERE/$repo_path" 2>/dev/null | cut -d' ' -f1 \
     || md5 -q "$HERE/$repo_path" 2>/dev/null || true)
 
@@ -68,6 +100,18 @@ while IFS= read -r line; do
     echo "ok     $repo_path"
   fi
 done <<< "$REMOTE_OUT"
+
+# Coverage assert — the fail-closed half. Silence about a file is NOT agreement
+# about it, and without this a truncated remote response would print a short list
+# of "ok" lines and then certify the whole set as matching.
+for pair in "${PAIRS[@]}"; do
+  repo_path="${pair%%:*}"
+  case "$SEEN" in
+    *" $repo_path "*) ;;
+    *) echo "DRIFT  $repo_path — NO result returned by the box (truncated output?)"
+       drift=1 ;;
+  esac
+done
 
 if [ "$drift" -ne 0 ]; then
   echo

--- a/avatar-deploy/bin/verify-matches-box.sh
+++ b/avatar-deploy/bin/verify-matches-box.sh
@@ -72,6 +72,22 @@ drift=0
 # /bin/bash and `declare -A` is a bash 4 feature, so an assoc array would abort
 # this script on the very laptop it is meant to be run from.
 SEEN=" "
+# Probe for the digest tool ONCE, explicitly, instead of chaining a fallback off a
+# pipeline's exit status. `md5sum f | cut -f1 || md5 -q f` never falls back: the
+# pipeline's status is CUT's, and cut exits 0 on empty input, so on a host without
+# md5sum the `||` arm is skipped and every file reports "missing in the repo".
+# macOS has no md5sum by default and this script is written to run from a macOS
+# laptop, so that is the primary path, not an edge case.
+if command -v md5sum >/dev/null 2>&1; then
+  local_digest() { md5sum "$1" 2>/dev/null | cut -d' ' -f1; }
+elif command -v md5 >/dev/null 2>&1; then
+  local_digest() { md5 -q "$1" 2>/dev/null; }
+else
+  echo "FAIL: neither md5sum nor md5 is available locally — cannot compute digests."
+  echo "      Treat this as UNKNOWN, not as agreement."
+  exit 1
+fi
+
 resolve_repo_path() {  # $1 = a path as reported by the box; echoes the repo path, or empty
   local reported="$1" pair repo tail
   for pair in "${PAIRS[@]}"; do
@@ -106,8 +122,7 @@ while IFS= read -r line; do
   fi
   SEEN="$SEEN$repo_path "
 
-  local_md5=$(md5sum "$HERE/$repo_path" 2>/dev/null | cut -d' ' -f1 \
-    || md5 -q "$HERE/$repo_path" 2>/dev/null || true)
+  local_md5=$(local_digest "$HERE/$repo_path")
 
   if [ -z "$local_md5" ]; then
     echo "DRIFT  $repo_path — missing in the repo"

--- a/avatar-deploy/bin/verify-matches-box.sh
+++ b/avatar-deploy/bin/verify-matches-box.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Drift check: does this repo still match what is actually installed on the box?
+#
+# The whole hazard of a tracked COPY is that it reads as truth while silently
+# diverging from the thing that runs. Until the deploy is inverted (repo
+# authoritative, box downstream) this script is the only thing standing between
+# "avatar-deploy/ describes production" and "avatar-deploy/ used to describe
+# production". Run it after any hand-edit on either side.
+#
+# Compares md5 only — it does not copy, install or repair anything.
+# Exit 0 = repo and box agree. Exit 1 = drift (or the box is unreachable).
+set -euo pipefail
+
+HOST="${AVATAR_DEPLOY_HOST:-imagineering}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# repo-relative path <-> path on the box
+PAIRS=(
+  "bin/deploy-dreamfinder-avatar.sh:\$HOME/bin/deploy-dreamfinder-avatar.sh"
+  "bin/deploy-lyra-avatar.sh:\$HOME/bin/deploy-lyra-avatar.sh"
+  "bin/rollback-dreamfinder-avatar.sh:\$HOME/bin/rollback-dreamfinder-avatar.sh"
+  "bin/rollback-lyra-avatar.sh:\$HOME/bin/rollback-lyra-avatar.sh"
+  "bin/flip-brain-api.sh:\$HOME/bin/flip-brain-api.sh"
+  "ssh/config:\$HOME/.ssh/config"
+  "ssh/config.d/imagineering-backups:\$HOME/.ssh/config.d/imagineering-backups"
+  "ssh/config.d/lyra:\$HOME/.ssh/config.d/lyra"
+  "ssh/config.d/xdeca-backups:\$HOME/.ssh/config.d/xdeca-backups"
+)
+
+# One ssh round trip, not one per file — this runs against a production host.
+REMOTE_CMD=""
+for pair in "${PAIRS[@]}"; do
+  REMOTE_CMD+="md5sum ${pair#*:} 2>/dev/null || echo 'ABSENT ${pair#*:}'; "
+done
+
+if ! REMOTE_OUT=$(ssh -o BatchMode=yes "$HOST" "$REMOTE_CMD" 2>/dev/null); then
+  echo "FAIL: cannot reach $HOST — cannot confirm the box matches the repo."
+  echo "      Treat this as UNKNOWN, not as agreement."
+  exit 1
+fi
+
+# Fail closed: an md5 tool that is missing or a path that is absent must not
+# read as a match. Anything other than a byte-identical digest is drift.
+drift=0
+i=0
+while IFS= read -r line; do
+  repo_path="${PAIRS[$i]%%:*}"
+  i=$((i + 1))
+  [ -n "$line" ] || continue
+
+  if [[ "$line" == ABSENT* ]]; then
+    echo "DRIFT  $repo_path — absent on the box"
+    drift=1
+    continue
+  fi
+
+  box_md5="${line%% *}"
+  local_md5=$(md5sum "$HERE/$repo_path" 2>/dev/null | cut -d' ' -f1 \
+    || md5 -q "$HERE/$repo_path" 2>/dev/null || true)
+
+  if [ -z "$local_md5" ]; then
+    echo "DRIFT  $repo_path — missing in the repo"
+    drift=1
+  elif [ "$box_md5" != "$local_md5" ]; then
+    echo "DRIFT  $repo_path — repo $local_md5 != box $box_md5"
+    drift=1
+  else
+    echo "ok     $repo_path"
+  fi
+done <<< "$REMOTE_OUT"
+
+if [ "$drift" -ne 0 ]; then
+  echo
+  echo "The box and this repo disagree. Decide which is right BEFORE deploying —"
+  echo "the box is still the source of truth, so a repo-side edit that was never"
+  echo "copied up has had no effect on production."
+  exit 1
+fi
+
+echo
+echo "repo matches $HOST for all ${#PAIRS[@]} files."

--- a/avatar-deploy/ssh/config
+++ b/avatar-deploy/ssh/config
@@ -1,0 +1,11 @@
+Include config.d/*
+
+# Deploy alias for imagineering-cc/dreamfinder-avatar. The deploy script clones
+# via git@github-dreamfinder: so the repo gets its own scoped key rather than the
+# box identity. Restored 2026-08-10 — the alias was referenced by the app src
+# remote but never defined, so every deploy failed at the first git fetch.
+Host github-dreamfinder
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/dreamfinder-deploy
+  IdentitiesOnly yes

--- a/avatar-deploy/ssh/config.d/imagineering-backups
+++ b/avatar-deploy/ssh/config.d/imagineering-backups
@@ -1,0 +1,5 @@
+Host github-imagineering-backups
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/imagineering-backups-deploy
+    IdentitiesOnly yes

--- a/avatar-deploy/ssh/config.d/lyra
+++ b/avatar-deploy/ssh/config.d/lyra
@@ -1,0 +1,11 @@
+# Deploy alias for imagineering-cc/lyra-avatar (was embodied-lyra). The app src
+# remote clones via git@github-lyra: so the repo gets its own scoped deploy key
+# rather than the box identity. Added 2026-08-10 — the alias was referenced by
+# the src remote but never defined, so every fetch failed at name resolution and
+# the box src sat frozen at 2e3f109 (2026-07-14). Same defect class as the
+# github-dreamfinder block above.
+Host github-lyra
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/embodied-lyra-deploy
+  IdentitiesOnly yes

--- a/avatar-deploy/ssh/config.d/xdeca-backups
+++ b/avatar-deploy/ssh/config.d/xdeca-backups
@@ -1,0 +1,5 @@
+Host github-backups
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/xdeca-backups-deploy
+    IdentitiesOnly yes


### PR DESCRIPTION
## What

The dreamfinder-avatar / lyra-avatar deploy path has never lived in a repo. ~370 lines of bash plus an ssh alias map, hand-edited in place on the production box, with no review, no history and no CI. This puts it in `avatar-deploy/`.

Three commits, deliberately ordered so the history is readable:

| commit | what |
|---|---|
| `e954625` | verbatim import, **pre-hotfix state** — the substrate as it stood before 2026-08-10, defects included |
| `5677e91` | the box's own same-day hot-fixes, **still verbatim** — this is the diff that never had a reviewer |
| `196a0bd` | wire it into CI, fix what CI immediately found |

A cleaned import would have laundered four unreviewed production changes into "how it always was". Splitting it this way makes them a diff instead.

## Why now

- **lyra ran a MONTH unpatched.** `~/.ssh/config` had no `github-lyra` block, so every fetch on the box died at name resolution and `~/apps/lyra-avatar/src` sat frozen at `2e3f109` (2026-07-14). Nothing in any repo recorded the alias→key map, which is exactly why its absence was invisible for a month.
- **An untracked gate reopened a live vulnerability.** `docker logs --since 3m` as a proxy for "this boot" returned an empty window on a no-op deploy; the gate declared a contract violation; the auto-rollback reverted production onto a 4-week-old image with the path-traversal auth bypass still in it. `df.imagineering.cc/avatars/../server.js` served 200 for ~10 minutes. Caught by a human noticing `docker ps`.
- **Four more defects went in during one afternoon.** Stale gate vectors that would have rolled lyra back, a shell-quoting crash, a self-overwriting rollback anchor.

## What the import found, immediately

**A fifth defect, live right now.** In `deploy-lyra-avatar.sh` a trailing `#` comment swallowed the rest of its physical line — `echo "image=$IMG"; \`, backslash included, so not even a continuation. Every lyra release record silently lost its image identity.

Confirmed on the box: `~/lyra-freeze/deployed.txt` has no `image=` line, `~/demo-freeze/deployed.txt` does.

`shellcheck` flags it for free as `SC2034: IMG appears unused`. It has presumably been reporting this to nobody since the moment it was written, because the file was not in a repo.

**A missed class sweep.** The StartedAt fix was applied to both *deploy* scripts and neither *rollback* script — both still used `--since 2m`. Not a repeat of the incident (lyra's only warns, dreamfinder's is informational), but a rollback runs `up -d --no-build`, which is exactly the no-recreate case where that window goes false, and it would report "0 worker registrations" to a human mid-rehearsal. Both anchored.

## Also in here

- `.github/workflows/ci.yml` — `avatar-deploy` gets its own shellcheck scandir. Without it, "Shell Linting" would be green while blind to the scripts that can roll production back onto a vulnerable image. Same reasoning, and same shape, as the existing `cd-bus` step.
- `bin/verify-matches-box.sh` — md5 drift check, one ssh round trip, **fails closed**: unreachable host, absent file or missing md5 all report drift rather than agreement. Exercised both ways before commit (5 ok / 4 DRIFT).
- `README.md` — states plainly that this directory is **not yet authoritative**.

## Explicitly NOT done

- **Nothing has been copied up to the box.** The three fixed scripts exist only here. `verify-matches-box.sh` currently reports 4 DRIFT, correctly. Production is untouched by this PR.
- **The direction of authority is not inverted yet.** The box is still the source of truth; nothing deploys from this repo. That is the next piece and the actual cure — until it lands, every improvement to the deploy path (including this one) is another artisanal edit.
- **No alerting.** Still none on either site.

## Review focus

The three fixes in `196a0bd` touch **production rollback scripts** — the exact surface that caused the last incident. Worth more attention than the import commits, which are byte-verified copies.

Refs task #10 (CRUX: the deploy substrate is untracked and artisanal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxwPwpFsbD6TqyzzD7i1RC